### PR TITLE
feat(search): boost core/verified/recent lessons in ranking (#228)

### DIFF
--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -28,6 +28,15 @@ WEIGHT_TITLE_PARTIAL = 0.2
 WEIGHT_HAS_REF = 0.08
 MAX_METADATA = 1.0
 
+# Feature #228: boost core/verified/recent lessons, penalize drafts.
+# Multipliers added to the final composite score (not the BM25 term),
+# so they don't compete with the existing 0.65 / 0.20 / 0.15 weights.
+BOOST_CORE = 0.15
+BOOST_VERIFIED = 0.10
+BOOST_RECENT = 0.05
+BOOST_DRAFT = -0.20
+BOOST_RECENT_DAYS = 30
+
 # ── 分层缓存 ──
 _CACHE_DIR = REPO / ".cache"
 _CACHE_DB = _CACHE_DIR / "search_cache.db"
@@ -278,6 +287,24 @@ def _normalize(values: list[float]) -> list[float]:
     return [(v - mn) / (mx - mn) for v in values]
 
 
+def _compute_boost(doc: CachedDoc) -> float:
+    """Feature #228: per-doc boost factor summed into the final score.
+
+    Sum of the applicable multipliers. Kept additive (not multiplicative)
+    so the constants stay easy to reason about and tune.
+    """
+    boost = 0.0
+    if _is_core(doc):
+        boost += BOOST_CORE
+    if _is_verified(doc):
+        boost += BOOST_VERIFIED
+    if _is_recent(doc):
+        boost += BOOST_RECENT
+    if doc.is_draft:
+        boost += BOOST_DRAFT
+    return boost
+
+
 def _rank_docs_impl(query: str, docs: list[CachedDoc],
                     titles_only: bool = False,
                     broad_only: bool = False) -> list[tuple[float, CachedDoc]]:
@@ -291,8 +318,13 @@ def _rank_docs_impl(query: str, docs: list[CachedDoc],
             docs = visible
     bm25_raw = _compute_bm25_scores(query, docs)
     bm25_norm = _normalize(bm25_raw)
-    scored = [(0.65 * bm25_norm[i] + 0.20 * _metadata_bonus(query, d) + 0.15 * d.score_baseline, d)
-              for i, d in enumerate(docs)]
+    scored = [
+        (0.65 * bm25_norm[i]
+         + 0.20 * _metadata_bonus(query, d)
+         + 0.15 * d.score_baseline
+         + _compute_boost(d), d)
+        for i, d in enumerate(docs)
+    ]
     scored.sort(key=lambda x: -x[0])
     return scored
 
@@ -398,7 +430,10 @@ def _format_output(scored: list[tuple[float, CachedDoc]],
             bm25 = _compute_bm25_scores(query, [doc])[0]
             meta = _metadata_bonus(query, doc)
             baseline = doc.score_baseline
-            print(f"  {'':>25} ↳ BM25: {bm25:.3f} | Meta: {meta:.3f} | Base: {baseline:.3f} | Tags: {', '.join(doc.tags[:5]) if doc.tags else '—'}")
+            boost = _compute_boost(doc)  # Feature #228
+            tag_str = ", ".join(doc.tags[:5]) if doc.tags else "—"
+            print(f"  {'':>25} ↳ BM25: {bm25:.3f} | Meta: {meta:.3f} | "
+                  f"Base: {baseline:.3f} | Boost: {boost:+.2f} | Tags: {tag_str}")
         # Feature: related lessons (cross-lesson reference graph)
         if all_docs is not None:
             related = _get_related_lessons(doc, all_docs, max_related=3)
@@ -452,8 +487,8 @@ __all__ = [
     "CachedDoc", "LESSONS", "REFERENCES",
     "_load_docs", "_rank_docs", "_format_output", "_show_timing",
     "_tokenize", "_compute_bm25_scores", "_normalize",
-    "_is_verified", "_is_core", "_relative_time", "_get_match_reason",
-    "_get_related_lessons",
+    "_is_verified", "_is_core", "_is_recent", "_compute_boost",
+    "_relative_time", "_get_match_reason", "_get_related_lessons",
 ]
 
 
@@ -467,6 +502,15 @@ def _is_verified(doc: CachedDoc) -> bool:
 def _is_core(doc: CachedDoc) -> bool:
     """Check if lesson is in core/ directory."""
     return 'lessons/core/' in str(doc.filepath)
+
+
+def _is_recent(doc: CachedDoc) -> bool:
+    """Feature #228: True if lesson was updated within BOOST_RECENT_DAYS days."""
+    if not doc.mtime:
+        return False
+    import datetime
+    age_days = (datetime.datetime.now().timestamp() - doc.mtime) / 86400
+    return age_days <= BOOST_RECENT_DAYS
 
 
 def _relative_time(mtime: float) -> str:

--- a/tests/test_boost_ranking.py
+++ b/tests/test_boost_ranking.py
@@ -1,0 +1,218 @@
+"""Feature #228: Boost core/verified lessons in search ranking.
+
+Verifies the four boost factors (core/verified/recent/draft) and their
+integration with the BM25 ranking pipeline.
+"""
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from misakanet.search.engine import (
+    BOOST_CORE,
+    BOOST_VERIFIED,
+    BOOST_RECENT,
+    BOOST_DRAFT,
+    BOOST_RECENT_DAYS,
+    CachedDoc,
+    _compute_boost,
+    _is_core,
+    _is_verified,
+    _is_recent,
+    _rank_docs_impl,
+)
+
+
+# ── Constants exposed at module level (AC: "module-level constants") ──
+
+def test_boost_constants_exposed():
+    """All four boost values must be defined as module-level constants."""
+    assert BOOST_CORE == 0.15
+    assert BOOST_VERIFIED == 0.10
+    assert BOOST_RECENT == 0.05
+    assert BOOST_DRAFT == -0.20
+    assert BOOST_RECENT_DAYS == 30
+
+
+# ── Per-factor helpers ──
+
+def _make_doc(path: str, content: str = "", status: str = "published",
+              mtime: float = 0.0) -> CachedDoc:
+    """Build a CachedDoc without going through disk I/O."""
+    return CachedDoc(
+        filename=Path(path).name,
+        filepath=Path(path),
+        content=content,
+        mtime=mtime,
+        status=status,
+    )
+
+
+def test_is_core_true_for_lessons_core_path():
+    """AC: 'Lesson is in lessons/core/' gets core boost."""
+    doc = _make_doc("lessons/core/foo.md")
+    assert _is_core(doc) is True
+
+
+def test_is_core_false_for_contrib_path():
+    """AC: contrib lessons should NOT be marked as core."""
+    doc = _make_doc("lessons/contrib/foo.md")
+    assert _is_core(doc) is False
+
+
+def test_is_verified_true_for_verify_section():
+    """AC: 'Has ## Verify or ## Verification section' gets verified boost."""
+    content = "---\ntitle: x\n---\n## Problem\n\n## Fix\n\n## Verify\nok\n"
+    assert _is_verified(_make_doc("lessons/core/x.md", content)) is True
+
+
+def test_is_verified_true_for_verification_section():
+    """Both 'Verify' and 'Verification' section headers must trigger boost."""
+    content = "---\ntitle: x\n---\n## Verification\nok\n"
+    assert _is_verified(_make_doc("lessons/core/x.md", content)) is True
+
+
+def test_is_verified_false_without_section():
+    """A lesson missing the verify section is not verified."""
+    content = "---\ntitle: x\n---\n## Problem\n\n## Fix\n"
+    assert _is_verified(_make_doc("lessons/core/x.md", content)) is False
+
+
+def test_is_recent_true_for_just_updated():
+    """Lessons updated within 30 days are 'recent'."""
+    now = time.time()
+    assert _is_recent(_make_doc("lessons/core/x.md", mtime=now - 86400)) is True
+    assert _is_recent(_make_doc("lessons/core/x.md", mtime=now)) is True
+
+
+def test_is_recent_false_for_old_lessons():
+    """Lessons older than 30 days are not recent."""
+    now = time.time()
+    old = now - (BOOST_RECENT_DAYS + 5) * 86400
+    assert _is_recent(_make_doc("lessons/core/x.md", mtime=old)) is False
+
+
+def test_is_recent_false_when_mtime_missing():
+    """A zero mtime (unknown age) is treated as not-recent, not recent."""
+    assert _is_recent(_make_doc("lessons/core/x.md", mtime=0.0)) is False
+
+
+# ── _compute_boost: factor sum ──
+
+def test_compute_boost_plain_doc_is_zero():
+    """A non-core, non-verified, non-recent, non-draft doc has zero boost."""
+    doc = _make_doc(
+        "lessons/contrib/x.md",
+        content="---\ntitle: x\n---\n## Problem\n",
+        mtime=0.0,
+        status="published",
+    )
+    assert _compute_boost(doc) == 0.0
+
+
+def test_compute_boost_core_only():
+    doc = _make_doc("lessons/core/x.md", mtime=0.0, status="published",
+                    content="## Problem\n")
+    assert _compute_boost(doc) == BOOST_CORE
+
+
+def test_compute_boost_verified_only():
+    doc = _make_doc("lessons/contrib/x.md", mtime=0.0, status="published",
+                    content="## Verify\nok\n")
+    assert _compute_boost(doc) == BOOST_VERIFIED
+
+
+def test_compute_boost_recent_only():
+    now = time.time()
+    doc = _make_doc("lessons/contrib/x.md", mtime=now - 86400, status="published",
+                    content="## Problem\n")
+    assert _compute_boost(doc) == BOOST_RECENT
+
+
+def test_compute_boost_draft_only():
+    doc = _make_doc("lessons/contrib/x.md", mtime=0.0, status="draft",
+                    content="## Problem\n")
+    assert _compute_boost(doc) == BOOST_DRAFT
+
+
+def test_compute_boost_core_verified_recent_stacks():
+    """A core+verified+recent lesson stacks all three positive boosts."""
+    now = time.time()
+    doc = _make_doc("lessons/core/x.md", mtime=now - 86400, status="published",
+                    content="## Verify\nok\n")
+    expected = BOOST_CORE + BOOST_VERIFIED + BOOST_RECENT
+    assert _compute_boost(doc) == expected
+
+
+# ── AC: ranking integration ──
+
+def test_rank_core_above_contrib_with_equal_bm25():
+    """AC: 'Core lessons rank higher than contrib with equal BM25 scores'.
+
+    Two lessons with the same content, only one in core/. The core lesson
+    should rank above the contrib lesson.
+    """
+    shared = "shared keyword alpha beta gamma delta epsilon"
+    now = time.time()
+    core = _make_doc("lessons/core/x.md", content=shared, mtime=now, status="published")
+    contrib = _make_doc("lessons/contrib/x.md", content=shared, mtime=now, status="published")
+    scored = _rank_docs_impl("alpha", [contrib, core])
+    # core must come first
+    assert scored[0][1].filepath == core.filepath
+    assert scored[0][0] > scored[1][0]
+
+
+def test_rank_verified_above_unverified_with_equal_bm25():
+    """AC: 'Verified lessons get a small boost over unverified'.
+
+    Both docs have the same character count so BM25 length normalization
+    can't dominate — only the verify-boost can tip the ranking.
+    """
+    # '## Verify' = 9 chars, '## Validation' = 14 chars; pad to match.
+    verified_content = "alpha beta gamma\n## Verify\nok\npadding here ok\n"
+    unverified_content = "alpha beta gamma\n## Validation\nok\npad here ok\n"
+    now = time.time()
+    verified = _make_doc("lessons/contrib/a.md", content=verified_content,
+                         mtime=now, status="published")
+    unverified = _make_doc("lessons/contrib/b.md", content=unverified_content,
+                           mtime=now, status="published")
+    assert len(verified.content) == len(unverified.content), (
+        f"lengths must match: verified={len(verified.content)} "
+        f"unverified={len(unverified.content)}"
+    )
+    scored = _rank_docs_impl("alpha", [unverified, verified])
+    assert scored[0][1].filepath == verified.filepath
+    assert scored[0][0] > scored[1][0]
+
+
+def test_rank_boost_values_observable_in_score():
+    """The boost must be reflected as a numeric score delta.
+
+    With identical content, the core+verified+recent doc should score
+    at least (BOOST_CORE + BOOST_VERIFIED + BOOST_RECENT) above a plain doc.
+    """
+    shared = "alpha beta gamma delta epsilon content body text"
+    now = time.time()
+    full = _make_doc("lessons/core/a.md", content=shared + "\n## Verify\nok\n",
+                     mtime=now, status="published")
+    plain = _make_doc("lessons/contrib/b.md", content=shared,
+                      mtime=0.0, status="published")
+    scored = _rank_docs_impl("alpha", [plain, full])
+    # The score gap between full and plain must be at least the sum of the
+    # three positive boosts (other components cancel because content matches).
+    gap = scored[0][0] - scored[1][0]
+    expected_min = BOOST_CORE + BOOST_VERIFIED + BOOST_RECENT
+    assert gap >= expected_min, f"gap={gap}, expected>={expected_min}"
+
+
+def test_rank_filtered_docs_unaffected_by_existing_logic():
+    """Existing filtering (titles_only / broad_only) must still work."""
+    docs = [
+        _make_doc("lessons/contrib/a.md", content="alpha", mtime=0.0, status="published"),
+        _make_doc("lessons/contrib/b.md", content="alpha", mtime=0.0, status="published"),
+    ]
+    # No exceptions, no regressions on the basic ranking path.
+    scored = _rank_docs_impl("alpha", docs, titles_only=True, broad_only=False)
+    assert len(scored) == 2


### PR DESCRIPTION
## Summary

Implements the four ranking boost factors proposed in #228 to elevate
trusted lessons in `search_knowledge` results.

| Factor                    | Boost |
|---------------------------|-------|
| Lesson in `lessons/core/` | +0.15 |
| Has `## Verify` section   | +0.10 |
| Updated within 30 days    | +0.05 |
| Is draft                  | -0.20 |

## Changes

- `misakanet/search/engine.py`
  - Add `BOOST_CORE`, `BOOST_VERIFIED`, `BOOST_RECENT`, `BOOST_DRAFT`,
    `BOOST_RECENT_DAYS` module-level constants
  - Add `_is_recent(doc)` helper alongside existing `_is_core` / `_is_verified`
  - Add `_compute_boost(doc)` helper that sums applicable factors
  - Wire boost into `_rank_docs_impl` composite score
  - Surface boost in `--explain` breakdown (Boost: +0.30 field)
  - Update `__all__` exports
- `tests/test_boost_ranking.py` (new, 19 tests)
  - Constant value exposure
  - Per-factor helper correctness
  - Additive stacking (core+verified+recent)
  - End-to-end ranking: core above contrib with equal BM25
  - End-to-end ranking: verified above unverified with equal BM25
  - Score delta observability
  - No regression on `titles_only` / `broad_only` paths

## Why additive (not multiplicative)

The issue text suggests "× BM25 score", but multiplying into the BM25
term (already inside a 0.65-weighted sum) makes the constant effects
harder to reason about. Adding to the final score keeps the existing
0.65/0.20/0.15 weighting intact and lets a maintainer tune one constant
without rebalancing the whole ranking. The net ordering effect is the
same: positive factors lift, negative factors demote.

## Design choice on `BOOST_DRAFT`

Draft lessons are currently filtered out by default in `_rank_docs_impl`
(`if not titles_only: visible = [d for d in docs if not d.is_draft]`).
The `BOOST_DRAFT` constant is implemented and ready to fire as soon as
a future `include_drafts` mode is added (YAGNI for now). This avoids
breaking the existing default-draft-hidden behavior.

## Verification

```
$ pytest tests/ -q
119 passed, 2 skipped, 10 subtests passed in 13.42s
```

Real `search_knowledge.py "github" --titles` run shows the expected
behavior: all top-10 hits are `[core] [verified]`, boost `+0.30`
appears in the explain breakdown.

## Checklist

- [x] Code meets all AC items in #228
- [x] `pytest tests/` passes (no regressions)
- [x] No raw Python Traceback in output
- [x] Every commit has `Signed-off-by:` trailer
- [x] No unrelated files included (profile.json excluded)

## Node ID

`hermes_wsl` (Node 1, hp WSL)

Refs #228
/claim #228
