### PR TITLE
Add query signature telemetry dedup

### DIFF
--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -3,6 +3,7 @@ import hashlib
 import re
 import sqlite3
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 # Try to import langchain BaseTool, fallback to a standalone class if not available
@@ -60,15 +61,22 @@ class MisakaNetSearchTool(BaseTool):
         self._audit_sliding_window()
         self._check_blacklist()
         started = time.perf_counter()
+        query_signature = self._query_signature(
+            query,
+            (time.perf_counter() - started) * 1000,
+        )
+        if self._has_repeated_query_signature(query_signature):
+            return "[Rate Limited] Repeated query pattern detected."
+
         cache_hit = 0
         cached = self._get_cached_result(query)
         if cached is not None:
-            self._record_telemetry(query, started, cache_hit=1)
+            self._record_telemetry(query, started, cache_hit=1, query_signature=query_signature)
             return cached
 
         result = self._execute_search(query)
         self._set_cached_result(query, result)
-        self._record_telemetry(query, started, cache_hit=cache_hit)
+        self._record_telemetry(query, started, cache_hit=cache_hit, query_signature=query_signature)
         return result
 
     def _execute_search(self, query: str) -> str:
@@ -174,6 +182,12 @@ class MisakaNetSearchTool(BaseTool):
     def _cache_key(self, query: str) -> str:
         return hashlib.sha256(query.strip().encode("utf-8")).hexdigest()
 
+    def _query_signature(self, query: str, latency_ms: float) -> str:
+        latency_bucket = round(latency_ms / 100) * 100
+        payload = f"{query.strip().lower()}\0{latency_bucket}"
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @contextmanager
     def _cache_connection(self):
         assert self.cache_path is not None
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -188,7 +202,14 @@ class MisakaNetSearchTool(BaseTool):
             )
             """
         )
-        return conn
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def _get_cached_result(self, query: str) -> str | None:
         now = time.time()
@@ -219,6 +240,7 @@ class MisakaNetSearchTool(BaseTool):
                 (self._cache_key(query), query, time.time(), result),
             )
 
+    @contextmanager
     def _telemetry_connection(self):
         assert self.telemetry_path is not None
         self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
@@ -234,6 +256,11 @@ class MisakaNetSearchTool(BaseTool):
             )
             """
         )
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(search_telemetry)").fetchall()
+        }
+        if "query_signature" not in columns:
+            conn.execute("ALTER TABLE search_telemetry ADD COLUMN query_signature TEXT")
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS local_blacklist (
@@ -244,7 +271,30 @@ class MisakaNetSearchTool(BaseTool):
             )
             """
         )
-        return conn
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _has_repeated_query_signature(self, query_signature: str) -> bool:
+        cutoff = time.time() - 60
+        with self._telemetry_connection() as conn:
+            count = int(
+                conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM search_telemetry
+                    WHERE query_signature = ?
+                      AND timestamp >= ?
+                    """,
+                    (query_signature, cutoff),
+                ).fetchone()[0]
+            )
+        return count >= 5
 
     def _check_blacklist(self) -> None:
         """Pre-flight check: raise PermissionError if currently blacklisted."""
@@ -297,16 +347,24 @@ class MisakaNetSearchTool(BaseTool):
                     (now + 300,),
                 )
 
-    def _record_telemetry(self, query: str, started: float, cache_hit: int) -> None:
+    def _record_telemetry(
+        self,
+        query: str,
+        started: float,
+        cache_hit: int,
+        query_signature: str | None = None,
+    ) -> None:
         latency_ms = (time.perf_counter() - started) * 1000
+        if query_signature is None:
+            query_signature = self._query_signature(query, latency_ms)
         with self._telemetry_connection() as conn:
             conn.execute(
                 """
                 INSERT INTO search_telemetry
-                    (query, timestamp, latency_ms, cache_hit)
-                VALUES (?, ?, ?, ?)
+                    (query, timestamp, latency_ms, cache_hit, query_signature)
+                VALUES (?, ?, ?, ?, ?)
                 """,
-                (query, time.time(), latency_ms, cache_hit),
+                (query, time.time(), latency_ms, cache_hit, query_signature),
             )
 
     def get_telemetry_summary(self) -> dict:

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -22,11 +22,15 @@ class TestMisakaNetSearchTool(unittest.TestCase):
             self.assertEqual(tool._run("cache me"), "fresh result")
             self.assertEqual(tool._execute_search.call_count, 1)
 
-            with sqlite3.connect(cache_path) as conn:
+            conn = sqlite3.connect(cache_path)
+            try:
                 conn.execute(
                     "UPDATE langchain_search_cache SET created_at = ?",
                     (time.time() - tool.cache_ttl_seconds - 1,),
                 )
+                conn.commit()
+            finally:
+                conn.close()
 
             tool._execute_search.return_value = "expired result"
             self.assertEqual(tool._run("cache me"), "expired result")
@@ -162,6 +166,34 @@ class TestMisakaNetSearchTool(unittest.TestCase):
             ["async result: first query", "async result: second query"],
         )
         self.assertLess(elapsed, 0.35)
+
+    def test_repeated_query_signature_short_circuits_search(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(return_value="should not run")
+
+            signature = tool._query_signature("  Duplicate Query  ", 0)
+            now = time.time()
+            with tool._telemetry_connection() as conn:
+                for i in range(5):
+                    conn.execute(
+                        """
+                        INSERT INTO search_telemetry
+                            (query, timestamp, latency_ms, cache_hit, query_signature)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        ("duplicate query", now - i, 0.0, 0, signature),
+                    )
+
+            result = tool._run("duplicate query")
+
+            self.assertEqual(result, "[Rate Limited] Repeated query pattern detected.")
+            tool._execute_search.assert_not_called()
+            with tool._telemetry_connection() as conn:
+                count = conn.execute("SELECT COUNT(*) FROM search_telemetry").fetchone()[0]
+            self.assertEqual(count, 5)
 
 
     def test_anti_abuse_rate_limit_trigger(self):


### PR DESCRIPTION
## Summary
- add a `query_signature` telemetry column with migration for existing local DBs
- short-circuit repeated signatures seen at least five times in the last 60 seconds before cache/search work
- close SQLite helper connections so temp DB tests clean up reliably on Windows

## Tests
- `python -m unittest tests.test_langchain_tool`
- `python -m unittest discover -s tests`
- `python -m py_compile misakanet\tools\langchain_tool.py`
- `git diff --check` (passes; reports existing CRLF normalization warnings)

Fixes #119