### PR TITLE
feat: add Anti-Abuse Shield with shadow auditing and dynamic circuit breaker (Fixes #117)

### DIFF
--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -57,19 +57,18 @@ class MisakaNetSearchTool(BaseTool):
         object.__setattr__(self, "cache_ttl_seconds", cache_ttl_seconds)
 
     def _run(self, query: str) -> str:
+        self._audit_sliding_window()
         self._check_blacklist()
         started = time.perf_counter()
         cache_hit = 0
         cached = self._get_cached_result(query)
         if cached is not None:
             self._record_telemetry(query, started, cache_hit=1)
-            self._audit_sliding_window()
             return cached
 
         result = self._execute_search(query)
         self._set_cached_result(query, result)
         self._record_telemetry(query, started, cache_hit=cache_hit)
-        self._audit_sliding_window()
         return result
 
     def _execute_search(self, query: str) -> str:

--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -57,16 +57,19 @@ class MisakaNetSearchTool(BaseTool):
         object.__setattr__(self, "cache_ttl_seconds", cache_ttl_seconds)
 
     def _run(self, query: str) -> str:
+        self._check_blacklist()
         started = time.perf_counter()
         cache_hit = 0
         cached = self._get_cached_result(query)
         if cached is not None:
             self._record_telemetry(query, started, cache_hit=1)
+            self._audit_sliding_window()
             return cached
 
         result = self._execute_search(query)
         self._set_cached_result(query, result)
         self._record_telemetry(query, started, cache_hit=cache_hit)
+        self._audit_sliding_window()
         return result
 
     def _execute_search(self, query: str) -> str:
@@ -232,7 +235,68 @@ class MisakaNetSearchTool(BaseTool):
             )
             """
         )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS local_blacklist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                blocked_until REAL,
+                reason TEXT,
+                hit_count INTEGER DEFAULT 1
+            )
+            """
+        )
         return conn
+
+    def _check_blacklist(self) -> None:
+        """Pre-flight check: raise PermissionError if currently blacklisted."""
+        now = time.time()
+        with self._telemetry_connection() as conn:
+            row = conn.execute(
+                "SELECT blocked_until, reason FROM local_blacklist WHERE blocked_until > ? LIMIT 1",
+                (now,),
+            ).fetchone()
+            if row is not None:
+                raise PermissionError(
+                    "MisakaNet Anti-Abuse Shield: Node access suspended due to anomalous behaviors."
+                )
+
+    def _audit_sliding_window(self) -> None:
+        """Run sliding window audit over last 10 telemetry rows."""
+        with self._telemetry_connection() as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM search_telemetry"
+            ).fetchone()[0]
+            if count < 10:
+                return
+
+            rows = conn.execute(
+                "SELECT timestamp, cache_hit FROM search_telemetry ORDER BY timestamp DESC LIMIT 10"
+            ).fetchall()
+
+            timestamps = [r[0] for r in rows]
+            cache_hits = [r[1] for r in rows]
+            window_span = max(timestamps) - min(timestamps)
+            cache_hit_rate = sum(cache_hits) / len(cache_hits)
+
+            now = time.time()
+            # Condition Alpha: Rate limit — 10 queries in < 2 seconds
+            if window_span < 2.0:
+                conn.execute(
+                    """
+                    INSERT INTO local_blacklist (blocked_until, reason, hit_count)
+                    VALUES (?, 'rate_limit', 1)
+                    """,
+                    (now + 600,),
+                )
+            # Condition Beta: Low quality — cache hit rate below 10%
+            elif cache_hit_rate < 0.10:
+                conn.execute(
+                    """
+                    INSERT INTO local_blacklist (blocked_until, reason, hit_count)
+                    VALUES (?, 'low_quality', 1)
+                    """,
+                    (now + 300,),
+                )
 
     def _record_telemetry(self, query: str, started: float, cache_hit: int) -> None:
         latency_ms = (time.perf_counter() - started) * 1000

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -164,5 +164,62 @@ class TestMisakaNetSearchTool(unittest.TestCase):
         self.assertLess(elapsed, 0.35)
 
 
+    def test_anti_abuse_rate_limit_trigger(self):
+        """10 rapid queries within 1 second should trigger PermissionError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(return_value="result")
+
+            # Insert 9 rapid telemetry rows (within 1 second)
+            now = time.time()
+            with tool._telemetry_connection() as conn:
+                for i in range(9):
+                    conn.execute(
+                        """
+                        INSERT INTO search_telemetry (query, timestamp, latency_ms, cache_hit)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (f"rapid-{i}", now + i * 0.05, 10.0, 0),
+                    )
+
+            # 10th call records telemetry + triggers audit → blacklist entry created
+            tool._run("rapid-9")
+
+            # 11th call should raise PermissionError (blacklisted from audit)
+            with self.assertRaises(PermissionError) as ctx:
+                tool._run("trigger-block")
+            self.assertIn("Anti-Abuse Shield", str(ctx.exception))
+
+    def test_anti_abuse_low_quality_trigger(self):
+        """10 continuous cache misses should trigger PermissionError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(return_value="result")
+
+            # Insert 9 cache-miss telemetry rows spread over 30 seconds
+            now = time.time()
+            with tool._telemetry_connection() as conn:
+                for i in range(9):
+                    conn.execute(
+                        """
+                        INSERT INTO search_telemetry (query, timestamp, latency_ms, cache_hit)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (f"miss-{i}", now + i * 3, 100.0, 0),
+                    )
+
+            # 10th call records telemetry (cache miss) + triggers audit → blacklist entry
+            tool._run("miss-9")
+
+            # 11th call should raise PermissionError (blacklisted from audit)
+            with self.assertRaises(PermissionError) as ctx:
+                tool._run("trigger-low-quality")
+            self.assertIn("Anti-Abuse Shield", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Implements the Anti-Abuse Shield as specified in #117 — an automated behavioral shadow auditing system with a dynamic circuit breaker (local blacklist) to protect MisakaNet nodes from spam and low-quality queries.

## Changes

### `misakanet/tools/langchain_tool.py`
- **Local blacklist table**: Added `local_blacklist` table to telemetry DB schema (id, blocked_until, reason, hit_count)
- **Pre-flight check**: `_check_blacklist()` runs before every `_run()` call — raises clean `PermissionError` when node is blocked
- **Sliding window audit**: `_audit_sliding_window()` runs after each search + telemetry recording:
  - **Condition Alpha (Rate Limit)**: If last 10 queries span < 2.0 seconds → 10-minute block
  - **Condition Beta (Low Quality)**: If cache hit rate of last 10 queries < 10% → 5-minute block
  - Only triggers when telemetry has ≥ 10 rows (avoids false positives on fresh installs)

### `tests/test_langchain_tool.py`
- **Rate limit trigger test**: Inserts 9 rapid telemetry rows, runs 10th query, asserts 11th raises `PermissionError`
- **Low quality trigger test**: Inserts 9 cache-miss rows over 30 seconds, runs 10th query, asserts 11th raises `PermissionError`
- All 9 tests passing (7 existing + 2 new)

## Testing
```bash
python3 -m pytest tests/test_langchain_tool.py -v
# 9 passed in 1.30s
```

## Related Issues
Fixes #117
/claim #117