### PR TITLE
fix: make lesson score output UTF-8 safe

### DIFF
--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -5,7 +5,19 @@ import time
 from misakanet.search.engine import *
 from misakanet.tools.lesson_scorer import DEFAULT_TELEMETRY, format_lesson_scores, score_lessons
 
+
+def _ensure_utf8_stdout():
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is None:
+        return
+    try:
+        reconfigure(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        pass
+
+
 def main():
+    _ensure_utf8_stdout()
     args = sys.argv[1:]
     if "--score" in args:
         top_k = None

--- a/tests/test_search_knowledge_stdout.py
+++ b/tests/test_search_knowledge_stdout.py
@@ -1,0 +1,37 @@
+import io
+import unittest
+from unittest import mock
+
+import search_knowledge
+
+
+class ReconfigurableStdout(io.StringIO):
+    def __init__(self):
+        super().__init__()
+        self.reconfigure_calls = []
+
+    def reconfigure(self, **kwargs):
+        self.reconfigure_calls.append(kwargs)
+
+
+class TestSearchKnowledgeStdout(unittest.TestCase):
+    def test_ensure_utf8_stdout_reconfigures_stream(self):
+        stdout = ReconfigurableStdout()
+
+        with mock.patch.object(search_knowledge.sys, "stdout", stdout):
+            search_knowledge._ensure_utf8_stdout()
+
+        self.assertEqual(
+            stdout.reconfigure_calls,
+            [{"encoding": "utf-8", "errors": "replace"}],
+        )
+
+    def test_ensure_utf8_stdout_ignores_unsupported_stream(self):
+        stdout = io.StringIO()
+
+        with mock.patch.object(search_knowledge.sys, "stdout", stdout):
+            search_knowledge._ensure_utf8_stdout()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- Reconfigures stdout to UTF-8 with replacement fallback before `search_knowledge.py` prints CLI output.
- Prevents `--score` from crashing on Windows terminals when lesson filenames contain non-CP949 Unicode characters.
- Adds focused regression coverage for the stdout reconfiguration helper.

## Validation
- `python search_knowledge.py dummy --score --top=3`
- `python -m pytest --capture=no tests/test_lesson_scorer.py tests/test_search_knowledge_stdout.py -q`

Closes #125

/claim #125
