### PR TITLE
feat(telemetry): implement query signature dedup local rate limiting ($3)

### DIFF
--- a/misakanet/tools/langchain_tool.py
+++ b/misakanet/tools/langchain_tool.py
@@ -1,0 +1,379 @@
+import asyncio
+import hashlib
+import re
+import sqlite3
+import time
+from pathlib import Path
+
+# Try to import langchain BaseTool, fallback to a standalone class if not available
+try:
+    from langchain_core.tools import BaseTool
+    HAS_LANGCHAIN = True
+except ImportError:
+    try:
+        from langchain.tools import BaseTool
+        HAS_LANGCHAIN = True
+    except ImportError:
+        BaseTool = object
+        HAS_LANGCHAIN = False
+
+
+class MisakaNetSearchTool(BaseTool):
+    name: str = "misakanet_search"
+    description: str = (
+        "Search the MisakaNet distributed knowledge base for solved developer bugs and experience."
+    )
+    cache_ttl_seconds: int = 300
+    cache_path: Path | None = None
+    telemetry_path: Path | None = None
+
+    def __init__(
+        self,
+        cache_path: str | Path | None = None,
+        telemetry_path: str | Path | None = None,
+        cache_ttl_seconds: int = 300,
+        **kwargs,
+    ):
+        if HAS_LANGCHAIN:
+            super().__init__(**kwargs)
+        else:
+            # Standalone mock implementation fields
+            pass
+        repo_root = Path(__file__).resolve().parents[2]
+        object.__setattr__(
+            self,
+            "cache_path",
+            Path(cache_path)
+            if cache_path is not None
+            else repo_root / ".cache" / "langchain_tool_cache.db",
+        )
+        object.__setattr__(
+            self,
+            "telemetry_path",
+            Path(telemetry_path)
+            if telemetry_path is not None
+            else repo_root / ".cache" / "langchain_telemetry.db",
+        )
+        object.__setattr__(self, "cache_ttl_seconds", cache_ttl_seconds)
+
+    def _run(self, query: str) -> str:
+        self._audit_sliding_window()
+        self._check_blacklist()
+
+        # Local Dedup Check
+        now = time.time()
+        cutoff = now - 60
+        normalized_query = query.strip().lower()
+        with self._telemetry_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT COUNT(*) FROM search_telemetry
+                WHERE timestamp > ? AND LOWER(TRIM(query)) = ?
+                GROUP BY query_signature
+                """,
+                (cutoff, normalized_query),
+            ).fetchall()
+            if any(r[0] >= 5 for r in rows):
+                return "[Rate Limited] Repeated query pattern detected."
+
+        started = time.perf_counter()
+        cache_hit = 0
+        cached = self._get_cached_result(query)
+        if cached is not None:
+            self._record_telemetry(query, started, cache_hit=1)
+            return cached
+
+        result = self._execute_search(query)
+        self._set_cached_result(query, result)
+        self._record_telemetry(query, started, cache_hit=cache_hit)
+        return result
+
+    def _execute_search(self, query: str) -> str:
+        # Import core engine elements
+        from misakanet.search.engine import _load_docs, _rank_docs, LESSONS, REFERENCES
+        
+        lessons_docs = _load_docs(LESSONS, is_lesson=True)
+        ref_docs = _load_docs(REFERENCES, is_lesson=False)
+        all_docs = lessons_docs + ref_docs
+        
+        # Rank docs using expanded local queries and Reciprocal Rank Fusion.
+        ranked = self._rank_with_rrf(query, all_docs, _rank_docs)
+        if not ranked:
+            return f"No results found in MisakaNet for '{query}'"
+            
+        results = []
+        for score, doc in ranked[:3]:
+            # Clean preview
+            preview = doc.content.replace('\r\n', '\n').split('\n')
+            preview_lines = [l for l in preview if l.strip() and not l.startswith('---')][:8]
+            content_preview = '\n'.join(preview_lines)
+            results.append(
+                f"📄 File: lessons/{doc.filename}\n"
+                f"📌 Title: {doc.title}\n"
+                f"🔍 Domain: {doc.domain}\n"
+                f"📝 Preview:\n{content_preview}\n"
+            )
+            
+        return "\n" + "\n----------------------------------------\n".join(results)
+
+    def run(self, query: str) -> str:
+        return self._run(query)
+
+    def search(self, query: str) -> str:
+        return self._run(query)
+
+    async def _arun(self, query: str) -> str:
+        return await asyncio.to_thread(self._run, query)
+
+    def _expand_query(self, query: str) -> list[str]:
+        base = " ".join(query.split())
+        tokens = re.findall(r"[\w\u4e00-\u9fff]+", base.lower())
+        unique_tokens = list(dict.fromkeys(tokens))
+
+        candidates = [
+            base,
+            " ".join(unique_tokens),
+            " ".join(reversed(unique_tokens)),
+        ]
+        if unique_tokens:
+            candidates.extend([
+                f"{base} solution",
+                f"{base} troubleshooting",
+                " ".join(unique_tokens[: max(1, len(unique_tokens) // 2)]),
+            ])
+
+        expanded = []
+        seen = set()
+        for candidate in candidates:
+            normalized = " ".join(candidate.split())
+            if normalized and normalized not in seen:
+                expanded.append(normalized)
+                seen.add(normalized)
+            if len(expanded) == 3:
+                return expanded
+
+        while len(expanded) < 3:
+            fallback = f"{base} variant {len(expanded) + 1}".strip()
+            if fallback not in seen:
+                expanded.append(fallback)
+                seen.add(fallback)
+        return expanded
+
+    def _rank_with_rrf(self, query: str, docs: list, ranker) -> list[tuple[float, object]]:
+        fused: dict[str, dict[str, object]] = {}
+        for subquery in self._expand_query(query):
+            for rank, (score, doc) in enumerate(ranker(subquery, docs), start=1):
+                doc_key = str(getattr(doc, "filepath", getattr(doc, "filename", id(doc))))
+                filename = str(getattr(doc, "filename", doc_key))
+                item = fused.setdefault(
+                    doc_key,
+                    {
+                        "score": 0.0,
+                        "doc": doc,
+                        "best_rank": rank,
+                        "filename": filename,
+                    },
+                )
+                item["score"] = float(item["score"]) + 1.0 / (60 + rank)
+                item["best_rank"] = min(int(item["best_rank"]), rank)
+                item["filename"] = min(str(item["filename"]), filename)
+
+        ranked = sorted(
+            fused.values(),
+            key=lambda item: (
+                -float(item["score"]),
+                int(item["best_rank"]),
+                str(item["filename"]),
+            ),
+        )
+        return [(float(item["score"]), item["doc"]) for item in ranked]
+
+    def _cache_key(self, query: str) -> str:
+        return hashlib.sha256(query.strip().encode("utf-8")).hexdigest()
+
+    def _cache_connection(self):
+        assert self.cache_path is not None
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.cache_path))
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS langchain_search_cache (
+                cache_key TEXT PRIMARY KEY,
+                query TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                result TEXT NOT NULL
+            )
+            """
+        )
+        return conn
+
+    def _get_cached_result(self, query: str) -> str | None:
+        now = time.time()
+        key = self._cache_key(query)
+        with self._cache_connection() as conn:
+            cutoff = now - self.cache_ttl_seconds
+            conn.execute("DELETE FROM langchain_search_cache WHERE created_at < ?", (cutoff,))
+            row = conn.execute(
+                "SELECT result, created_at FROM langchain_search_cache WHERE cache_key = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                return None
+            result, created_at = row
+            if now - float(created_at) <= self.cache_ttl_seconds:
+                return result
+            conn.execute("DELETE FROM langchain_search_cache WHERE cache_key = ?", (key,))
+        return None
+
+    def _set_cached_result(self, query: str, result: str) -> None:
+        with self._cache_connection() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO langchain_search_cache
+                    (cache_key, query, created_at, result)
+                VALUES (?, ?, ?, ?)
+                """,
+                (self._cache_key(query), query, time.time(), result),
+            )
+
+    def _telemetry_connection(self):
+        assert self.telemetry_path is not None
+        self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.telemetry_path), timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS search_telemetry (
+                query TEXT,
+                timestamp REAL,
+                latency_ms REAL,
+                cache_hit INTEGER,
+                query_signature TEXT
+            )
+            """
+        )
+        try:
+            conn.execute("ALTER TABLE search_telemetry ADD COLUMN query_signature TEXT")
+        except sqlite3.OperationalError:
+            pass
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS local_blacklist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                blocked_until REAL,
+                reason TEXT,
+                hit_count INTEGER DEFAULT 1
+            )
+            """
+        )
+        return conn
+
+    def _check_blacklist(self) -> None:
+        """Pre-flight check: raise PermissionError if currently blacklisted."""
+        now = time.time()
+        with self._telemetry_connection() as conn:
+            row = conn.execute(
+                "SELECT blocked_until, reason FROM local_blacklist WHERE blocked_until > ? LIMIT 1",
+                (now,),
+            ).fetchone()
+            if row is not None:
+                raise PermissionError(
+                    "MisakaNet Anti-Abuse Shield: Node access suspended due to anomalous behaviors."
+                )
+
+    def _audit_sliding_window(self) -> None:
+        """Run sliding window audit over last 10 telemetry rows."""
+        with self._telemetry_connection() as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM search_telemetry"
+            ).fetchone()[0]
+            if count < 10:
+                return
+
+            rows = conn.execute(
+                "SELECT timestamp, cache_hit FROM search_telemetry ORDER BY timestamp DESC LIMIT 10"
+            ).fetchall()
+
+            timestamps = [r[0] for r in rows]
+            cache_hits = [r[1] for r in rows]
+            window_span = max(timestamps) - min(timestamps)
+            cache_hit_rate = sum(cache_hits) / len(cache_hits)
+
+            now = time.time()
+            # Condition Alpha: Rate limit — 10 queries in < 2 seconds
+            if window_span < 2.0:
+                conn.execute(
+                    """
+                    INSERT INTO local_blacklist (blocked_until, reason, hit_count)
+                    VALUES (?, 'rate_limit', 1)
+                    """,
+                    (now + 600,),
+                )
+            # Condition Beta: Low quality — cache hit rate below 10%
+            elif cache_hit_rate < 0.10:
+                conn.execute(
+                    """
+                    INSERT INTO local_blacklist (blocked_until, reason, hit_count)
+                    VALUES (?, 'low_quality', 1)
+                    """,
+                    (now + 300,),
+                )
+
+    def _compute_query_signature(self, query: str, latency_ms: float) -> str:
+        normalized = query.strip().lower()
+        latency_bucket = round(latency_ms / 100) * 100
+        signature_str = f"{normalized}:{latency_bucket}"
+        return hashlib.sha256(signature_str.encode("utf-8")).hexdigest()
+
+    def _record_telemetry(self, query: str, started: float, cache_hit: int) -> None:
+        latency_ms = (time.perf_counter() - started) * 1000
+        query_signature = self._compute_query_signature(query, latency_ms)
+        with self._telemetry_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO search_telemetry
+                    (query, timestamp, latency_ms, cache_hit, query_signature)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (query, time.time(), latency_ms, cache_hit, query_signature),
+            )
+
+    def get_telemetry_summary(self) -> dict:
+        with self._telemetry_connection() as conn:
+            total_searches = int(
+                conn.execute("SELECT COUNT(*) FROM search_telemetry").fetchone()[0]
+            )
+            if total_searches == 0:
+                return {
+                    "total_searches": 0,
+                    "cache_hit_rate": 0.0,
+                    "avg_latency_ms": 0.0,
+                    "saved_time_ms": 0,
+                }
+
+            hit_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM search_telemetry WHERE cache_hit = 1"
+                ).fetchone()[0]
+            )
+            avg_latency_ms = float(
+                conn.execute("SELECT AVG(latency_ms) FROM search_telemetry").fetchone()[0]
+                or 0.0
+            )
+            avg_hit_latency = conn.execute(
+                "SELECT AVG(latency_ms) FROM search_telemetry WHERE cache_hit = 1"
+            ).fetchone()[0]
+            avg_miss_latency = conn.execute(
+                "SELECT AVG(latency_ms) FROM search_telemetry WHERE cache_hit = 0"
+            ).fetchone()[0]
+
+        saved_time_ms = 0
+        if hit_count and avg_hit_latency is not None and avg_miss_latency is not None:
+            saved_time_ms = (float(avg_miss_latency) - float(avg_hit_latency)) * hit_count
+
+        return {
+            "total_searches": total_searches,
+            "cache_hit_rate": hit_count / total_searches,
+            "avg_latency_ms": avg_latency_ms,
+            "saved_time_ms": saved_time_ms,
+        }

--- a/tests/test_langchain_tool.py
+++ b/tests/test_langchain_tool.py
@@ -1,0 +1,284 @@
+import asyncio
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from misakanet.tools.langchain_tool import MisakaNetSearchTool
+
+
+class TestMisakaNetSearchTool(unittest.TestCase):
+    def setUp(self):
+        import sqlite3
+        self._original_connect = sqlite3.connect
+        self._connections = []
+        def tracked_connect(*args, **kwargs):
+            conn = self._original_connect(*args, **kwargs)
+            self._connections.append(conn)
+            return conn
+        sqlite3.connect = tracked_connect
+
+    def tearDown(self):
+        import gc
+        import sqlite3
+        sqlite3.connect = self._original_connect
+        for c in self._connections:
+            try:
+                c.close()
+            except:
+                pass
+        self._connections.clear()
+        gc.collect()
+
+    def test_cache_hit_and_expired_miss(self):
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(return_value="fresh result")
+
+            self.assertEqual(tool._run("cache me"), "fresh result")
+            self.assertEqual(tool._run("cache me"), "fresh result")
+            self.assertEqual(tool._execute_search.call_count, 1)
+
+            with sqlite3.connect(cache_path) as conn:
+                conn.execute(
+                    "UPDATE langchain_search_cache SET created_at = ?",
+                    (time.time() - tool.cache_ttl_seconds - 1,),
+                )
+
+            tool._execute_search.return_value = "expired result"
+            self.assertEqual(tool._run("cache me"), "expired result")
+            self.assertEqual(tool._execute_search.call_count, 2)
+
+    def test_telemetry_summary_reports_cache_hit_rate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(side_effect=lambda query: f"fresh result: {query}")
+
+            self.assertEqual(tool._run("cache me"), "fresh result: cache me")
+            self.assertEqual(tool._run("cache me"), "fresh result: cache me")
+            self.assertEqual(tool._run("cache other"), "fresh result: cache other")
+
+            summary = tool.get_telemetry_summary()
+
+            self.assertEqual(summary["total_searches"], 3)
+            self.assertAlmostEqual(summary["cache_hit_rate"], 1 / 3)
+            self.assertGreater(summary["avg_latency_ms"], 0)
+
+    def test_telemetry_summary_calculates_saved_time(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(
+                cache_path=Path(tmp) / "search.db",
+                telemetry_path=telemetry_path,
+            )
+
+            self.assertEqual(tool.get_telemetry_summary()["saved_time_ms"], 0)
+
+            with tool._telemetry_connection() as conn:
+                conn.executemany(
+                    """
+                    INSERT INTO search_telemetry
+                        (query, timestamp, latency_ms, cache_hit)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    [
+                        ("hit one", 1.0, 10.0, 1),
+                        ("hit two", 2.0, 20.0, 1),
+                        ("miss one", 3.0, 100.0, 0),
+                        ("miss two", 4.0, 120.0, 0),
+                    ],
+                )
+
+            summary = tool.get_telemetry_summary()
+
+            self.assertEqual(summary["total_searches"], 4)
+            self.assertAlmostEqual(summary["cache_hit_rate"], 0.5)
+            self.assertAlmostEqual(summary["avg_latency_ms"], 62.5)
+            self.assertAlmostEqual(summary["saved_time_ms"], 190.0)
+
+    def test_rrf_merges_multi_query_rankings(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+        doc_a = SimpleNamespace(filename="a.md", filepath=Path("a.md"))
+        doc_b = SimpleNamespace(filename="b.md", filepath=Path("b.md"))
+        doc_c = SimpleNamespace(filename="c.md", filepath=Path("c.md"))
+
+        rankings = {
+            "cache invalidation bug": [(0.9, doc_a), (0.5, doc_b)],
+            "cache invalidation bug solution": [(0.7, doc_b), (0.4, doc_c)],
+            "cache invalidation bug troubleshooting": [(0.8, doc_c), (0.3, doc_b)],
+        }
+
+        def ranker(subquery, docs):
+            return rankings[subquery]
+
+        tool._expand_query = Mock(
+            return_value=[
+                "cache invalidation bug",
+                "cache invalidation bug solution",
+                "cache invalidation bug troubleshooting",
+            ]
+        )
+
+        ranked = tool._rank_with_rrf("cache invalidation bug", [doc_a, doc_b, doc_c], ranker)
+
+        self.assertEqual(ranked[0][1], doc_b)
+        self.assertEqual({doc.filename for _, doc in ranked}, {"a.md", "b.md", "c.md"})
+
+    def test_rrf_uses_rank_and_filename_tiebreakers(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+        doc_a = SimpleNamespace(filename="a.md", filepath=Path("a.md"))
+        doc_b = SimpleNamespace(filename="b.md", filepath=Path("b.md"))
+        doc_c = SimpleNamespace(filename="c.md", filepath=Path("c.md"))
+
+        rankings = {
+            "query one": [(0.9, doc_b), (0.8, doc_a), (0.7, doc_c)],
+            "query two": [(0.6, doc_c), (0.5, doc_a), (0.4, doc_b)],
+        }
+
+        def ranker(subquery, docs):
+            return rankings[subquery]
+
+        tool._expand_query = Mock(return_value=["query one", "query two"])
+
+        ranked = tool._rank_with_rrf("query", [doc_a, doc_b, doc_c], ranker)
+
+        self.assertEqual([doc.filename for _, doc in ranked], ["b.md", "c.md", "a.md"])
+
+    def test_expand_query_returns_three_distinct_queries(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+
+        expanded = tool._expand_query("async cache async cache")
+
+        self.assertEqual(len(expanded), 3)
+        self.assertEqual(len(set(expanded)), 3)
+        self.assertEqual(expanded[0], "async cache async cache")
+
+    def test_arun_runs_blocking_work_concurrently(self):
+        tool = MisakaNetSearchTool(cache_path=Path(tempfile.gettempdir()) / "unused-misakanet.db")
+
+        async def run():
+            def slow_run(query):
+                time.sleep(0.2)
+                return f"async result: {query}"
+
+            tool._run = slow_run
+            started = time.perf_counter()
+            results = await asyncio.gather(
+                tool._arun("first query"),
+                tool._arun("second query"),
+            )
+            elapsed = time.perf_counter() - started
+            return results, elapsed
+
+        results, elapsed = asyncio.run(run())
+
+        self.assertEqual(
+            results,
+            ["async result: first query", "async result: second query"],
+        )
+        self.assertLess(elapsed, 0.35)
+
+
+    def test_anti_abuse_rate_limit_trigger(self):
+        """10 rapid queries within 1 second should trigger PermissionError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(return_value="result")
+
+            # Insert 9 rapid telemetry rows (within 1 second)
+            now = time.time()
+            with tool._telemetry_connection() as conn:
+                for i in range(9):
+                    conn.execute(
+                        """
+                        INSERT INTO search_telemetry (query, timestamp, latency_ms, cache_hit)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (f"rapid-{i}", now + i * 0.05, 10.0, 0),
+                    )
+
+            # 10th call records telemetry + triggers audit → blacklist entry created
+            tool._run("rapid-9")
+
+            # 11th call should raise PermissionError (blacklisted from audit)
+            with self.assertRaises(PermissionError) as ctx:
+                tool._run("trigger-block")
+            self.assertIn("Anti-Abuse Shield", str(ctx.exception))
+
+    def test_anti_abuse_low_quality_trigger(self):
+        """10 continuous cache misses should trigger PermissionError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            tool._execute_search = Mock(return_value="result")
+
+            # Insert 9 cache-miss telemetry rows spread over 30 seconds
+            now = time.time()
+            with tool._telemetry_connection() as conn:
+                for i in range(9):
+                    conn.execute(
+                        """
+                        INSERT INTO search_telemetry (query, timestamp, latency_ms, cache_hit)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (f"miss-{i}", now + i * 3, 100.0, 0),
+                    )
+
+            # 10th call records telemetry (cache miss) + triggers audit → blacklist entry
+            tool._run("miss-9")
+
+            # 11th call should raise PermissionError (blacklisted from audit)
+            with self.assertRaises(PermissionError) as ctx:
+                tool._run("trigger-low-quality")
+            self.assertIn("Anti-Abuse Shield", str(ctx.exception))
+
+    def test_query_signature_dedup_rate_limiting(self):
+        """5 identical query signatures in 60s should trigger rate limiting short-circuit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "search.db"
+            telemetry_path = Path(tmp) / "telemetry.db"
+            tool = MisakaNetSearchTool(cache_path=cache_path, telemetry_path=telemetry_path)
+            
+            # Use side_effect to introduce a mock search latency (~120ms) which rounds to 100ms bucket
+            def mock_search(query):
+                time.sleep(0.12)
+                return "result"
+            tool._execute_search = Mock(side_effect=mock_search)
+
+            # 1. Insert 4 identical telemetry rows (same query, same latency class/bucket)
+            now = time.time()
+            with tool._telemetry_connection() as conn:
+                for i in range(4):
+                    conn.execute(
+                        """
+                        INSERT INTO search_telemetry (query, timestamp, latency_ms, cache_hit, query_signature)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        ("repeat-query", now - 10 + i, 100.0, 0, tool._compute_query_signature("repeat-query", 100.0)),
+                    )
+                conn.commit()
+
+            # The 5th call should be allowed (it's the 5th attempt, so it records the 5th signature row in telemetry)
+            res5 = tool._run("repeat-query")
+            self.assertEqual(res5, "result")
+
+            # The 6th call should be short-circuited because there are now 5 identical signatures in the last 60s
+            res6 = tool._run("repeat-query")
+            self.assertEqual(res6, "[Rate Limited] Repeated query pattern detected.")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
### Summary
Implemented a lightweight query signature rate-limiting mechanism inside `MisakaNetSearchTool` to detect rapid query repetition patterns within a sliding window of 60 seconds and prevent abuse.

### Key Implementations

1. **Table Schema Update (AC 1 & 2)**:
   - Added `query_signature TEXT` column inside `search_telemetry` table structure in `_telemetry_connection()`.
   - Proactively executing dynamic `ALTER TABLE` for schema backwards compatibility.

2. **Query Signature Computation (AC 2)**:
   - Implemented `_compute_query_signature()` to generate a SHA-256 hash of `(query.strip().lower(), round(latency_ms / 100) * 100)`.
   - Populating and saving `query_signature` in SQLite during telemetry logs.

3. **Local Dedup Verification & Short-Circuit (AC 3)**:
   - Performing a lightning-fast pre-flight SQL query in `_run()` to count repeated query patterns.
   - If any identical query signature appeared ≥ 5 times in the last 60 seconds, immediately short-circuit and return `"[Rate Limited] Repeated query pattern detected."` without executing BM25 or recording duplicate telemetry logs.

4. **Robust Test Compliance (AC 4)**:
   - Added `test_query_signature_dedup_rate_limiting` unit test in `tests/test_langchain_tool.py` to verify that the 5th attempt finishes successfully while the 6th call is correctly rate-limited and short-circuited.
   - All tests run and pass flawlessly.

/claim #119