### PR TITLE
fix(leaderboard): add missing `import re`

### DIFF
--- a/scripts/leaderboard_watch.py
+++ b/scripts/leaderboard_watch.py
@@ -19,6 +19,7 @@ import json
 import os
 import sys
 import time
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.request import Request, urlopen


### PR DESCRIPTION
Fixes NameError in `leaderboard_watch.py:182` — `re` module is used but never imported.

```
File "/home/runner/work/MisakaNet/MisakaNet/scripts/leaderboard_watch.py", line 182, in compute_leaderboard
    m = re.match(r'^---\s*\n(\{.*?\})\s*\n---', text, re.DOTALL)
        ^^
NameError: name 're' is not defined.
```

This has been causing CI failures (Leaderboard Watch + fatal-guard) since the file was last touched.