### PR TITLE
Harden new lesson filename slugging

### DIFF
--- a/lessons/contrib/scripts-slugify-windows-path-safety.md
+++ b/lessons/contrib/scripts-slugify-windows-path-safety.md
@@ -1,0 +1,19 @@
+---
+{"title": "scripts slugify Windows path safety", "domain": "scripts", "source": "agent", "status": "published", "tags": ["slugify", "windows", "path", "filename"], "created": "2026-05-30 20:40:00 UTC", "updated": "2026-05-30 20:40:00 UTC"}
+---
+
+## Problem
+
+The `scripts/new_lesson.py` lesson generator used the raw slug as the Markdown filename stem after replacing unsupported title characters. Titles made only from slashes, emoji, or punctuation could collapse to an empty stem, and Windows-reserved names such as `CON` or `LPT1` could still become invalid filenames.
+
+## Root cause
+
+The original slugify path only lowercased, replaced non-word runs, stripped dashes, and truncated. It did not provide a fallback after sanitation, normalize Unicode compatibility forms, trim unsafe trailing filename characters, or disarm reserved Windows basenames.
+
+## Fix
+
+The slugify wrapper now normalizes titles with the Python standard library, collapses separator runs, trims unsafe edges, falls back to `lesson` for empty sanitized titles, and appends `-lesson` to reserved Windows names.
+
+## Verification
+
+`python tests/test_new_lesson_slugify.py` verifies slash/backslash replacement, symbol-only fallback, Windows reserved name handling, and long-title truncation. `python search_knowledge.py "slugify windows path"` finds this lesson card.

--- a/scripts/new_lesson.py
+++ b/scripts/new_lesson.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import re
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -20,14 +21,28 @@ LESSONS_DIR = REPO / "lessons"
 DOMAINS = sorted([
     "rag", "feishu", "development", "devops", "general",
     "python", "wsl", "git", "docker", "network",
-    "security", "frontend", "testing", "ci-cd",
+    "security", "frontend", "testing", "ci-cd", "scripts",
 ])
+
+WINDOWS_RESERVED_NAMES = {
+    "con", "prn", "aux", "nul",
+    *(f"com{i}" for i in range(1, 10)),
+    *(f"lpt{i}" for i in range(1, 10)),
+}
 
 
 def _slugify(title: str) -> str:
-    slug = title.lower().strip()
-    slug = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", "-", slug)
-    return slug.strip("-")[:60]
+    normalized = unicodedata.normalize("NFKC", title).casefold().strip()
+    slug = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", "-", normalized)
+    slug = re.sub(r"-+", "-", slug).strip("-._ ")
+    slug = slug[:60].rstrip("-._ ")
+
+    if not slug:
+        slug = "lesson"
+    if slug in WINDOWS_RESERVED_NAMES:
+        slug = f"{slug}-lesson"
+
+    return slug
 
 
 def _input_or_default(prompt: str, default: str = "") -> str:

--- a/tests/test_new_lesson_slugify.py
+++ b/tests/test_new_lesson_slugify.py
@@ -1,0 +1,31 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+from new_lesson import _slugify
+
+
+class TestNewLessonSlugify(unittest.TestCase):
+    def test_replaces_path_separators_and_symbols(self):
+        self.assertEqual(
+            _slugify("slugify Windows/WSL path: a\\b/c?.md"),
+            "slugify-windows-wsl-path-a-b-c-md",
+        )
+
+    def test_symbol_only_titles_use_safe_fallback(self):
+        self.assertEqual(_slugify("//// 😄 ***"), "lesson")
+
+    def test_windows_reserved_names_are_disarmed(self):
+        self.assertEqual(_slugify("CON"), "con-lesson")
+        self.assertEqual(_slugify("lpt1"), "lpt1-lesson")
+
+    def test_long_titles_trim_to_safe_boundary(self):
+        self.assertEqual(_slugify("a" * 80), "a" * 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize lesson titles before generating Markdown filename stems
- fall back to a safe `lesson` stem for symbol-only titles and disarm Windows reserved basenames
- add a scripts-domain lesson card documenting the slugify Windows path fix

Fixes #95
/claim #95

## Validation
- `python tests/test_new_lesson_slugify.py`
- `PYTHONIOENCODING=utf-8 python -m unittest discover -s tests`
- `PYTHONIOENCODING=utf-8 python search_knowledge.py "slugify windows path"`
- `git diff --cached --check`