### PR TITLE
fix(ci): include hub requirements in root requirements.txt for CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install -r requirements.txt 2>/dev/null || true
+          pip install -r hub/requirements.txt 2>/dev/null || true
           pip install pytest pytest-cov
           echo "PYTHONPATH=$(pwd):$PYTHONPATH" >> "$GITHUB_ENV"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 # MisakaNet core — pure Python, zero external dependencies
 # 核心搜索和 lesson 管理功能纯 Python 实现，无需安装任何依赖
 # 
-# 如需 Hub 服务（高级功能），请安装 hub/ 下的依赖：
-#   pip install -r hub/requirements.txt
+# Hub 依赖（federation, 飞书通知等）
+# 如需完整安装：pip install -r requirements.txt -r hub/requirements.txt
+# 当前自动包含 hub 依赖以通过 CI 审计
+-r hub/requirements.txt
 #
 # 需要以下可选功能时请安装对应依赖：
 # - 语义搜索（--semantic）: pip install sentence-transformers


### PR DESCRIPTION
Hub federation tests (PR #184) require PyYAML from hub/requirements.txt. This PR makes the root requirements.txt include hub dependencies so CI installs them automatically.