### PR TITLE
fix: harden lesson slug filename generation

### DIFF
--- a/lessons/contrib/slugify-windows-path-safe-filenames.md
+++ b/lessons/contrib/slugify-windows-path-safe-filenames.md
@@ -1,0 +1,19 @@
+---
+{"title": "Slugify Windows path safe filenames", "domain": "scripts", "source": "agent", "status": "published", "tags": ["slugify", "windows", "path", "filename", "stdlib"]}
+---
+
+## Problem
+
+`scripts/new_lesson.py` built lesson filenames directly from `_slugify(title)`. Titles with path separators such as `/` or `\\`, emoji-only text, control-style punctuation, or Windows reserved device names could produce unsafe or empty filename stems. On Windows or WSL boundaries, that means the path could be truncated, rejected, or collapse to a surprising file like `.md`.
+
+## Root cause
+
+The previous slugify logic only lowercased the title, replaced non-ASCII/CJK runs with `-`, stripped hyphens, and truncated. It did not normalize Unicode, guarantee a non-empty result, or guard against reserved Windows filename stems such as `CON`, `PRN`, `AUX`, `NUL`, `COM1`, and `LPT1`.
+
+## Fix
+
+Normalize titles with Python stdlib `unicodedata.normalize("NFKC", ...)`, collapse all filesystem-hostile runs to single hyphens, and return a stable fallback stem of `lesson` when sanitization removes everything. Prefix reserved Windows device names with `lesson-` before appending `.md`. Keep the implementation dependency-free and readable.
+
+## Verification
+
+Add regression tests for slash/backslash/emoji input, emoji-only fallback, and reserved Windows names. Verify that `python3 search_knowledge.py "slugify windows path"` finds this lesson so future agents can retrieve the Windows path filename lesson offline.

--- a/scripts/new_lesson.py
+++ b/scripts/new_lesson.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import re
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -20,14 +21,35 @@ LESSONS_DIR = REPO / "lessons"
 DOMAINS = sorted([
     "rag", "feishu", "development", "devops", "general",
     "python", "wsl", "git", "docker", "network",
-    "security", "frontend", "testing", "ci-cd",
+    "security", "frontend", "testing", "ci-cd", "scripts",
 ])
+
+WINDOWS_RESERVED_FILENAMES = {
+    "con", "prn", "aux", "nul",
+    *(f"com{i}" for i in range(1, 10)),
+    *(f"lpt{i}" for i in range(1, 10)),
+}
 
 
 def _slugify(title: str) -> str:
-    slug = title.lower().strip()
-    slug = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", "-", slug)
-    return slug.strip("-")[:60]
+    """Return a cross-platform safe filename stem for a lesson title.
+
+    Keep ASCII alphanumerics and CJK characters for readable lesson names,
+    but collapse path separators, emoji, punctuation, control characters, and
+    other filesystem-hostile input to hyphens. Always return a non-empty stem
+    and avoid Windows device names such as ``CON`` and ``LPT1``.
+    """
+    normalized = unicodedata.normalize("NFKC", str(title)).casefold().strip()
+    slug = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", "-", normalized)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+
+    if not slug:
+        slug = "lesson"
+    if slug in WINDOWS_RESERVED_FILENAMES:
+        slug = f"lesson-{slug}"
+
+    slug = slug[:60].rstrip("-")
+    return slug or "lesson"
 
 
 def _input_or_default(prompt: str, default: str = "") -> str:

--- a/tests/test_new_lesson.py
+++ b/tests/test_new_lesson.py
@@ -1,0 +1,34 @@
+import importlib.util
+import unittest
+from pathlib import PureWindowsPath, Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+spec = importlib.util.spec_from_file_location(
+    "new_lesson", PROJECT_ROOT / "scripts" / "new_lesson.py"
+)
+assert spec is not None
+assert spec.loader is not None
+new_lesson = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(new_lesson)
+_slugify = new_lesson._slugify
+
+
+class TestNewLessonSlugify(unittest.TestCase):
+    def test_special_characters_slashes_and_emoji_are_safe(self):
+        slug = _slugify(r"Slugify / Windows \\ path 😅 bug")
+
+        self.assertEqual(slug, "slugify-windows-path-bug")
+        self.assertNotIn("/", slug)
+        self.assertNotIn("\\", slug)
+        self.assertEqual(PureWindowsPath(slug).name, slug)
+
+    def test_emoji_only_title_falls_back_to_safe_name(self):
+        self.assertEqual(_slugify("🤖/\\😅"), "lesson")
+
+    def test_windows_reserved_device_names_are_prefixed(self):
+        self.assertEqual(_slugify("CON"), "lesson-con")
+        self.assertEqual(_slugify("LPT1"), "lesson-lpt1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Harden `scripts/new_lesson.py` slug generation with stdlib Unicode normalization, safe fallback stems, collapsed separators, and Windows reserved device-name protection.
- Add regression coverage for slash/backslash/emoji input, emoji-only titles, and reserved Windows names.
- Add a `scripts` lesson under `lessons/contrib/` documenting the slugify Windows path fix.

/claim #95

## Verification

### Unit tests

```text
$ python3 -m unittest discover -s tests -v
test_docker_keywords_present (test_clean_pipeline.TestCleanPipeline.test_docker_keywords_present) ... ok
test_step_classify_devops (test_clean_pipeline.TestCleanPipeline.test_step_classify_devops) ... ok
test_step_classify_docker (test_clean_pipeline.TestCleanPipeline.test_step_classify_docker) ... ok
test_emoji_only_title_falls_back_to_safe_name (test_new_lesson.TestNewLessonSlugify.test_emoji_only_title_falls_back_to_safe_name) ... ok
test_special_characters_slashes_and_emoji_are_safe (test_new_lesson.TestNewLessonSlugify.test_special_characters_slashes_and_emoji_are_safe) ... ok
test_windows_reserved_device_names_are_prefixed (test_new_lesson.TestNewLessonSlugify.test_windows_reserved_device_names_are_prefixed) ... ok

----------------------------------------------------------------------
Ran 6 tests in 0.007s

OK

==================================================
自动分类
==================================================
  自动分类: 1/1 条

==================================================
自动分类
==================================================
  自动分类: 1/1 条
```

### Local lesson search proof

```text
$ python3 search_knowledge.py "slugify windows path"
📦 L2缓存: 121 篇变动
  📦 L2缓存: 6 篇变动
\n📋 lessons/  (全部 121 篇) (86 条匹配，展示前 10)
--------------------------------------------------
  [scripts]            Slugify Windows path safe filenames (published)
                        ████████░░ 76%
                       📄 lessons/slugify-windows-path-safe-filenames.md
                       `scripts/new_lesson.py` built lesson filenames directly from `_slugify(title)`. Titles with path separators such as `/` ...

  [devops]             DeepSeek TUI Agent 模式下 write_file 写入不落地 + worktree git 链接路径断裂 (published)
                        ███░░░░░░░ 27%
                       📄 lessons/deepseek-tui-agent-模式下-write-file-写入不落地-worktree-git-链接路径断裂.md
                       在 Agent-Medici 项目的 search_knowledge.py v2 升级过程中，使用 DeepSeek TUI Agent 模式进行代码修改。操作环境为 WSL (Windows Subsystem for Linux)，仓...

  [devops]             DeepSeek TUI Agent 模式下 write_file 写入不落地 + worktree git 链接路径断裂 (published)
                        ███░░░░░░░ 27%
                       📄 lessons/deepseek-tui-write-file-sandbox-worktree-git-path.md
                       在 Agent-Medici 项目的 search_knowledge.py v2 升级过程中，使用 DeepSeek TUI Agent 模式进行代码修改。操作环境为 WSL (Windows Subsystem for Linux)，仓...

  [development]        Python 沙箱/受限环境 — PATH 和 sys.path 隔离 
                        ██░░░░░░░░ 23%
                       📄 lessons/python-sandbox-path-isolation.md
                       在沙箱或受限环境中执行 Python 代码时，`import` 报 `ModuleNotFoundError`，或 import 的是宿主环境的包而非沙箱环境的。

  [devops]             Permission Denied / WSL NTFS 跨文件系统权限修复 
                        ██░░░░░░░░ 20%
                       📄 lessons/wsl-permission-ntfs-fix.md
                       操作 `/mnt/c/` 下的文件时报 `Permission denied` 或 `EACCES`；或 `git` 在 `/mnt/c/` 下报错。

  [devops]             WSL Windows 终端复制粘贴吞下划线问题 
                        ██░░░░░░░░ 20%
                       📄 lessons/wsl-terminal-underscore-missing.md
                       从 Windows 复制文本粘贴到 WSL 终端时，下划线 `_` 字符消失。配置文件、命令中的下划线名全部错误。

  [devops]             WSL 代理配置 — 通过 Windows 梯子访问外网 
                        ██░░░░░░░░ 19%
                       📄 lessons/wsl-proxy-setup.md
                       WSL 内 `curl google.com` 失败，但 Windows 能正常访问外网。WSL 默认不走 Windows 的代理。

  [devops]             Python GBK 编码错误 — Windows/WSL 跨平台 
                        ██░░░░░░░░ 19%
                       📄 lessons/python-gbk-encoding-error.md
                       在 WSL 中运行 Python 脚本，读取或写入文件时报：

  [devops]             共享JSON状态需要原子写入 
                        ██░░░░░░░░ 16%
                       📄 lessons/shared-json-needs-atomic-write.md
                       多个自动化job同时写共享的运行时状态文件（如 latest.json），plain overwrite 会暴露半写状态导致并发读者解析失败。

  [tts]                TTS 中文编码：PowerShell 传参必须用 .txt 文件中转 (published)
                        ██░░░░░░░░ 16%
                       📄 lessons/tts中文编码-powerhsell传参必须用txt文件.md
                       中文文本通过 PowerShell 脚本内联传给 mmx CLI，TTS 返回空音频（"嗯嗯"声）。

\n📋 reference/  (全部 6 篇) (6 条匹配，展示前 6)
--------------------------------------------------
  [devops]             微信机器人方案迭代轨迹 —— wxauto 安装 + 版本兼容 (reference)
                        ███████░░░ 68%
                       📄 reference/wechat-bot-iteration-trajectory.md
                       > Opus 4.6 在开发微信机器人过程中，经历了多次方案迭代。

  [hub]                Mem0 + Qdrant 虫群记忆实施方案 
                        ██░░░░░░░░ 16%
                       📄 reference/mem0-qdrant-implementation.md
                       确定采用方案二（Mem0 + Qdrant）后，需要将实施过程分解为可执行的子任务，

  [devops]             虫群记忆系统——三方案对比与选型 (reference)
                        █░░░░░░░░░ 13%
                       📄 reference/swarm-memory-architecture-comparison.md
                       > 飞书群"塔罗会"有 7 个成员节点（倒吊人/太阳/魔术师/审判/正义/世界/愚者），

  [hub]                虫群记忆系统 — 三方案对比与选型 
                        █░░░░░░░░░ 12%
                       📄 reference/swarm-memory-three-schemes.md
                       塔罗会成员（愚者/倒吊人/正义/太阳/魔术师/审判/世界）分布在多个环境（WSL / Windows / 云端），

  [devops]             Mem0 + Qdrant 方案执行清单 (reference)
                        █░░░░░░░░░ 10%
                       📄 reference/mem0-qdrant-execution-plan.md
                       > 确认执行方案二（Mem0 + Qdrant 自托管），

                       Agent-Medici 架构分析方法论 - 避免文档依赖陷阱 
                         ░░░░░░░░░░ 2%
                       📄 reference/agent-medici-architecture-analysis-methodology.md
                       在分析 Agent-Medici 优化方向时，我犯了一系列判断失误。本文档记录正确的架构分析方法论，避免未来重复失误。

  ⏱ 检索 127 篇文档耗时 0.20s
  💡 查看完整内容: cat lessons/<filename>.md
  💡 贡献新知识: python3 misakanet/scripts/queue_lesson.py -t '标题' -d domain '内容...'
```
