### PR TITLE
feat(telemetry): add asyncio.Lock gating and persistent connection (#154)

### DIFF
--- a/lessons/contrib/node_148.md
+++ b/lessons/contrib/node_148.md
@@ -10,3 +10,5 @@
 
 Running telemetry pipeline benchmarks on sliding window audit migration.
 Focus: decoupling audit from search hot path while maintaining backward compatibility.
+
+Implementing asyncio.Lock gating for TelemetryPipeline (Issue #154).

--- a/misakanet/tools/telemetry_pipeline.py
+++ b/misakanet/tools/telemetry_pipeline.py
@@ -77,6 +77,9 @@ class TelemetryPipeline:
         self._consumer_task: asyncio.Task[None] | None = None
         self._shutdown_event = asyncio.Event()
         self._closed = False
+        # Persistent connection and lock (Issue #154)
+        self._conn: sqlite3.Connection | None = None
+        self._write_lock = asyncio.Lock()
 
     # -- async context manager --------------------------------------------------
 
@@ -90,11 +93,16 @@ class TelemetryPipeline:
     # -- lifecycle --------------------------------------------------------------
 
     async def start(self) -> None:
-        """Start the background consumer task."""
+        """Start the background consumer task and open persistent connection."""
         if self._consumer_task is not None:
             return
         self._shutdown_event.clear()
         self._closed = False
+        # Open persistent connection
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path), timeout=5)
+        _ensure_schema(self._conn)
+        logger.info("TelemetryPipeline started with persistent connection")
         self._consumer_task = asyncio.create_task(self._consumer_loop())
 
     async def shutdown(self) -> None:
@@ -109,6 +117,15 @@ class TelemetryPipeline:
             except asyncio.CancelledError:
                 pass
             self._consumer_task = None
+        # Close persistent connection
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                logger.warning("Failed to close persistent connection", exc_info=True)
+            finally:
+                self._conn = None
+        logger.info("TelemetryPipeline shutdown complete")
 
     # -- producer ---------------------------------------------------------------
 
@@ -137,7 +154,8 @@ class TelemetryPipeline:
                 "Telemetry queue full (%d), falling back to sync write",
                 self._queue.maxsize,
             )
-            self._sync_write([event])
+            async with self._write_lock:
+                self._sync_write([event])
 
     # -- consumer ---------------------------------------------------------------
 
@@ -162,8 +180,9 @@ class TelemetryPipeline:
                 continue
 
             if batch:
-                self._sync_write(batch)
-                self._run_sliding_window_audit()
+                async with self._write_lock:
+                    self._sync_write(batch)
+                    self._run_sliding_window_audit()
 
         # Shutdown: flush remaining events
         await self._drain_queue()
@@ -177,109 +196,108 @@ class TelemetryPipeline:
             except asyncio.QueueEmpty:
                 break
         if batch:
-            self._sync_write(batch)
+            async with self._write_lock:
+                self._sync_write(batch)
 
-    # -- synchronous DB operations (run in executor to avoid blocking) ----------
+    # -- synchronous DB operations ----------------------------------------------
 
     def _sync_write(self, batch: list[dict[str, Any]]) -> None:
-        """Write a batch of events to SQLite synchronously."""
+        """Write a batch of events to SQLite using persistent connection."""
+        if self._conn is None:
+            logger.error("Telemetry write failed: no persistent connection")
+            return
         try:
-            self._db_path.parent.mkdir(parents=True, exist_ok=True)
-            conn = sqlite3.connect(str(self._db_path), timeout=5)
-            try:
-                _ensure_schema(conn)
-                conn.executemany(
-                    """
-                    INSERT INTO search_telemetry
-                        (query, timestamp, latency_ms, cache_hit, query_signature)
-                    VALUES (?, ?, ?, ?, ?)
-                    """,
-                    [
-                        (
-                            e["query"],
-                            e["timestamp"],
-                            e["latency_ms"],
-                            e["cache_hit"],
-                            e["query_signature"],
-                        )
-                        for e in batch
-                    ],
-                )
-                conn.commit()
-            except Exception:
-                conn.rollback()
-                logger.error("Telemetry batch write failed", exc_info=True)
-            finally:
-                conn.close()
+            self._conn.executemany(
+                """
+                INSERT INTO search_telemetry
+                    (query, timestamp, latency_ms, cache_hit, query_signature)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        e["query"],
+                        e["timestamp"],
+                        e["latency_ms"],
+                        e["cache_hit"],
+                        e["query_signature"],
+                    )
+                    for e in batch
+                ],
+            )
+            self._conn.commit()
         except Exception:
-            logger.error("Telemetry DB connection failed", exc_info=True)
+            try:
+                self._conn.rollback()
+            except Exception:
+                pass
+            logger.error("Telemetry batch write failed", exc_info=True)
 
     def _run_sliding_window_audit(self) -> None:
         """Run sliding window audit over last 10 telemetry rows.
 
         Mirrors the audit logic from MisakaNetSearchTool._audit_sliding_window.
+        Uses the same persistent connection (under write lock).
         """
+        if self._conn is None:
+            logger.error("Sliding window audit failed: no persistent connection")
+            return
         try:
-            conn = sqlite3.connect(str(self._db_path), timeout=5)
-            try:
-                _ensure_schema(conn)
-                count = conn.execute(
-                    "SELECT COUNT(*) FROM search_telemetry"
-                ).fetchone()[0]
-                if count < 10:
-                    return
+            count = self._conn.execute(
+                "SELECT COUNT(*) FROM search_telemetry"
+            ).fetchone()[0]
+            if count < 10:
+                return
 
-                rows = conn.execute(
+            rows = self._conn.execute(
+                """
+                SELECT timestamp, cache_hit
+                FROM search_telemetry
+                ORDER BY timestamp DESC
+                LIMIT 10
+                """
+            ).fetchall()
+
+            timestamps = [r[0] for r in rows]
+            cache_hits = [r[1] for r in rows]
+            window_span = max(timestamps) - min(timestamps)
+            cache_hit_rate = sum(cache_hits) / len(cache_hits)
+
+            now = time.time()
+
+            # Condition Alpha: Rate limit — 10 queries in < 2 seconds
+            if window_span < 2.0:
+                self._conn.execute(
                     """
-                    SELECT timestamp, cache_hit
-                    FROM search_telemetry
-                    ORDER BY timestamp DESC
-                    LIMIT 10
+                    INSERT INTO local_blacklist (blocked_until, reason, hit_count)
+                    VALUES (?, 'rate_limit', 1)
+                    """,
+                    (now + 600,),
+                )
+                self._conn.commit()
+                logger.warning(
+                    "Sliding window audit: rate limit trigger (10 queries in %.1fs)",
+                    window_span,
+                )
+            # Condition Beta: Low quality — cache hit rate below 10%
+            elif cache_hit_rate < 0.10:
+                self._conn.execute(
                     """
-                ).fetchall()
-
-                timestamps = [r[0] for r in rows]
-                cache_hits = [r[1] for r in rows]
-                window_span = max(timestamps) - min(timestamps)
-                cache_hit_rate = sum(cache_hits) / len(cache_hits)
-
-                now = time.time()
-
-                # Condition Alpha: Rate limit — 10 queries in < 2 seconds
-                if window_span < 2.0:
-                    conn.execute(
-                        """
-                        INSERT INTO local_blacklist (blocked_until, reason, hit_count)
-                        VALUES (?, 'rate_limit', 1)
-                        """,
-                        (now + 600,),
-                    )
-                    conn.commit()
-                    logger.warning(
-                        "Sliding window audit: rate limit trigger (10 queries in %.1fs)",
-                        window_span,
-                    )
-                # Condition Beta: Low quality — cache hit rate below 10%
-                elif cache_hit_rate < 0.10:
-                    conn.execute(
-                        """
-                        INSERT INTO local_blacklist (blocked_until, reason, hit_count)
-                        VALUES (?, 'low_quality', 1)
-                        """,
-                        (now + 300,),
-                    )
-                    conn.commit()
-                    logger.warning(
-                        "Sliding window audit: low quality trigger (cache hit rate %.1f%%)",
-                        cache_hit_rate * 100,
-                    )
-            except Exception:
-                conn.rollback()
-                logger.error("Sliding window audit failed", exc_info=True)
-            finally:
-                conn.close()
+                    INSERT INTO local_blacklist (blocked_until, reason, hit_count)
+                    VALUES (?, 'low_quality', 1)
+                    """,
+                    (now + 300,),
+                )
+                self._conn.commit()
+                logger.warning(
+                    "Sliding window audit: low quality trigger (cache hit rate %.1f%%)",
+                    cache_hit_rate * 100,
+                )
         except Exception:
-            logger.error("Sliding window audit DB connection failed", exc_info=True)
+            try:
+                self._conn.rollback()
+            except Exception:
+                pass
+            logger.error("Sliding window audit failed", exc_info=True)
 
     # -- read-only queries ------------------------------------------------------
 
@@ -290,7 +308,7 @@ class TelemetryPipeline:
         )
 
     def _sync_summary(self) -> dict[str, Any]:
-        """Synchronous summary query."""
+        """Synchronous summary query (uses short-lived read-only connection)."""
         try:
             conn = sqlite3.connect(str(self._db_path), timeout=5)
             try:


### PR DESCRIPTION
## Summary

Replace per-batch SQLite open/close with a single persistent connection, and add `asyncio.Lock` to gate the write + audit cycle. This resolves the sporadic lock contentions under multi-node load identified in post-merge review of PR #147.

## Changes

### `misakanet/tools/telemetry_pipeline.py`

**Persistent connection:**
- `sqlite3.Connection` opened once in `start()` (WAL mode enabled)
- Closed in `shutdown()` — no per-call connect/disconnect
- `_ensure_schema()` called once at startup

**asyncio.Lock gating:**
- `asyncio.Lock` instance (`_write_lock`) created in `__init__`
- `_consumer_loop` wraps `_sync_write` + `_run_sliding_window_audit` in `async with self._write_lock:`
- `_drain_queue()` during shutdown also runs under the same lock
- `emit()` queue-full fallback also uses the lock

**Backward compatibility:**
- `get_summary()` / `_sync_summary()` keeps short-lived read-only connection (WAL allows concurrent reads)
- `langchain_tool.py` unchanged

### `lessons/contrib/node_148.md`
- Node registration file

## Acceptance Criteria

- [x] Persistent connection: opened in `start()`, closed in `shutdown()`
- [x] asyncio.Lock: gates write + audit cycle
- [x] `_drain_queue()` under same lock
- [x] Backward compatibility: `get_summary()` uses short-lived connection
- [x] Error handling: missing connection logs error, returns gracefully
- [x] DCO Signed-off-by on all commits
- [x] Node ID in PR frontmatter

## Testing

```bash
pytest tests/test_telemetry_pipeline.py -v
pytest tests/  # All existing tests
```

## Design Reference

Based on analysis in [Discussion #152](https://github.com/Ikalus1988/MisakaNet/discussions/152):
- `asyncio.Lock` chosen over SQLite timeout (stdlib sqlite3 is synchronous)
- Single persistent connection reduces overhead
- Audit runs on same connection under lock (no separate read-only needed)

Closes #154

Signed-off-by: zsxh1990 <zsxh1990@users.noreply.github.com>