### PR TITLE
feat(ci): lessons-only PRs skip full test suite (#230)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      # ── Scope Detection (Issue #230) ──
+      - name: Detect Change Scope
+        id: scope
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # workflow_dispatch has no PR context — always full
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "scope=full" >> "$GITHUB_OUTPUT"
+            echo "Scope: full (workflow_dispatch)"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | awk -F/ '{print $1}' | sort -u)
+
+          if echo "$CHANGED" | grep -qv "^lessons$"; then
+            echo "scope=full" >> "$GITHUB_OUTPUT"
+            echo "Scope: full (changes outside lessons/)"
+          else
+            echo "scope=lessons-only" >> "$GITHUB_OUTPUT"
+            echo "Scope: lessons-only"
+          fi
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -30,6 +54,7 @@ jobs:
           cache: pip
 
       - name: Install Dependencies
+        if: steps.scope.outputs.scope == 'full'
         run: |
           echo "=== Installing core dependencies ==="
           pip install -r requirements.txt || { echo "::error::Core dependency install failed"; exit 1; }
@@ -46,8 +71,15 @@ jobs:
           echo "PYTHONPATH=$(pwd):$PYTHONPATH" >> "$GITHUB_ENV"
           echo "=== Dependency install complete ==="
 
-      # ── Quality Score Gate ──
+      - name: Install Schema Dependencies
+        if: steps.scope.outputs.scope == 'lessons-only'
+        run: |
+          pip install pyyaml jsonschema
+          echo "PYTHONPATH=$(pwd):$PYTHONPATH" >> "$GITHUB_ENV"
+
+      # ── Quality Score Gate (full scope only) ──
       - name: Agent Quality Score
+        if: steps.scope.outputs.scope == 'full'
         id: score
         uses: ./.github/actions/score-agent
         with:
@@ -57,7 +89,7 @@ jobs:
           gh-token: ${{ secrets.SHELDON_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Reject Low-Quality PR
-        if: steps.score.outputs.verdict == 'fail'
+        if: steps.scope.outputs.scope == 'full' && steps.score.outputs.verdict == 'fail'
         env:
           GH_TOKEN: ${{ secrets.SHELDON_PAT || secrets.GITHUB_TOKEN }}
         run: |
@@ -75,7 +107,7 @@ jobs:
           Please clean up formatting noise and resubmit."
           exit 1
 
-      # ── DCO Audit Gate ──
+      # ── DCO Audit Gate (all PRs) ──
       - name: DCO Audit
         id: dco
         uses: Ikalus1988/dco-audit@v1
@@ -92,8 +124,9 @@ jobs:
           echo "DCO check failed: ${{ steps.dco.outputs.failed-count }} commit(s) without sign-off."
           exit 1
 
-      # ── PR Size Check ──
+      # ── PR Size Check (full scope only) ──
       - name: Check PR Size
+        if: steps.scope.outputs.scope == 'full'
         id: prsize
         run: |
           CHANGED=${{ github.event.pull_request.changed_files || 0 }}
@@ -112,8 +145,9 @@ jobs:
           echo "notes=${NOTES}" >> "$GITHUB_OUTPUT"
           printf '## PR Size Check\n\n| Metric | Value |\n|--------|-------|\n| Files Changed | %s |\n| Lines Added | %s |\n| Suspicious | %s |\n\n' "${CHANGED}" "${ADDITIONS}" "${SUSPICIOUS}" >> "$GITHUB_STEP_SUMMARY"
 
-      # ── Test Suite ──
+      # ── Test Suite (full scope only) ──
       - name: Run Test Suite
+        if: steps.scope.outputs.scope == 'full'
         id: pytest
         run: |
           pytest --cov=scripts --cov=misakanet --cov-report=term --cov-fail-under=20 tests/ > pytest_report.txt 2>&1 || true
@@ -121,6 +155,7 @@ jobs:
         continue-on-error: true
 
       - name: Parse Coverage
+        if: steps.scope.outputs.scope == 'full'
         id: coverage
         run: |
           coverage=$(grep -oP 'TOTAL\s+\d+\s+\d+\s+\K\d+(?=%)' pytest_report.txt || echo "0")
@@ -134,7 +169,7 @@ jobs:
           fi
           printf '## Test Suite\n\n| Metric | Value |\n|--------|-------|\n| Outcome | %s |\n| Coverage | %s%% |\n\n' "${RESULT}" "${coverage}" >> "$GITHUB_STEP_SUMMARY"
 
-      # ── Lesson Schema Validation ──
+      # ── Lesson Schema Validation (all PRs) ──
       - name: Validate Lesson Schema
         id: schema
         continue-on-error: true
@@ -146,12 +181,13 @@ jobs:
             echo "⚠️ Schema validation produced warnings or errors" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      # ── Audit Report ──
+      # ── Audit Report (all PRs) ──
       - name: Post Audit Report
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          SCOPE="${{ steps.scope.outputs.scope }}"
           OUTCOME="${{ steps.pytest.outcome }}"
           COVERAGE="${{ steps.coverage.outputs.rate }}"
           SUSPICIOUS="${{ steps.prsize.outputs.suspicious }}"
@@ -160,27 +196,35 @@ jobs:
           REASONS="${{ steps.score.outputs.reasons }}"
           DCO_RESULT="${{ steps.dco.outputs.dco-passed }}"
           DCO_FAILED="${{ steps.dco.outputs.failed-count }}"
+          SCHEMA="${{ steps.schema.outputs.schema_result }}"
           PR_NUM="${{ github.event.inputs.pr_number || github.event.pull_request.number }}"
           SHA="${{ github.event.pull_request.head.sha || 'manual' }}"
           SHA_SHORT=$(echo "$SHA" | cut -c1-7)
 
           # ── Build report ──
           REPORT="## 🧾 Audit Report — PR #${PR_NUM} (${SHA_SHORT})"
-          REPORT+=$'\n\n'
 
-          # 1. Quality Score
-          REPORT+="### 📊 Quality Score: ${SCORE:-?}/100"
-          REPORT+=$'\n\n'
-          if [ -n "$REASONS" ]; then
-            REPORT+="**Deductions:**"
-            REPORT+=$'\n'
-            echo "$REASONS" | while IFS= read -r line; do
-              [ -n "$line" ] && REPORT+="- ${line}"$'\n'
-            done
-          else
-            REPORT+="No deductions."
+          if [ "$SCOPE" = "lessons-only" ]; then
+            REPORT+=$'\n\n'
+            REPORT+="> 📚 **Lessons-only PR** — skipped: quality score, PR size, test suite"
           fi
           REPORT+=$'\n\n'
+
+          # 1. Quality Score (full scope only)
+          if [ "$SCOPE" = "full" ]; then
+            REPORT+="### 📊 Quality Score: ${SCORE:-?}/100"
+            REPORT+=$'\n\n'
+            if [ -n "$REASONS" ]; then
+              REPORT+="**Deductions:**"
+              REPORT+=$'\n'
+              echo "$REASONS" | while IFS= read -r line; do
+                [ -n "$line" ] && REPORT+="- ${line}"$'\n'
+              done
+            else
+              REPORT+="No deductions."
+            fi
+            REPORT+=$'\n\n'
+          fi
 
           # 2. DCO Audit
           REPORT+="### 🔏 DCO Audit"
@@ -192,56 +236,86 @@ jobs:
           fi
           REPORT+=$'\n\n'
 
-          # 3. PR Size
-          REPORT+="### 📏 PR Size"
-          REPORT+=$'\n\n'
-          REPORT+="| Metric | Value |"
-          REPORT+=$'\n'
-          REPORT+="|--------|-------|"
-          REPORT+=$'\n'
-          REPORT+="| Files Changed | ${{ github.event.pull_request.changed_files }} |"
-          REPORT+=$'\n'
-          REPORT+="| Lines Added | ${{ github.event.pull_request.additions }} |"
-          REPORT+=$'\n'
-          if [ "$SUSPICIOUS" = "true" ]; then
-            REPORT+="| ⚠️ Warning | ${SIZE_NOTES} |"
-          fi
-          REPORT+=$'\n\n'
-
-          # 4. Test Suite
-          REPORT+="### 🧪 Test Suite"
-          REPORT+=$'\n\n'
-          if [ "$OUTCOME" = "success" ]; then
-            REPORT+="✅ **PASS** — ${COVERAGE}% coverage"
-          else
-            REPORT+="❌ **FAIL** — tests have failures"
-            if [ -n "$COVERAGE" ]; then
-              REPORT+=" (${COVERAGE}% coverage)"
+          # 3. PR Size (full scope only)
+          if [ "$SCOPE" = "full" ]; then
+            REPORT+="### 📏 PR Size"
+            REPORT+=$'\n\n'
+            REPORT+="| Metric | Value |"
+            REPORT+=$'\n'
+            REPORT+="|--------|-------|"
+            REPORT+=$'\n'
+            REPORT+="| Files Changed | ${{ github.event.pull_request.changed_files }} |"
+            REPORT+=$'\n'
+            REPORT+="| Lines Added | ${{ github.event.pull_request.additions }} |"
+            REPORT+=$'\n'
+            if [ "$SUSPICIOUS" = "true" ]; then
+              REPORT+="| ⚠️ Warning | ${SIZE_NOTES} |"
             fi
+            REPORT+=$'\n\n'
+          fi
+
+          # 4. Test Suite (full scope only)
+          if [ "$SCOPE" = "full" ]; then
+            REPORT+="### 🧪 Test Suite"
+            REPORT+=$'\n\n'
+            if [ "$OUTCOME" = "success" ]; then
+              REPORT+="✅ **PASS** — ${COVERAGE}% coverage"
+            else
+              REPORT+="❌ **FAIL** — tests have failures"
+              if [ -n "$COVERAGE" ]; then
+                REPORT+=" (${COVERAGE}% coverage)"
+              fi
+            fi
+            REPORT+=$'\n\n'
+          fi
+
+          # 5. Schema Validation
+          REPORT+="### 📋 Lesson Schema"
+          REPORT+=$'\n\n'
+          if [ "$SCHEMA" = "pass" ]; then
+            REPORT+="✅ All lessons valid."
+          elif [ "$SCHEMA" = "fail" ]; then
+            REPORT+="⚠️ Schema validation produced warnings."
+          else
+            REPORT+="⏭️ Skipped (no lessons changed)."
           fi
           REPORT+=$'\n\n'
 
-          # 5. Verdict
+          # 6. Verdict
           REPORT+="### ⚖️ Verdict"
           REPORT+=$'\n\n'
           VERDICT_PASS=true
-          if [ "$SCORE" -lt 40 ] 2>/dev/null; then
-            REPORT+="❌ Quality Score ${SCORE}/40 below threshold."$'\n'
-            VERDICT_PASS=false
-          fi
+
           if [ "$DCO_RESULT" != "true" ]; then
             REPORT+="❌ DCO audit failed."$'\n'
             VERDICT_PASS=false
           fi
-          if [ "$OUTCOME" != "success" ]; then
-            REPORT+="❌ Test suite failed."$'\n'
+
+          if [ "$SCOPE" = "full" ]; then
+            if [ "$SCORE" -lt 40 ] 2>/dev/null; then
+              REPORT+="❌ Quality Score ${SCORE}/40 below threshold."$'\n'
+              VERDICT_PASS=false
+            fi
+            if [ "$OUTCOME" != "success" ]; then
+              REPORT+="❌ Test suite failed."$'\n'
+              VERDICT_PASS=false
+            fi
+          fi
+
+          if [ "$SCHEMA" = "fail" ]; then
+            REPORT+="❌ Lesson schema validation failed."$'\n'
             VERDICT_PASS=false
           fi
+
           if [ "$VERDICT_PASS" = "true" ]; then
-            REPORT+="✅ All gates passed. Ready for merge."
+            if [ "$SCOPE" = "lessons-only" ]; then
+              REPORT+="✅ DCO + schema passed. Ready for merge."
+            else
+              REPORT+="✅ All gates passed. Ready for merge."
+            fi
           fi
           REPORT+=$'\n\n---\n'
-          REPORT+="_Triggered by \`${SHA_SHORT}\` | [View run](https://github.com/Ikalus1988/MisakaNet/actions/runs/${{ github.run_id }})_"
+          REPORT+="_Scope: \`${SCOPE}\` | Triggered by \`${SHA_SHORT}\` | [View run](https://github.com/Ikalus1988/MisakaNet/actions/runs/${{ github.run_id }})_"
 
           # ── Post comment ──
           if [ -n "$PR_NUM" ]; then
@@ -251,12 +325,20 @@ jobs:
           fi
 
           # ── Exit with failure if any hard gate fails ──
-          if [ "$OUTCOME" != "success" ]; then
+          if [ "$SCOPE" = "full" ] && [ "$OUTCOME" != "success" ]; then
             echo "Audit failed: test suite has issues."
             exit 1
           fi
+          if [ "$DCO_RESULT" != "true" ]; then
+            echo "Audit failed: DCO violations."
+            exit 1
+          fi
+          if [ "$SCHEMA" = "fail" ]; then
+            echo "Audit failed: lesson schema validation failed."
+            exit 1
+          fi
 
-      # ── Auto-Merge Gate ──
+      # ── Auto-Merge Gate (all PRs) ──
       - name: Auto-Merge Gate
         if: success() && github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
Closes #230

Path-based scope detection: changes under `lessons/` only run DCO + schema validation, skipping pytest/coverage/quality score gates.

### Changes
- Add Detect Change Scope step after checkout
- Conditional gates: quality score, PR size, test suite only for full scope
- Always run: DCO audit, lesson schema validation, auto-merge
- Audit report adapts to scope

### Acceptance Criteria
- [x] Lessons-only PRs skip pytest, coverage, quality score gates
- [x] DCO and schema validation still run on all PRs
- [x] Mixed changes trigger full pipeline
- [x] Auto-merge works for passing lessons-only PRs