### PR TITLE
feat: add async cached multi-query search tool

### DIFF
--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -1,21 +1,202 @@
-import sys
+import asyncio
+import hashlib
+import re
+import sqlite3
+import time
 from pathlib import Path
 
 # Try to import langchain BaseTool, fallback to a standalone class if not available
 try:
     from langchain_core.tools import BaseTool
+
     HAS_LANGCHAIN = True
 except ImportError:
     try:
         from langchain.tools import BaseTool
+
         HAS_LANGCHAIN = True
     except ImportError:
         BaseTool = object
         HAS_LANGCHAIN = False
 
+
+REPO = Path(__file__).resolve().parents[2]
+_CACHE_TTL_SECONDS = 300
+_CACHE_DB = REPO / ".cache" / "langchain_tool_cache.db"
+_RRF_K = 60
+
+
+def _query_key(query: str) -> str:
+    return hashlib.sha256(query.encode("utf-8")).hexdigest()
+
+
+def _cache_conn() -> sqlite3.Connection:
+    _CACHE_DB.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(_CACHE_DB))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS search_cache (
+            query_key TEXT PRIMARY KEY,
+            query TEXT NOT NULL,
+            result TEXT NOT NULL,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    return conn
+
+
+def _cache_lookup(query: str) -> str | None:
+    cutoff = time.time() - _CACHE_TTL_SECONDS
+    with _cache_conn() as conn:
+        conn.execute("DELETE FROM search_cache WHERE created_at < ?", (cutoff,))
+        row = conn.execute(
+            "SELECT result FROM search_cache WHERE query_key = ? AND created_at >= ?",
+            (_query_key(query), cutoff),
+        ).fetchone()
+    return row[0] if row else None
+
+
+def _cache_store(query: str, result: str) -> None:
+    with _cache_conn() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO search_cache (query_key, query, result, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (_query_key(query), query, result, time.time()),
+        )
+
+
+def _expand_query(query: str) -> list[str]:
+    compact = " ".join(query.split())
+    if not compact:
+        return ["", "keywords", "summary"]
+
+    stopwords = {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "for",
+        "from",
+        "how",
+        "in",
+        "is",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "with",
+        "what",
+        "when",
+        "where",
+        "why",
+    }
+    tokens = [
+        token
+        for token in re.findall(r"[\w\u4e00-\u9fff]+", compact.lower())
+        if token not in stopwords
+    ]
+
+    variants = [compact]
+    if tokens:
+        variants.append(" ".join(tokens[:8]))
+        variants.append(" ".join(tokens[-8:]))
+
+    # Keep exactly three distinct local variants without relying on an LLM.
+    for suffix in ("troubleshooting", "solution", "implementation"):
+        if len({v for v in variants if v}) >= 3:
+            break
+        variants.append(f"{compact} {suffix}")
+
+    distinct = []
+    seen = set()
+    for variant in variants:
+        normalized = " ".join(variant.split())
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            distinct.append(normalized)
+        if len(distinct) == 3:
+            break
+    while len(distinct) < 3:
+        distinct.append(compact)
+    return distinct
+
+
+def _load_search_docs():
+    from misakanet.search.engine import LESSONS, REFERENCES, _load_docs
+
+    lessons_docs = _load_docs(LESSONS, is_lesson=True)
+    ref_docs = _load_docs(REFERENCES, is_lesson=False)
+    return lessons_docs + ref_docs
+
+
+def _rank_subquery(query: str, docs):
+    from misakanet.search.engine import _rank_docs
+
+    return _rank_docs(query, docs)
+
+
+def _rrf_merge(result_sets, k: int = _RRF_K):
+    doc_map = {}
+    scores = {}
+    best_rank = {}
+
+    for ranked in result_sets:
+        for rank, (_score, doc) in enumerate(ranked, start=1):
+            doc_id = str(getattr(doc, "filepath", getattr(doc, "filename", id(doc))))
+            doc_map[doc_id] = doc
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k + rank)
+            best_rank[doc_id] = min(best_rank.get(doc_id, rank), rank)
+
+    merged = [(score, doc_map[doc_id], best_rank[doc_id]) for doc_id, score in scores.items()]
+    merged.sort(key=lambda item: (-item[0], item[2], getattr(item[1], "filename", "")))
+    return [(score, doc) for score, doc, _rank in merged]
+
+
+def _format_doc_path(doc) -> str:
+    filepath = getattr(doc, "filepath", None)
+    if filepath:
+        try:
+            return str(Path(filepath).relative_to(REPO)).replace("\\", "/")
+        except ValueError:
+            return str(filepath).replace("\\", "/")
+    return getattr(doc, "filename", "unknown")
+
+
+def _format_results(query: str, ranked) -> str:
+    if not ranked:
+        return f"No results found in MisakaNet for '{query}'"
+
+    results = []
+    for score, doc in ranked[:3]:
+        preview = getattr(doc, "content", "").replace("\r\n", "\n").split("\n")
+        preview_lines = [line for line in preview if line.strip() and not line.startswith("---")][:8]
+        content_preview = "\n".join(preview_lines)
+        results.append(
+            "\n".join(
+                [
+                    f"File: {_format_doc_path(doc)}",
+                    f"Title: {getattr(doc, 'title', '')}",
+                    f"Domain: {getattr(doc, 'domain', '')}",
+                    f"RRF Score: {score:.6f}",
+                    "Preview:",
+                    content_preview,
+                ]
+            )
+        )
+    return "\n" + "\n----------------------------------------\n".join(results)
+
+
 class MisakaNetSearchTool(BaseTool):
     name: str = "misakanet_search"
-    description: str = "Search the MisakaNet distributed knowledge base for solved developer bugs and experience."
+    description: str = (
+        "Search the MisakaNet distributed knowledge base for solved developer bugs and "
+        "experience."
+    )
 
     def __init__(self, **kwargs):
         if HAS_LANGCHAIN:
@@ -25,30 +206,19 @@ class MisakaNetSearchTool(BaseTool):
             pass
 
     def _run(self, query: str) -> str:
-        # Import core engine elements
-        from misakanet.search.engine import _load_docs, _rank_docs, LESSONS, REFERENCES
-        
-        lessons_docs = _load_docs(LESSONS, is_lesson=True)
-        ref_docs = _load_docs(REFERENCES, is_lesson=False)
-        all_docs = lessons_docs + ref_docs
-        
-        # Rank docs using BM25
-        ranked = _rank_docs(query, all_docs)
-        if not ranked:
-            return f"No results found in MisakaNet for '{query}'"
-            
-        results = []
-        for score, doc in ranked[:3]:
-            # Clean preview
-            preview = doc.content.replace('\r\n', '\n').split('\n')
-            preview_lines = [l for l in preview if l.strip() and not l.startswith('---')][:8]
-            content_preview = '\n'.join(preview_lines)
-            results.append(f"📄 File: lessons/{doc.filename}\n📌 Title: {doc.title}\n🔍 Domain: {doc.domain}\n📝 Preview:\n{content_preview}\n")
-            
-        return "\n" + "\n----------------------------------------\n".join(results)
+        cached = _cache_lookup(query)
+        if cached is not None:
+            return cached
+
+        all_docs = _load_search_docs()
+        result_sets = [_rank_subquery(subquery, all_docs) for subquery in _expand_query(query)]
+        ranked = _rrf_merge(result_sets)
+        result = _format_results(query, ranked)
+        _cache_store(query, result)
+        return result
 
     def run(self, query: str) -> str:
         return self._run(query)
 
     async def _arun(self, query: str) -> str:
-        return self._run(query)
+        return await asyncio.to_thread(self._run, query)

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -1,0 +1,106 @@
+import asyncio
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from misakanet.tools import langchain_tool as tool_module
+
+
+def _doc(name, title=None):
+    return SimpleNamespace(
+        filename=name,
+        filepath=Path(name),
+        title=title or name,
+        domain="test",
+        content=f"{title or name} body",
+        status="published",
+        reference="",
+        is_lesson=True,
+    )
+
+
+class TestLangChainTool(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.original_db = tool_module._CACHE_DB
+        self.original_ttl = tool_module._CACHE_TTL_SECONDS
+        tool_module._CACHE_DB = Path(self.tmpdir.name) / "tool-cache.db"
+        tool_module._CACHE_TTL_SECONDS = 300
+        self.addCleanup(self._restore_cache_settings)
+
+    def _restore_cache_settings(self):
+        tool_module._CACHE_DB = self.original_db
+        tool_module._CACHE_TTL_SECONDS = self.original_ttl
+
+    def test_cache_hit_and_expired_miss(self):
+        doc = _doc("cache.md", "Cache result")
+        calls = {"rank": 0}
+
+        def fake_rank(_query, _docs):
+            calls["rank"] += 1
+            return [(1.0, doc)]
+
+        search_tool = tool_module.MisakaNetSearchTool()
+        with patch.object(tool_module, "_load_search_docs", return_value=[doc]), patch.object(
+            tool_module, "_rank_subquery", side_effect=fake_rank
+        ):
+            first = search_tool._run("cache query")
+            second = search_tool._run("cache query")
+
+            self.assertEqual(first, second)
+            self.assertEqual(calls["rank"], 3)
+
+            with sqlite3.connect(tool_module._CACHE_DB) as conn:
+                conn.execute("UPDATE search_cache SET created_at = ?", (time.time() - 301,))
+
+            third = search_tool._run("cache query")
+            self.assertEqual(third, first)
+            self.assertEqual(calls["rank"], 6)
+
+    def test_rrf_prefers_consistently_high_ranked_docs(self):
+        doc_a = _doc("a.md")
+        doc_b = _doc("b.md")
+        doc_c = _doc("c.md")
+
+        merged = tool_module._rrf_merge(
+            [
+                [(10.0, doc_a), (9.0, doc_b)],
+                [(10.0, doc_b), (9.0, doc_a)],
+                [(10.0, doc_b), (9.0, doc_c)],
+            ]
+        )
+
+        self.assertEqual(merged[0][1].filename, "b.md")
+        self.assertEqual([doc.filename for _score, doc in merged], ["b.md", "a.md", "c.md"])
+
+    def test_arun_does_not_block_event_loop(self):
+        search_tool = tool_module.MisakaNetSearchTool()
+        ticks = []
+
+        def slow_run(_self, _query):
+            time.sleep(0.2)
+            return "ok"
+
+        async def marker():
+            await asyncio.sleep(0.02)
+            ticks.append(time.perf_counter())
+
+        async def scenario():
+            start = time.perf_counter()
+            with patch.object(tool_module.MisakaNetSearchTool, "_run", slow_run):
+                result, _ = await asyncio.gather(search_tool._arun("async query"), marker())
+            return result, ticks[0] - start
+
+        result, tick_elapsed = asyncio.run(scenario())
+
+        self.assertEqual(result, "ok")
+        self.assertLess(tick_elapsed, 0.16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿Title: feat: add async cached multi-query search tool

Summary:
- rewrites MisakaNetSearchTool._arun to run search work through asyncio.to_thread
- expands each search into 3 local query variants, ranks each with the existing BM25 path, and merges with RRF k=60
- adds an independent SQLite cache at .cache/langchain_tool_cache.db with a 5-minute TTL and cleanup on read
- adds tests for cache hit/expiry, RRF ordering, and non-blocking async execution

Claim:
/claim #112

Tests:
PYTHONUTF8=1 python -m unittest discover -s tests
