### PR TITLE
Add telemetry lesson scoring CLI

### DIFF
--- a/misakanet/tools/lesson_scorer.py
+++ b/misakanet/tools/lesson_scorer.py
@@ -1,0 +1,92 @@
+import sqlite3
+from pathlib import Path
+
+from misakanet.search.engine import _tokenize
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TELEMETRY = REPO_ROOT / ".cache" / "langchain_telemetry.db"
+DEFAULT_LESSONS = REPO_ROOT / "lessons" / "contrib"
+
+
+def _read_queries(telemetry_path: str | Path) -> list[str]:
+    path = Path(telemetry_path)
+    if not path.exists():
+        return []
+
+    conn = None
+    try:
+        conn = sqlite3.connect(path)
+        rows = conn.execute(
+            "SELECT query FROM search_telemetry WHERE query IS NOT NULL"
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        if conn is not None:
+            conn.close()
+
+    return [str(row[0]).strip() for row in rows if str(row[0]).strip()]
+
+
+def _lesson_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _query_matches_lesson(query: str, lesson_tokens: set[str]) -> bool:
+    query_tokens = {token for token in _tokenize(query) if token}
+    if not query_tokens:
+        return False
+    return bool(query_tokens & lesson_tokens)
+
+
+def score_lessons(
+    telemetry_path: str | Path = DEFAULT_TELEMETRY,
+    *,
+    lessons_dir: str | Path = DEFAULT_LESSONS,
+) -> list[dict]:
+    queries = _read_queries(telemetry_path)
+    lesson_root = Path(lessons_dir)
+    lessons = sorted(lesson_root.glob("*.md")) if lesson_root.exists() else []
+    total_queries = len(queries)
+    scored = []
+
+    for lesson_path in lessons:
+        content = _lesson_text(lesson_path)
+        lesson_tokens = {
+            token for token in _tokenize(f"{lesson_path.stem} {content}") if token
+        }
+        searches = sum(
+            1 for query in queries if _query_matches_lesson(query, lesson_tokens)
+        )
+        score = searches / total_queries if total_queries else 0.0
+        scored.append(
+            {
+                "lesson": lesson_path.name,
+                "score": round(score, 4),
+                "searches": searches,
+            }
+        )
+
+    scored.sort(key=lambda item: (-item["score"], -item["searches"], item["lesson"]))
+    return scored
+
+
+def format_lesson_scores(scores: list[dict], *, limit: int | None = None) -> str:
+    rows = scores[:limit] if limit is not None else scores
+    if not rows:
+        return "No lessons found."
+
+    lesson_width = min(max(len("lesson"), *(len(row["lesson"]) for row in rows)), 64)
+    lines = [
+        f"{'lesson':<{lesson_width}}  {'score':>7}  {'searches':>8}",
+        f"{'-' * lesson_width}  {'-' * 7}  {'-' * 8}",
+    ]
+    for row in rows:
+        lesson = row["lesson"]
+        if len(lesson) > lesson_width:
+            lesson = lesson[: lesson_width - 3] + "..."
+        lines.append(f"{lesson:<{lesson_width}}  {row['score']:>7.2f}  {row['searches']:>8}")
+    return "\n".join(lines)

--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -3,8 +3,29 @@
 import sys
 import time
 from misakanet.search.engine import *
+from misakanet.tools.lesson_scorer import DEFAULT_TELEMETRY, format_lesson_scores, score_lessons
 
 def main():
+    args = sys.argv[1:]
+    if "--score" in args:
+        top_k = None
+        telemetry_path = DEFAULT_TELEMETRY
+        for i, arg in enumerate(args):
+            if arg.startswith("--top="):
+                try:
+                    top_k = int(arg.split("=", 1)[1])
+                except ValueError:
+                    pass
+            elif arg == "--top" and i + 1 < len(args):
+                try:
+                    top_k = int(args[i + 1])
+                except ValueError:
+                    pass
+            elif arg.startswith("--telemetry="):
+                telemetry_path = arg.split("=", 1)[1]
+        print(format_lesson_scores(score_lessons(telemetry_path), limit=top_k))
+        return
+
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(1)
@@ -33,11 +54,11 @@ def main():
                 pass
         elif arg == "--semantic":
             use_semantic = True
-    args = sys.argv[2:]
-    for i, arg in enumerate(args):
-        if arg == "--top" and i + 1 < len(args):
+    search_args = sys.argv[2:]
+    for i, arg in enumerate(search_args):
+        if arg == "--top" and i + 1 < len(search_args):
             try:
-                top_k = int(args[i + 1])
+                top_k = int(search_args[i + 1])
             except ValueError:
                 pass
     t0 = time.time()

--- a/tests/test_lesson_scorer.py
+++ b/tests/test_lesson_scorer.py
@@ -1,0 +1,98 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from misakanet.tools.lesson_scorer import format_lesson_scores, score_lessons
+
+
+class TestLessonScorer(unittest.TestCase):
+    def _make_telemetry(self, path: Path, queries: list[str]) -> None:
+        conn = sqlite3.connect(path)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE search_telemetry (
+                    query TEXT,
+                    timestamp REAL,
+                    latency_ms REAL,
+                    cache_hit INTEGER
+                )
+                """
+            )
+            conn.executemany(
+                """
+                INSERT INTO search_telemetry (query, timestamp, latency_ms, cache_hit)
+                VALUES (?, 0.0, 0.0, 0)
+                """,
+                [(query,) for query in queries],
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_score_lessons_ranks_matches_from_telemetry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            lessons_dir = root / "lessons"
+            lessons_dir.mkdir()
+            telemetry = root / "telemetry.db"
+            self._make_telemetry(
+                telemetry,
+                [
+                    "windows path sanitation",
+                    "path traversal null byte",
+                    "python virtual environment",
+                ],
+            )
+            (lessons_dir / "slugify-windows-path-sanitation.md").write_text(
+                "Windows path sanitation prevents traversal and null byte issues.",
+                encoding="utf-8",
+            )
+            (lessons_dir / "python-venv-troubleshoot.md").write_text(
+                "Python virtual environment activation and pip troubleshooting.",
+                encoding="utf-8",
+            )
+
+            scores = score_lessons(telemetry, lessons_dir=lessons_dir)
+
+            self.assertEqual(scores[0]["lesson"], "slugify-windows-path-sanitation.md")
+            self.assertEqual(scores[0]["searches"], 2)
+            self.assertAlmostEqual(scores[0]["score"], 2 / 3, places=3)
+            self.assertEqual(scores[1]["lesson"], "python-venv-troubleshoot.md")
+            self.assertEqual(scores[1]["searches"], 1)
+
+    def test_score_lessons_keeps_zero_match_lesson(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            lessons_dir = root / "lessons"
+            lessons_dir.mkdir()
+            telemetry = root / "telemetry.db"
+            self._make_telemetry(telemetry, ["docker proxy timeout"])
+            (lessons_dir / "unrelated-feishu-card.md").write_text(
+                "Feishu interactive card block rendering.",
+                encoding="utf-8",
+            )
+
+            scores = score_lessons(telemetry, lessons_dir=lessons_dir)
+
+            self.assertEqual(scores, [
+                {
+                    "lesson": "unrelated-feishu-card.md",
+                    "score": 0.0,
+                    "searches": 0,
+                }
+            ])
+
+    def test_format_lesson_scores_outputs_readable_table(self):
+        table = format_lesson_scores(
+            [{"lesson": "a.md", "score": 0.5, "searches": 2}],
+        )
+
+        self.assertIn("lesson", table)
+        self.assertIn("score", table)
+        self.assertIn("a.md", table)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #125

## Changes
- add a zero-dependency lesson scorer that reads `search_telemetry` queries and ranks `lessons/contrib` by keyword overlap
- add `search_knowledge.py --score` with `--top` and `--telemetry=` support for a readable score table
- add focused unit coverage for ranking, zero-match lessons, and table formatting

## Verification
- `python -m unittest tests.test_lesson_scorer`
- `python -m py_compile search_knowledge.py misakanet\tools\lesson_scorer.py`
- `python search_knowledge.py --score --top=3`
- `git diff --check`