### PR TITLE
feat(cli): add graceful degradation and auto-retry to network requests

### DIFF
--- a/misakanet/scripts/hub_poller.py
+++ b/misakanet/scripts/hub_poller.py
@@ -48,9 +48,10 @@ def _get_graph():
     return kg
 
 
-def gh_api(method, path, data=None):
-    """调用 GitHub REST API"""
+def gh_api(method, path, data=None, max_retries=3):
+    """调用 GitHub REST API with Graceful Degradation & Auto-Retry"""
     import requests
+    import time
 
     headers = {
         "Authorization": f"token {TOKEN}",
@@ -60,21 +61,33 @@ def gh_api(method, path, data=None):
 
     url = f"{API_BASE}/{path.lstrip('/')}"
 
-    if method == "GET":
-        resp = requests.get(url, headers=headers, timeout=15)
-    elif method == "POST":
-        resp = requests.post(url, headers=headers, json=data, timeout=15)
-    elif method == "PATCH":
-        resp = requests.patch(url, headers=headers, json=data, timeout=15)
-    else:
-        raise ValueError(f"unsupported method: {method}")
+    for attempt in range(max_retries):
+        try:
+            if method == "GET":
+                resp = requests.get(url, headers=headers, timeout=15)
+            elif method == "POST":
+                resp = requests.post(url, headers=headers, json=data, timeout=15)
+            elif method == "PATCH":
+                resp = requests.patch(url, headers=headers, json=data, timeout=15)
+            else:
+                raise ValueError(f"unsupported method: {method}")
 
-    if resp.status_code >= 400:
-        print(f"  [warn] API error {resp.status_code}: {resp.text[:200]}", file=sys.stderr)
-        return None
-    if resp.status_code == 204:
-        return {"status": "ok"}
-    return resp.json()
+            # Raise for specific server or transient errors to trigger retry
+            if resp.status_code in [404, 500, 502, 503, 504]:
+                resp.raise_for_status()
+                
+            if resp.status_code == 204:
+                return {"status": "ok"}
+            return resp.json()
+            
+        except (requests.exceptions.Timeout, requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            if attempt < max_retries - 1:
+                backoff_time = 2 ** attempt
+                print(f"  [warn] API Error: {e}. Retrying in {backoff_time}s... ({attempt + 1}/{max_retries})")
+                time.sleep(backoff_time)
+            else:
+                print(f"  [error] API request failed after {max_retries} attempts: {e}")
+                return None
 
 
 def fetch_unprocessed_feedback():


### PR DESCRIPTION
## Description

This PR fulfills the requirements outlined in #103 by implementing a robust auto-retry and graceful degradation mechanism in the core fetching logic (`misakanet/scripts/hub_poller.py`).

### Changes Made:
- Integrated a standard retry loop within the `gh_api` network handler.
- Catches specific network exceptions (`Timeout`, `ConnectionError`) as well as HTTP errors (specifically 404, 500, 502, 503, 504) via `raise_for_status()`.
- Implements exponential backoff (`2 ** attempt`) for up to a maximum of 3 retries before returning `None` instead of crashing the CLI with a traceback.

## Related Issues
Closes #103

---
*Payout Address (Solana):* `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`