### PR TITLE
Add async expanded LangChain search cache

### DIFF
--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -1,4 +1,8 @@
-import sys
+import asyncio
+import hashlib
+import re
+import sqlite3
+import time
 from pathlib import Path
 
 # Try to import langchain BaseTool, fallback to a standalone class if not available
@@ -15,16 +19,43 @@ except ImportError:
 
 class MisakaNetSearchTool(BaseTool):
     name: str = "misakanet_search"
-    description: str = "Search the MisakaNet distributed knowledge base for solved developer bugs and experience."
+    description: str = (
+        "Search the MisakaNet distributed knowledge base for solved developer bugs and experience."
+    )
+    cache_ttl_seconds: int = 300
+    cache_path: Path | None = None
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        cache_path: str | Path | None = None,
+        cache_ttl_seconds: int = 300,
+        **kwargs,
+    ):
         if HAS_LANGCHAIN:
             super().__init__(**kwargs)
         else:
             # Standalone mock implementation fields
             pass
+        repo_root = Path(__file__).resolve().parents[2]
+        object.__setattr__(
+            self,
+            "cache_path",
+            Path(cache_path)
+            if cache_path is not None
+            else repo_root / ".cache" / "langchain_tool_cache.db",
+        )
+        object.__setattr__(self, "cache_ttl_seconds", cache_ttl_seconds)
 
     def _run(self, query: str) -> str:
+        cached = self._get_cached_result(query)
+        if cached is not None:
+            return cached
+
+        result = self._execute_search(query)
+        self._set_cached_result(query, result)
+        return result
+
+    def _execute_search(self, query: str) -> str:
         # Import core engine elements
         from misakanet.search.engine import _load_docs, _rank_docs, LESSONS, REFERENCES
         
@@ -32,8 +63,8 @@ class MisakaNetSearchTool(BaseTool):
         ref_docs = _load_docs(REFERENCES, is_lesson=False)
         all_docs = lessons_docs + ref_docs
         
-        # Rank docs using BM25
-        ranked = _rank_docs(query, all_docs)
+        # Rank docs using expanded local queries and Reciprocal Rank Fusion.
+        ranked = self._rank_with_rrf(query, all_docs, _rank_docs)
         if not ranked:
             return f"No results found in MisakaNet for '{query}'"
             
@@ -43,7 +74,12 @@ class MisakaNetSearchTool(BaseTool):
             preview = doc.content.replace('\r\n', '\n').split('\n')
             preview_lines = [l for l in preview if l.strip() and not l.startswith('---')][:8]
             content_preview = '\n'.join(preview_lines)
-            results.append(f"📄 File: lessons/{doc.filename}\n📌 Title: {doc.title}\n🔍 Domain: {doc.domain}\n📝 Preview:\n{content_preview}\n")
+            results.append(
+                f"📄 File: lessons/{doc.filename}\n"
+                f"📌 Title: {doc.title}\n"
+                f"🔍 Domain: {doc.domain}\n"
+                f"📝 Preview:\n{content_preview}\n"
+            )
             
         return "\n" + "\n----------------------------------------\n".join(results)
 
@@ -51,4 +87,102 @@ class MisakaNetSearchTool(BaseTool):
         return self._run(query)
 
     async def _arun(self, query: str) -> str:
-        return self._run(query)
+        return await asyncio.to_thread(self._run, query)
+
+    def _expand_query(self, query: str) -> list[str]:
+        base = " ".join(query.split())
+        tokens = re.findall(r"[\w\u4e00-\u9fff]+", base.lower())
+        unique_tokens = list(dict.fromkeys(tokens))
+
+        candidates = [
+            base,
+            " ".join(unique_tokens),
+            " ".join(reversed(unique_tokens)),
+        ]
+        if unique_tokens:
+            candidates.extend([
+                f"{base} solution",
+                f"{base} troubleshooting",
+                " ".join(unique_tokens[: max(1, len(unique_tokens) // 2)]),
+            ])
+
+        expanded = []
+        seen = set()
+        for candidate in candidates:
+            normalized = " ".join(candidate.split())
+            if normalized and normalized not in seen:
+                expanded.append(normalized)
+                seen.add(normalized)
+            if len(expanded) == 3:
+                return expanded
+
+        while len(expanded) < 3:
+            fallback = f"{base} variant {len(expanded) + 1}".strip()
+            if fallback not in seen:
+                expanded.append(fallback)
+                seen.add(fallback)
+        return expanded
+
+    def _rank_with_rrf(self, query: str, docs: list, ranker) -> list[tuple[float, object]]:
+        fused: dict[str, dict[str, object]] = {}
+        for subquery in self._expand_query(query):
+            for rank, (score, doc) in enumerate(ranker(subquery, docs), start=1):
+                doc_key = str(getattr(doc, "filepath", getattr(doc, "filename", id(doc))))
+                item = fused.setdefault(doc_key, {"score": 0.0, "doc": doc, "best_score": score})
+                item["score"] = float(item["score"]) + 1.0 / (60 + rank)
+                item["best_score"] = max(float(item["best_score"]), float(score))
+
+        ranked = [
+            (float(item["score"]) + 0.001 * float(item["best_score"]), item["doc"])
+            for item in fused.values()
+        ]
+        ranked.sort(key=lambda item: item[0], reverse=True)
+        return ranked
+
+    def _cache_key(self, query: str) -> str:
+        return hashlib.sha256(query.strip().encode("utf-8")).hexdigest()
+
+    def _cache_connection(self):
+        assert self.cache_path is not None
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.cache_path))
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS langchain_search_cache (
+                cache_key TEXT PRIMARY KEY,
+                query TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                result TEXT NOT NULL
+            )
+            """
+        )
+        return conn
+
+    def _get_cached_result(self, query: str) -> str | None:
+        now = time.time()
+        key = self._cache_key(query)
+        with self._cache_connection() as conn:
+            cutoff = now - self.cache_ttl_seconds
+            conn.execute("DELETE FROM langchain_search_cache WHERE created_at < ?", (cutoff,))
+            row = conn.execute(
+                "SELECT result, created_at FROM langchain_search_cache WHERE cache_key = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                return None
+            result, created_at = row
+            if now - float(created_at) <= self.cache_ttl_seconds:
+                return result
+            conn.execute("DELETE FROM langchain_search_cache WHERE cache_key = ?", (key,))
+        return None
+
+    def _set_cached_result(self, query: str, result: str) -> None:
+        with self._cache_connection() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO langchain_search_cache
+                    (cache_key, query, created_at, result)
+                VALUES (?, ?, ?, ?)
+                """,
+                (self._cache_key(query), query, time.time(), result),
+            )

--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -128,16 +128,29 @@ class MisakaNetSearchTool(BaseTool):
         for subquery in self._expand_query(query):
             for rank, (score, doc) in enumerate(ranker(subquery, docs), start=1):
                 doc_key = str(getattr(doc, "filepath", getattr(doc, "filename", id(doc))))
-                item = fused.setdefault(doc_key, {"score": 0.0, "doc": doc, "best_score": score})
+                filename = str(getattr(doc, "filename", doc_key))
+                item = fused.setdefault(
+                    doc_key,
+                    {
+                        "score": 0.0,
+                        "doc": doc,
+                        "best_rank": rank,
+                        "filename": filename,
+                    },
+                )
                 item["score"] = float(item["score"]) + 1.0 / (60 + rank)
-                item["best_score"] = max(float(item["best_score"]), float(score))
+                item["best_rank"] = min(int(item["best_rank"]), rank)
+                item["filename"] = min(str(item["filename"]), filename)
 
-        ranked = [
-            (float(item["score"]) + 0.001 * float(item["best_score"]), item["doc"])
-            for item in fused.values()
-        ]
-        ranked.sort(key=lambda item: item[0], reverse=True)
-        return ranked
+        ranked = sorted(
+            fused.values(),
+            key=lambda item: (
+                -float(item["score"]),
+                int(item["best_rank"]),
+                str(item["filename"]),
+            ),
+        )
+        return [(float(item["score"]), item["doc"]) for item in ranked]
 
     def _cache_key(self, query: str) -> str:
         return hashlib.sha256(query.strip().encode("utf-8")).hexdigest()

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -1,0 +1,87 @@
+import asyncio
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from misakanet.tools.langchain_tool import MisakaNetSearchTool
+
+
+class TestMisakaNetSearchTool(unittest.TestCase):
+    def test_cache_hit_and_expired_miss(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path)
+            tool._execute_search = Mock(return_value="fresh result")
+
+            self.assertEqual(tool._run("cache me"), "fresh result")
+            self.assertEqual(tool._run("cache me"), "fresh result")
+            self.assertEqual(tool._execute_search.call_count, 1)
+
+            with sqlite3.connect(cache_path) as conn:
+                conn.execute(
+                    "UPDATE langchain_search_cache SET created_at = ?",
+                    (time.time() - tool.cache_ttl_seconds - 1,),
+                )
+
+            tool._execute_search.return_value = "expired result"
+            self.assertEqual(tool._run("cache me"), "expired result")
+            self.assertEqual(tool._execute_search.call_count, 2)
+
+    def test_rrf_merges_multi_query_rankings(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+        doc_a = SimpleNamespace(filename="a.md", filepath=Path("a.md"))
+        doc_b = SimpleNamespace(filename="b.md", filepath=Path("b.md"))
+        doc_c = SimpleNamespace(filename="c.md", filepath=Path("c.md"))
+
+        rankings = {
+            "cache invalidation bug": [(0.9, doc_a), (0.5, doc_b)],
+            "cache invalidation bug solution": [(0.7, doc_b), (0.4, doc_c)],
+            "cache invalidation bug troubleshooting": [(0.8, doc_c), (0.3, doc_b)],
+        }
+
+        def ranker(subquery, docs):
+            return rankings[subquery]
+
+        tool._expand_query = Mock(
+            return_value=[
+                "cache invalidation bug",
+                "cache invalidation bug solution",
+                "cache invalidation bug troubleshooting",
+            ]
+        )
+
+        ranked = tool._rank_with_rrf("cache invalidation bug", [doc_a, doc_b, doc_c], ranker)
+
+        self.assertEqual(ranked[0][1], doc_b)
+        self.assertEqual({doc.filename for _, doc in ranked}, {"a.md", "b.md", "c.md"})
+
+    def test_expand_query_returns_three_distinct_queries(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+
+        expanded = tool._expand_query("async cache async cache")
+
+        self.assertEqual(len(expanded), 3)
+        self.assertEqual(len(set(expanded)), 3)
+        self.assertEqual(expanded[0], "async cache async cache")
+
+    def test_arun_uses_thread_offload(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+
+        async def run():
+            with patch(
+                "misakanet.tools.langchain_tool.asyncio.to_thread",
+                new=AsyncMock(return_value="async result"),
+            ) as to_thread:
+                result = await tool._arun("async query")
+                to_thread.assert_awaited_once_with(tool._run, "async query")
+                return result
+
+        self.assertEqual(asyncio.run(run()), "async result")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -5,7 +5,7 @@ import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock
 
 from misakanet.tools.langchain_tool import MisakaNetSearchTool
 
@@ -59,6 +59,26 @@ class TestMisakaNetSearchTool(unittest.TestCase):
         self.assertEqual(ranked[0][1], doc_b)
         self.assertEqual({doc.filename for _, doc in ranked}, {"a.md", "b.md", "c.md"})
 
+    def test_rrf_uses_rank_and_filename_tiebreakers(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+        doc_a = SimpleNamespace(filename="a.md", filepath=Path("a.md"))
+        doc_b = SimpleNamespace(filename="b.md", filepath=Path("b.md"))
+        doc_c = SimpleNamespace(filename="c.md", filepath=Path("c.md"))
+
+        rankings = {
+            "query one": [(0.9, doc_b), (0.8, doc_a), (0.7, doc_c)],
+            "query two": [(0.6, doc_c), (0.5, doc_a), (0.4, doc_b)],
+        }
+
+        def ranker(subquery, docs):
+            return rankings[subquery]
+
+        tool._expand_query = Mock(return_value=["query one", "query two"])
+
+        ranked = tool._rank_with_rrf("query", [doc_a, doc_b, doc_c], ranker)
+
+        self.assertEqual([doc.filename for _, doc in ranked], ["b.md", "c.md", "a.md"])
+
     def test_expand_query_returns_three_distinct_queries(self):
         tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
 
@@ -68,19 +88,30 @@ class TestMisakaNetSearchTool(unittest.TestCase):
         self.assertEqual(len(set(expanded)), 3)
         self.assertEqual(expanded[0], "async cache async cache")
 
-    def test_arun_uses_thread_offload(self):
+    def test_arun_runs_blocking_work_concurrently(self):
         tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
 
         async def run():
-            with patch(
-                "misakanet.tools.langchain_tool.asyncio.to_thread",
-                new=AsyncMock(return_value="async result"),
-            ) as to_thread:
-                result = await tool._arun("async query")
-                to_thread.assert_awaited_once_with(tool._run, "async query")
-                return result
+            def slow_run(query):
+                time.sleep(0.2)
+                return f"async result: {query}"
 
-        self.assertEqual(asyncio.run(run()), "async result")
+            tool._run = slow_run
+            started = time.perf_counter()
+            results = await asyncio.gather(
+                tool._arun("first query"),
+                tool._arun("second query"),
+            )
+            elapsed = time.perf_counter() - started
+            return results, elapsed
+
+        results, elapsed = asyncio.run(run())
+
+        self.assertEqual(
+            results,
+            ["async result: first query", "async result: second query"],
+        )
+        self.assertLess(elapsed, 0.35)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds an isolated SQLite cache for MisakaNetSearchTool results with a 5-minute TTL and expired-entry cleanup on read.
- Adds local 3-query expansion and Reciprocal Rank Fusion reranking before formatting LangChain tool results.
- Offloads async _arun execution through asyncio.to_thread so the event loop is not blocked.
- Adds unit coverage for cache hit/expiry, RRF merging, distinct query expansion, and async thread offload.

## Validation
- python3 -m unittest discover tests
- python3 -m py_compile misakanet/tools/langchain_tool.py tests/test_langchain_tool.py
- git diff --check

Closes #112

/claim #112