### PR TITLE
Add LangChain search telemetry

### DIFF
--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -17,6 +17,7 @@ except ImportError:
         BaseTool = object
         HAS_LANGCHAIN = False
 
+
 class MisakaNetSearchTool(BaseTool):
     name: str = "misakanet_search"
     description: str = (
@@ -24,10 +25,12 @@ class MisakaNetSearchTool(BaseTool):
     )
     cache_ttl_seconds: int = 300
     cache_path: Path | None = None
+    telemetry_path: Path | None = None
 
     def __init__(
         self,
         cache_path: str | Path | None = None,
+        telemetry_path: str | Path | None = None,
         cache_ttl_seconds: int = 300,
         **kwargs,
     ):
@@ -44,15 +47,26 @@ class MisakaNetSearchTool(BaseTool):
             if cache_path is not None
             else repo_root / ".cache" / "langchain_tool_cache.db",
         )
+        object.__setattr__(
+            self,
+            "telemetry_path",
+            Path(telemetry_path)
+            if telemetry_path is not None
+            else repo_root / ".cache" / "langchain_telemetry.db",
+        )
         object.__setattr__(self, "cache_ttl_seconds", cache_ttl_seconds)
 
     def _run(self, query: str) -> str:
+        started = time.perf_counter()
+        cache_hit = 0
         cached = self._get_cached_result(query)
         if cached is not None:
+            self._record_telemetry(query, started, cache_hit=1)
             return cached
 
         result = self._execute_search(query)
         self._set_cached_result(query, result)
+        self._record_telemetry(query, started, cache_hit=cache_hit)
         return result
 
     def _execute_search(self, query: str) -> str:
@@ -84,6 +98,9 @@ class MisakaNetSearchTool(BaseTool):
         return "\n" + "\n----------------------------------------\n".join(results)
 
     def run(self, query: str) -> str:
+        return self._run(query)
+
+    def search(self, query: str) -> str:
         return self._run(query)
 
     async def _arun(self, query: str) -> str:
@@ -199,3 +216,72 @@ class MisakaNetSearchTool(BaseTool):
                 """,
                 (self._cache_key(query), query, time.time(), result),
             )
+
+    def _telemetry_connection(self):
+        assert self.telemetry_path is not None
+        self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.telemetry_path), timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS search_telemetry (
+                query TEXT,
+                timestamp REAL,
+                latency_ms REAL,
+                cache_hit INTEGER
+            )
+            """
+        )
+        return conn
+
+    def _record_telemetry(self, query: str, started: float, cache_hit: int) -> None:
+        latency_ms = (time.perf_counter() - started) * 1000
+        with self._telemetry_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO search_telemetry
+                    (query, timestamp, latency_ms, cache_hit)
+                VALUES (?, ?, ?, ?)
+                """,
+                (query, time.time(), latency_ms, cache_hit),
+            )
+
+    def get_telemetry_summary(self) -> dict:
+        with self._telemetry_connection() as conn:
+            total_searches = int(
+                conn.execute("SELECT COUNT(*) FROM search_telemetry").fetchone()[0]
+            )
+            if total_searches == 0:
+                return {
+                    "total_searches": 0,
+                    "cache_hit_rate": 0.0,
+                    "avg_latency_ms": 0.0,
+                    "saved_time_ms": 0,
+                }
+
+            hit_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM search_telemetry WHERE cache_hit = 1"
+                ).fetchone()[0]
+            )
+            avg_latency_ms = float(
+                conn.execute("SELECT AVG(latency_ms) FROM search_telemetry").fetchone()[0]
+                or 0.0
+            )
+            avg_hit_latency = conn.execute(
+                "SELECT AVG(latency_ms) FROM search_telemetry WHERE cache_hit = 1"
+            ).fetchone()[0]
+            avg_miss_latency = conn.execute(
+                "SELECT AVG(latency_ms) FROM search_telemetry WHERE cache_hit = 0"
+            ).fetchone()[0]
+
+        saved_time_ms = 0
+        if hit_count and avg_hit_latency is not None and avg_miss_latency is not None:
+            saved_time_ms = (float(avg_miss_latency) - float(avg_hit_latency)) * hit_count
+
+        return {
+            "total_searches": total_searches,
+            "cache_hit_rate": hit_count / total_searches,
+            "avg_latency_ms": avg_latency_ms,
+            "saved_time_ms": saved_time_ms,
+        }

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -14,7 +14,8 @@ class TestMisakaNetSearchTool(unittest.TestCase):
     def test_cache_hit_and_expired_miss(self):
         with tempfile.TemporaryDirectory() as tmp:
             cache_path = Path(tmp) / "search.db"
-            tool = MisakaNetSearchTool(cache_path=cache_path)
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
             tool._execute_search = Mock(return_value="fresh result")
 
             self.assertEqual(tool._run("cache me"), "fresh result")
@@ -30,6 +31,55 @@ class TestMisakaNetSearchTool(unittest.TestCase):
             tool._execute_search.return_value = "expired result"
             self.assertEqual(tool._run("cache me"), "expired result")
             self.assertEqual(tool._execute_search.call_count, 2)
+
+    def test_telemetry_summary_reports_cache_hit_rate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(side_effect=lambda query: f"fresh result: {query}")
+
+            self.assertEqual(tool._run("cache me"), "fresh result: cache me")
+            self.assertEqual(tool._run("cache me"), "fresh result: cache me")
+            self.assertEqual(tool._run("cache other"), "fresh result: cache other")
+
+            summary = tool.get_telemetry_summary()
+
+            self.assertEqual(summary["total_searches"], 3)
+            self.assertAlmostEqual(summary["cache_hit_rate"], 1 / 3)
+            self.assertGreater(summary["avg_latency_ms"], 0)
+
+    def test_telemetry_summary_calculates_saved_time(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(
+                cache_path=Path(tmp) / "search.db",
+                telemetry_path=telemetry_path,
+            )
+
+            self.assertEqual(tool.get_telemetry_summary()["saved_time_ms"], 0)
+
+            with tool._telemetry_connection() as conn:
+                conn.executemany(
+                    """
+                    INSERT INTO search_telemetry
+                        (query, timestamp, latency_ms, cache_hit)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    [
+                        ("hit one", 1.0, 10.0, 1),
+                        ("hit two", 2.0, 20.0, 1),
+                        ("miss one", 3.0, 100.0, 0),
+                        ("miss two", 4.0, 120.0, 0),
+                    ],
+                )
+
+            summary = tool.get_telemetry_summary()
+
+            self.assertEqual(summary["total_searches"], 4)
+            self.assertAlmostEqual(summary["cache_hit_rate"], 0.5)
+            self.assertAlmostEqual(summary["avg_latency_ms"], 62.5)
+            self.assertAlmostEqual(summary["saved_time_ms"], 190.0)
 
     def test_rrf_merges_multi_query_rankings(self):
         tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")


### PR DESCRIPTION
## Summary
- add isolated SQLite telemetry storage for LangChain search calls at `.cache/langchain_telemetry.db` by default
- record query latency and cache-hit status for `search()`, `run()`, and `_arun()` flows
- expose `get_telemetry_summary()` with total searches, cache hit rate, average latency, and saved-time calculation
- add regression tests for cache hit-rate accuracy and saved-time math

## Verification
- `docker run --rm -v "$PWD":/work -w /work python:3.12-slim python -m unittest discover -s tests`
- `docker run --rm -v "$PWD":/work -w /work python:3.10-slim sh -lc "pip install -q pytest && python -m pytest tests/"`
- `git diff --check`

/claim #115