### PR TITLE
docs: standardize lesson metadata headers

### DIFF
--- a/lessons/TEMPLATE.md
+++ b/lessons/TEMPLATE.md
@@ -1,4 +1,7 @@
 ---
+domain: "general"
+title: "<English Title>"
+verification: "metadata-normalized"
 {"title": "<English Title: 4-120 chars>", "domain": "<domain>", "tags": ["tag1", "tag2", "tag3"], "status": "published", "confidence": "0.9", "created": "<YYYY-MM-DD>", "updated": "<YYYY-MM-DD>", "source": "<your-source>", "verified_date": "", "domain_expert": ""}
 ---
 

--- a/lessons/_archive/context-compaction-earlier-turns-in-this-convers.md
+++ b/lessons/_archive/context-compaction-earlier-turns-in-this-convers.md
@@ -1,6 +1,7 @@
 ---
-title: CONTEXT COMPACTION] Earlier turns in this convers
-domain: rag
+domain: "rag"
+title: "CONTEXT COMPACTION] Earlier turns in this convers"
+verification: "metadata-normalized"
 source: bootstrap
 status: active
 confidence: 0.7

--- a/lessons/_archive/context-compaction-reference-only-earlier-turn.md
+++ b/lessons/_archive/context-compaction-reference-only-earlier-turn.md
@@ -1,6 +1,7 @@
 ---
-title: CONTEXT COMPACTION — REFERENCE ONLY] Earlier turn
-domain: feishu
+domain: "feishu"
+title: "CONTEXT COMPACTION — REFERENCE ONLY] Earlier turn"
+verification: "metadata-normalized"
 source: bootstrap
 status: active
 confidence: 0.7

--- a/lessons/_archive/conversation-dumps/config-was-last-written-by-a-newer-openclaw-2026.md
+++ b/lessons/_archive/conversation-dumps/config-was-last-written-by-a-newer-openclaw-2026.md
@@ -1,6 +1,7 @@
 ---
-title: Config was last written by a newer OpenClaw (2026.
-domain: feishu
+domain: "feishu"
+title: "Config was last written by a newer OpenClaw (2026."
+verification: "metadata-normalized"
 source: bootstrap
 status: active
 confidence: 0.7

--- a/lessons/_archive/hook-raw/cc-haha-acceptEdits-permission-mode.md
+++ b/lessons/_archive/hook-raw/cc-haha-acceptEdits-permission-mode.md
@@ -1,6 +1,7 @@
 ---
-title: cc-haha 配置 acceptEdits 权限模式减少确认提示
-domain: agent-medici
+domain: "agent-medici"
+title: "cc-haha 配置 acceptEdits 权限模式减少确认提示"
+verification: "metadata-normalized"
 subdomain: cc-haha
 source: bootstrap
 status: draft

--- a/lessons/_archive/hook-raw/cc-haha-error-hook.md
+++ b/lessons/_archive/hook-raw/cc-haha-error-hook.md
@@ -1,6 +1,8 @@
 ---
+domain: "devops"
+title: "cc-haha PostToolUseFailure 钩子 — Bash 失败时提示 lessons"
+verification: "metadata-normalized"
 created: 2026-04-30 09:30 UTC
-domain: devops
 machine: hermes-pc
 source: hermes_wsl2
 status: published
@@ -9,7 +11,6 @@ tags:
 - hook
 - lessons
 - error-interception
-title: cc-haha PostToolUseFailure 钩子 — Bash 失败时提示 lessons
 updated: 2026-04-30 09:30 UTC
 ---
 

--- a/lessons/_archive/skill-harvest/skill-harvest-airtable.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-airtable.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Airtable"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-arxiv.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-arxiv.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Arxiv"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-ascii-art.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-ascii-art.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Ascii Art"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-baoyu-comic.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-baoyu-comic.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Baoyu Comic"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-baoyu-infographic.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-baoyu-infographic.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Baoyu Infographic"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-ccswitch.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-ccswitch.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Ccswitch"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-claude-code-proxy-troubleshoot.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-claude-code-proxy-troubleshoot.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Claude Code Proxy Troubleshoot"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-claude-design.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-claude-design.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Claude Design"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-comfyui.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-comfyui.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Comfyui"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-debugging-python-bytecode-cache.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-debugging-python-bytecode-cache.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Debugging Python Bytecode Cache"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-edoc-pipeline-retrospective.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-edoc-pipeline-retrospective.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Edoc Pipeline Retrospective"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-edoc-rag.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-edoc-rag.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Edoc Rag"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-excalidraw.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-excalidraw.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Excalidraw"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-google-workspace.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-google-workspace.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Google Workspace"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-gradio-feedback-panel.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-gradio-feedback-panel.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Gradio Feedback Panel"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-heartmula.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-heartmula.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Heartmula"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-himalaya.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-himalaya.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Himalaya"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-humanizer.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-humanizer.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Humanizer"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-jupyter-live-kernel.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-jupyter-live-kernel.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Jupyter Live Kernel"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-knowledge-base-quality-audit.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-knowledge-base-quality-audit.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Knowledge Base Quality Audit"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-linear.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-linear.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Linear"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-llama-cpp.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-llama-cpp.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Llama Cpp"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-manim-video.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-manim-video.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Manim Video"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-minecraft-modpack-server.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-minecraft-modpack-server.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Minecraft Modpack Server"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-bootstrap-fix.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-bootstrap-fix.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Native Claude Code Bootstrap Fix"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-wsl-bare-fix.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-wsl-bare-fix.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Native Claude Code Wsl Bare Fix"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-wsl-proxy-fix.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-wsl-proxy-fix.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Native Claude Code Wsl Proxy Fix"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-wsl.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-native-claude-code-wsl.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Native Claude Code Wsl"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-node-inspect-debugger.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-node-inspect-debugger.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Node Inspect Debugger"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-ocr-and-documents.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-ocr-and-documents.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Ocr And Documents"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-outlines.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-outlines.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Outlines"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-p5js.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-p5js.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "P5Js"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-pixel-art.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-pixel-art.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Pixel Art"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-powerpoint.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-powerpoint.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Powerpoint"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-python-debugpy.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-python-debugpy.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Python Debugpy"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-requesting-code-review.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-requesting-code-review.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Requesting Code Review"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-self-grow-wiki-code-review.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-self-grow-wiki-code-review.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Self Grow Wiki Code Review"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-self-review.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-self-review.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Self Review"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-songsee.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-songsee.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Songsee"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-systematic-debugging.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-systematic-debugging.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Systematic Debugging"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-test-driven-development.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-test-driven-development.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Test Driven Development"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-vllm.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-vllm.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Vllm"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/skill-harvest/skill-harvest-xurl.md
+++ b/lessons/_archive/skill-harvest/skill-harvest-xurl.md
@@ -1,5 +1,7 @@
 ---
+domain: "archive"
 title: "Xurl"
+verification: "metadata-normalized"
 source: "skill-pipeline"
 status: "draft"
 created: "2026-05-09"

--- a/lessons/_archive/system-note-your-previous-turn-was-interrupted-b.md
+++ b/lessons/_archive/system-note-your-previous-turn-was-interrupted-b.md
@@ -1,12 +1,13 @@
 ---
+domain: "general"
+title: "system note your previous turn was interrupted b"
+verification: "metadata-normalized"
 confidence: 0.5
 created: '2026-04-01'
-domain: general
 source: bootstrap
 status: draft
 tags:
 - bootstrap
-title: system note your previous turn was interrupted b
 ---
 
 ---

--- a/lessons/contrib/README.md
+++ b/lessons/contrib/README.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Contrib Lessons"
+verification: "metadata-normalized"
+---
 # Contrib Lessons
 
 Community-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lessons are automatically scanned for dangerous patterns via CI on every PR.
@@ -9,4 +14,3 @@ To promote a lesson to `core/`, submit a curation PR with review evidence.
 2. Run any relevant commands or tests to confirm the fix
 3. Verify the symptom no longer occurs
 4. Check related logs or outputs for expected behavior
-

--- a/lessons/contrib/agent-manual-update-timeout.md
+++ b/lessons/contrib/agent-manual-update-timeout.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Agent 手动Update步骤（update Timeout Handling）"
+verification: "metadata-normalized"
+---
 ---{"title": "Agent 手动Update步骤（update Timeout Handling）", "domain": "devops", "source": "bootstrap", "status": "draft", "confidence": "0.8", "created": "2026-05-03"}---
 ## Verification
 

--- a/lessons/contrib/agent-state-database-lock-cleanup.md
+++ b/lessons/contrib/agent-state-database-lock-cleanup.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Agent State Database Lock Issues — Cleanup Protocol"
+verification: "metadata-normalized"
 {"title": "Agent State Database Lock Issues — Cleanup Protocol", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["database", "lock", "state", "cleanup", "lesson-written"], "created": "2026-05-16 00:00:00 UTC", "updated": "2026-05-16 00:00:00 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-16"}
 ---
 ## Verification

--- a/lessons/contrib/agent-write-file-sandbox-worktree-path-breakage.md
+++ b/lessons/contrib/agent-write-file-sandbox-worktree-path-breakage.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "agent write file sandbox worktree path breakage"
+verification: "metadata-normalized"
 {"title": "Agent Write File 写入不落地 + Worktree Git 链接路径断裂", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"], "created": "2026-05-13 01:01:46 UTC", "updated": "2026-05-13 01:01:52 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-13"}
 ---
 

--- a/lessons/contrib/ai-agent-project-outreach-guide.md
+++ b/lessons/contrib/ai-agent-project-outreach-guide.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "AI Agent Project Outreach Guide"
+verification: "metadata-normalized"
 {"title": "AI Agent Project Outreach Guide", "domain": "marketing", "subdomain": "outreach", "source": "Misaka10004", "tags": ["outreach", "github", "awesome-list", "pr", "promotion", "agent", "marketing"], "confidence": "0.95", "created": "2026-05-11", "domain_expert": "Misaka10004", "verified_date": "2026-05-11"}
 ---
 

--- a/lessons/contrib/aily-feishu-mcp-pull-only.md
+++ b/lessons/contrib/aily-feishu-mcp-pull-only.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "aily feishu mcp pull only"
+verification: "metadata-normalized"
 {"title": "aily 飞书 MCP 通道：只能拉取不能推送", "domain": "feishu", "subdomain": "mcp-capability", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/anthropic-proxy-internal-gateway.md
+++ b/lessons/contrib/anthropic-proxy-internal-gateway.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy"
+verification: "metadata-normalized"
 {"created": "2026-04-30 09:00 UTC", "domain": "devops", "machine": "hp-wsl", "source": "hermes_wsl", "status": "published", "tags": "", "title": "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy", "updated": "2026-04-30 09:00 UTC", "domain_expert": "hermes_wsl", "verified_date": "2026-04-30"}
 ---
 

--- a/lessons/contrib/api-gateway-anthropic-incompatibility.md
+++ b/lessons/contrib/api-gateway-anthropic-incompatibility.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "api gateway anthropic incompatibility"
+verification: "metadata-normalized"
 {"title": "InternalGateway API 网关不兼容 Anthropic 原生格式", "domain": "devops", "subdomain": "api", "source": "bootstrap", "status": "draft", "tags": ["project:rag", "severity:medium", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/api-rate-limit-handling-best-practices.md
+++ b/lessons/contrib/api-rate-limit-handling-best-practices.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "api rate limit handling best practices"
+verification: "metadata-normalized"
+---
 ---{"title": "API限流Handling最佳实践", "domain": "devops", "tags": ["api", "rate-limit", "backoff", "batch"]}---
 
 ## 背景

--- a/lessons/contrib/api-rate-limit-handling.md
+++ b/lessons/contrib/api-rate-limit-handling.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "API 请求限流 (Rate Limit) Handling方案"
+verification: "metadata-normalized"
+---
 ---{"title": "API 请求限流 (Rate Limit) Handling方案", "domain": "devops", "tags": ["api", "rate-limit", "retry", "429"]}---
 
 ## 背景

--- a/lessons/contrib/audit-sampling-stratified-sampling-for-kb-inspection.md
+++ b/lessons/contrib/audit-sampling-stratified-sampling-for-kb-inspection.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "audit sampling stratified sampling for kb inspection"
+verification: "metadata-normalized"
 {"title": "巡检题库分层抽样策略", "domain": "rag", "tags": ["rag", "audit", "sampling", "quality", "test-bank"], "confidence": 0.88, "created": "2026-05-21", "domain_expert": "unknown", "verified_date": "2026-05-21"}
 ---
 

--- a/lessons/contrib/bge-embedding-fallback-crash.md
+++ b/lessons/contrib/bge-embedding-fallback-crash.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "bge embedding fallback crash"
+verification: "metadata-normalized"
 {"title": "BGE embedding 模型需要降级 fallback 避免启动崩溃", "domain": "rag", "subdomain": "embedding", "source": "bootstrap", "status": "draft", "tags": ["project:agent-medici", "severity:high", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/browser-harness-cdp-browser-automation.md
+++ b/lessons/contrib/browser-harness-cdp-browser-automation.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation"
+verification: "metadata-normalized"
+---
 ---{"title": "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation", "domain": "devops", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20"}---
 
 # browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation

--- a/lessons/contrib/cc-connect-feishu-display-optimization.md
+++ b/lessons/contrib/cc-connect-feishu-display-optimization.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "cc connect feishu display optimization"
+verification: "metadata-normalized"
+---
 ---{"title": "cc-connect 飞书显示Optimization：禁用工具调用和上下文提示", "domain": "feishu", "subdomain": "cc-connect", "source": "bootstrap", "status": "published", "confidence": "0.9", "created": "2026-05-19"}---
 
 ## cc-connect 飞书显示优化：禁用工具调用和上下文提示

--- a/lessons/contrib/cc-connect-feishu-setup-complete.md
+++ b/lessons/contrib/cc-connect-feishu-setup-complete.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "cc connect feishu setup complete"
+verification: "metadata-normalized"
+---
 ---{"title": "cc-connect 飞书机器人完整SetupGuide", "domain": "feishu", "subdomain": "cc-connect", "source": "bootstrap", "status": "published", "confidence": "0.95", "created": "2026-05-19"}---
 ## Verification
 

--- a/lessons/contrib/ccswitch-hermes-switch.md
+++ b/lessons/contrib/ccswitch-hermes-switch.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "ccswitch-hermes-switch 踩坑Notes"
+verification: "metadata-normalized"
+---
 ---{"confidence": "0.7", "created": "2026-05-02", "domain": "devops", "source": "bootstrap", "status": "draft", "tags": "", "- node": "cc_haha", "title": "ccswitch-hermes-switch 踩坑Notes"}---
 
 # ccswitch-hermes-switch 踩坑Notes

--- a/lessons/contrib/chroma-rebuild-no-checkpoint-cn.md
+++ b/lessons/contrib/chroma-rebuild-no-checkpoint-cn.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Chroma 建库无 Checkpoint — 进程一死全部丢失"
+verification: "metadata-normalized"
 {"title": "Chroma 建库无 Checkpoint — 进程一死全部丢失", "domain": "rag", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
 ---
 

--- a/lessons/contrib/chroma-rebuild-no-checkpoint.md
+++ b/lessons/contrib/chroma-rebuild-no-checkpoint.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Chroma 建库无 Checkpoint — 进程一死全部丢失"
+verification: "metadata-normalized"
 {"title": "Chroma 建库无 Checkpoint — 进程一死全部丢失", "domain": "rag", "source": "bootstrap", "bootstrapped": true, "author": "node2", "machine": "hermes-wsl", "original_date": "2026-04-12", "tags": "", "- node": "hermes_wsl", "- project": "edoc", "- severity": "high", "status": "published", "quality": "published", "created": "2026-04-01", "confidence": "0.7", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
 ---
 

--- a/lessons/contrib/chrome-relay-browser-automation.md
+++ b/lessons/contrib/chrome-relay-browser-automation.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器"
+verification: "metadata-normalized"
+---
 ---{"title": "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器", "domain": "development", "tags": ["chrome", "browser", "automation", "cdp", "websocket", "openclaw"], "contributor": "hermes-agent"}---
 
 ## 背景

--- a/lessons/contrib/ci-dco-decouple-pythonpath-fork-pr.md
+++ b/lessons/contrib/ci-dco-decouple-pythonpath-fork-pr.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix"
+verification: "metadata-normalized"
+---
 ---{"title": "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix", "domain": "devops", "tags": ["github-actions", "ci", "dco", "python", "ai-agent", "fork-pr", "pytest", "coverage"], "status": "published", "source": "deepseek", "created": "2026-06-04 00:00:00 UTC", "updated": "2026-06-12 00:00:00 UTC"}---
 
 ## 根因

--- a/lessons/contrib/cloudflare-email-worker-registration-trap.md
+++ b/lessons/contrib/cloudflare-email-worker-registration-trap.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF"
+verification: "metadata-normalized"
+---
 ---{"title": "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF", "domain": "devops", "tags": ["cloudflare", "email-worker", "kv", "turnstile", "registration", "spf"]}---
 
 ## 背景

--- a/lessons/contrib/codewhale-git-push-yolo-task.md
+++ b/lessons/contrib/codewhale-git-push-yolo-task.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI"
+verification: "metadata-normalized"
 {"title": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI", "domain": "devops", "tags": ["codewhale", "git", "yolo", "push", "lesson"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/cron-job-not-running.md
+++ b/lessons/contrib/cron-job-not-running.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Cron 作业不执行 / 不生效排障"
+verification: "metadata-normalized"
 {"title": "Cron 作业不执行 / 不生效排障", "domain": "devops", "tags": ["cron", "scheduler", "not-running", "debug"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/curl-request-troubleshoot.md
+++ b/lessons/contrib/curl-request-troubleshoot.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "curl / wget 请求失败通用Diagnosis"
+verification: "metadata-normalized"
+---
 ---{"title": "curl / wget 请求失败通用Diagnosis", "domain": "devops", "tags": ["network", "curl", "wget", "debug", "troubleshoot"]}---
 
 ## 背景

--- a/lessons/contrib/deepseek-tui-write-file-sandbox-worktree-git-path.md
+++ b/lessons/contrib/deepseek-tui-write-file-sandbox-worktree-git-path.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "deepseek tui write file sandbox worktree git path"
+verification: "metadata-normalized"
 {"title": "DeepSeek TUI — write_file Sandbox + Worktree Git Path Breakage", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["deepseek-tui", "agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"], "created": "2026-05-13 01:01:46 UTC", "updated": "2026-05-13 01:01:46 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-13"}
 ---
 
@@ -63,4 +66,3 @@ WSL 侧的 worktree 目录只是一个"影子"（含 .git 指针），实际文�
 4. Check that `git log` in the worktree correctly tracks the new file without polluting main
 
 4. 提交前先对比 main 与 worktree 的分叉点，避免在错误版本上做修改
-

--- a/lessons/contrib/disk-space-cleanup.md
+++ b/lessons/contrib/disk-space-cleanup.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "磁盘空间不足 / chroma_db_v4 CacheCleanup"
+verification: "metadata-normalized"
+---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "磁盘空间不足 / chroma_db_v4 CacheCleanup", "updated": "2026-05-01 08:00 UTC"}---
 
 

--- a/lessons/contrib/fanuc-kl-err-abort-vs-err-pause.md
+++ b/lessons/contrib/fanuc-kl-err-abort-vs-err-pause.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "fanuc kl err abort vs err pause"
+verification: "metadata-normalized"
 {"title": "FANUC KL: ERR_ABORT vs ERR_PAUSE 行为差异", "domain": "fanuc", "subdomain": "error-handling", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/fanuc-kl-mm-module-h-no-routine.md
+++ b/lessons/contrib/fanuc-kl-mm-module-h-no-routine.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "fanuc kl mm module h no routine"
+verification: "metadata-normalized"
 {"title": "FANUC KL: mm_module_h.kl 禁止 ROUTINE 声明", "domain": "fanuc", "subdomain": "kl-modules", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/fanuc-r-2000ic-retrieval-fix.md
+++ b/lessons/contrib/fanuc-r-2000ic-retrieval-fix.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "fanuc r 2000ic retrieval fix"
+verification: "metadata-normalized"
+---
 ---{"created": "2026-04-30 08:50 UTC", "domain": "rag", "source": "hermes_wsl", "status": "published", "tags": "", "title": "FANUC R-2000iC 检索混淆Fix — 关键词强制召回", "updated": "2026-04-30 08:50 UTC"}---
 
 

--- a/lessons/contrib/feishu-agent-display-settings.md
+++ b/lessons/contrib/feishu-agent-display-settings.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "feishu agent display settings"
+verification: "metadata-normalized"
+---
 ---{"title": "飞书 Agent 显示Optimization：禁用工具调用和上下文提示", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.9", "created": "2026-05-19"}---
 
 ## 飞书 Agent 显示优化：禁用工具调用和上下文提示

--- a/lessons/contrib/feishu-block-api-false-success.md
+++ b/lessons/contrib/feishu-block-api-false-success.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu block api false success"
+verification: "metadata-normalized"
 {"title": "飞书 Block API 假成功特征", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/feishu-block-batch-limit.md
+++ b/lessons/contrib/feishu-block-batch-limit.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "feishu block batch limit"
+verification: "metadata-normalized"
+---
 ---{"title": "飞书 Block Batch写入上限", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03"}---
 
 ## 飞书 Block 批量写入上限

--- a/lessons/contrib/feishu-block-type-values-limits.md
+++ b/lessons/contrib/feishu-block-type-values-limits.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "feishu block type values limits"
+verification: "metadata-normalized"
+---
 ---{"title": "飞书 Block Type 正确值与已知Limit", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03"}---
 
 ## 飞书 Block Type 正确值与已知限制

--- a/lessons/contrib/feishu-bot-setup-complete.md
+++ b/lessons/contrib/feishu-bot-setup-complete.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "feishu bot setup complete"
+verification: "metadata-normalized"
+---
 ---{"title": "飞书机器人完整SetupGuide", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.95", "created": "2026-05-19"}---
 ## Verification
 

--- a/lessons/contrib/feishu-doc-url-use-api-return.md
+++ b/lessons/contrib/feishu-doc-url-use-api-return.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu doc url use api return"
+verification: "metadata-normalized"
 {"title": "Feishu 文档 URL：必须用 API 返回值，不要拼接", "domain": "feishu", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-03-29", "confidence": "0.95", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-03-29"}
 ---
 

--- a/lessons/contrib/feishu-markdown-table-not-rendered.md
+++ b/lessons/contrib/feishu-markdown-table-not-rendered.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "feishu markdown table not rendered"
+verification: "metadata-normalized"
+---
 ---{"title": "飞书 post Messaging中 Markdown 表格不渲染", "domain": "development", "source": "Misaka10019", "tags": ["feishu", "markdown", "table", "post", "lark"]}---
 
 ## 背景

--- a/lessons/contrib/feishu-mcp-server-deepseek-tui-setup.md
+++ b/lessons/contrib/feishu-mcp-server-deepseek-tui-setup.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries"
+verification: "metadata-normalized"
 {"title": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries", "domain": "feishu", "source": "deepseek-tui", "status": "published", "tags": ["feishu", "mcp", "deepseek", "docx-api", "permissions"], "created": "2026-05-19", "updated": "2026-05-19", "domain_expert": "deepseek-tui", "verified_date": "2026-05-19"}
 ---
 

--- a/lessons/contrib/feishu-upload-file-type-opus.md
+++ b/lessons/contrib/feishu-upload-file-type-opus.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu upload file type opus"
+verification: "metadata-normalized"
 {"title": "Feishu 文件上传：file_type 必须用 opus", "domain": "feishu", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-03-29", "confidence": "0.95", "scope": "broad", "alternative_of": "None", "related": "", "domain_expert": "hanged-man", "verified_date": "2026-03-29"}
 ---
 

--- a/lessons/contrib/feishu-webhook-url-env-config.md
+++ b/lessons/contrib/feishu-webhook-url-env-config.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu webhook url env config"
+verification: "metadata-normalized"
 {"title": "飞书 webhook URL 必须用环境变量或 gitignored 的 config.yaml", "domain": "devops", "subdomain": "feishu", "source": "bootstrap", "status": "draft", "tags": ["project:agent-medici", "severity:critical", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
+++ b/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu websocket 404 error http webhook required"
+verification: "metadata-normalized"
 {"title": "Feishu WebSocket 404 Error - HTTP Webhook Required", "domain": "feishu-integration", "source": "hermes_wsl2", "status": "published", "tags": [], "created": "2026-05-19 01:19:29 UTC", "updated": "2026-05-19 01:19:29 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-19"}
 ---
 
@@ -9,4 +12,3 @@
 2. Run any relevant commands or tests to confirm the fix
 3. Verify the symptom no longer occurs
 4. Check related logs or outputs for expected behavior
-

--- a/lessons/contrib/feishu-wiki-batch-download.md
+++ b/lessons/contrib/feishu-wiki-batch-download.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Feishu WikiBatch Download：文件类型Handling策略"
+verification: "metadata-normalized"
+---
 ---{"title": "Feishu WikiBatch Download：文件类型Handling策略", "domain": "devops", "tags": "feishu, wiki, batch-download, file-type, pdf, docx, safari", "status": "published", "source": "hermes_wsl2", "updated": "2026-05-19 15:40:11 UTC"}---
 
 # Feishu WikiBatch Download：文件类型Handling策略

--- a/lessons/contrib/ffmpeg-audio-libopus-not-ogg.md
+++ b/lessons/contrib/ffmpeg-audio-libopus-not-ogg.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "ffmpeg audio libopus not ogg"
+verification: "metadata-normalized"
 {"title": "FFmpeg 音频转码：必须用 libopus 而非 -format ogg", "domain": "audio", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-03-29", "confidence": "0.9", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-03-29"}
 ---
 

--- a/lessons/contrib/firewall-port-open-not-public.md
+++ b/lessons/contrib/firewall-port-open-not-public.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "firewall port open not public"
+verification: "metadata-normalized"
 {"title": "防火墙端口开放不等于内网穿透", "domain": "devops", "subdomain": "network", "source": "bootstrap", "status": "draft", "tags": ["project:rag", "platform:wsl", "node:hermes_wsl", "scope:broad"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/game-mcp-end-turn-conflict-409.md
+++ b/lessons/contrib/game-mcp-end-turn-conflict-409.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Game MCP: End Turn Returns 409 Conflict"
+verification: "metadata-normalized"
 {"title": "Game MCP: End Turn Returns 409 Conflict", "domain": "mcp", "source": "hanged-man", "status": "published", "domain_expert": "hanged-man"}
 ---
 

--- a/lessons/contrib/game-mcp-game-over-restart-flow.md
+++ b/lessons/contrib/game-mcp-game-over-restart-flow.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Game MCP: GAME OVER Restart Flow"
+verification: "metadata-normalized"
 {"title": "Game MCP: GAME OVER Restart Flow", "domain": "mcp", "source": "hanged-man", "status": "published", "domain_expert": "hanged-man"}
 ---
 

--- a/lessons/contrib/game-mcp-rare-relic-freeze.md
+++ b/lessons/contrib/game-mcp-rare-relic-freeze.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "game mcp rare relic freeze"
+verification: "metadata-normalized"
 {"title": "Game MCP: Rare Relic Selection Freeze", "domain": "mcp", "source": "hanged-man", "status": "published", "domain_expert": "hanged-man"}
 ---
 

--- a/lessons/contrib/gateway-hang-watchdog-recovery.md
+++ b/lessons/contrib/gateway-hang-watchdog-recovery.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Gateway 进程挂死未崩溃 — watchdog 自动Recovery"
+verification: "metadata-normalized"
+---
 ---{"title": "Gateway 进程挂死未崩溃 — watchdog 自动Recovery", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01"}---
 
 

--- a/lessons/contrib/git-credential-helper-gh-path-mismatch.md
+++ b/lessons/contrib/git-credential-helper-gh-path-mismatch.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "gh credential helper 路径Error导致 git push 静默失败"
+verification: "metadata-normalized"
+---
 ---{"title": "gh credential helper 路径Error导致 git push 静默失败", "domain": "devops", "tags": ["git", "github", "credential", "gh", "auth", "push"]}---
 
 ## 背景

--- a/lessons/contrib/git-credentials-and-node-id-setup.md
+++ b/lessons/contrib/git-credentials-and-node-id-setup.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Git Credentials 和 Node ID Setup"
+verification: "metadata-normalized"
+---
 ---{"title": "Git Credentials 和 Node ID Setup", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["git", "credentials", "node-id", "setup"]}---
 
 ## Git Credentials 和 Node ID 配置

--- a/lessons/contrib/git-credentials-automation.md
+++ b/lessons/contrib/git-credentials-automation.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Git 凭证Setup — Automation push 免密码"
+verification: "metadata-normalized"
+---
 ---{"title": "Git 凭证Setup — Automation push 免密码", "domain": "devops", "tags": ["git", "credentials", "auth", "github"]}---
 
 ## 背景

--- a/lessons/contrib/git-merge-conflict-resolution.md
+++ b/lessons/contrib/git-merge-conflict-resolution.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Git 合并ConflictHandling — 手动解决最佳实践"
+verification: "metadata-normalized"
+---
 ---{"title": "Git 合并ConflictHandling — 手动解决最佳实践", "domain": "development", "tags": ["git", "merge", "conflict", "rebase"]}---
 
 ## 背景

--- a/lessons/contrib/git-push-without-shell-agent.md
+++ b/lessons/contrib/git-push-without-shell-agent.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Git Push 的正确方式 — 在受限 Agent 环境中推送代码"
+verification: "metadata-normalized"
 {"title": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码", "domain": "devops", "tags": ["git", "push", "agent", "gh-cli", "lesson"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/git-tls-handshake-failure.md
+++ b/lessons/contrib/git-tls-handshake-failure.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "GitHub TLS 握手失败 — gnutls_handshake() Error"
+verification: "metadata-normalized"
+---
 ---{"title": "GitHub TLS 握手失败 — gnutls_handshake() Error", "domain": "devops", "tags": ["git", "github", "TLS", "SSL", "network"]}---
 
 ## 背景

--- a/lessons/contrib/github-401-credential-lookup.md
+++ b/lessons/contrib/github-401-credential-lookup.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "GitHub API 401 后本地凭证查找顺序"
+verification: "metadata-normalized"
 {"title": "GitHub API 401 后本地凭证查找顺序", "domain": "devops", "tags": ["github", "api", "credential", "401", "auth", "pat"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/github-dns-443-block-hosts-workaround.md
+++ b/lessons/contrib/github-dns-443-block-hosts-workaround.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案"
+verification: "metadata-normalized"
 {"title": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案", "domain": "devops", "tags": ["git", "github", "TLS", "network", "DNS", "hosts", "connectivity"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/gpt-sovits-hubert-16khz.md
+++ b/lessons/contrib/gpt-sovits-hubert-16khz.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "gpt sovits hubert 16khz"
+verification: "metadata-normalized"
 {"title": "GPT-SoVITS：HuBERT 必须 16kHz 且 get_model() 返回单体", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-05", "confidence": "0.9", "scope": "narrow", "domain_expert": "hanged-man", "verified_date": "2026-04-05"}
 ---
 

--- a/lessons/contrib/gpt-sovits-name2text-arpabet.md
+++ b/lessons/contrib/gpt-sovits-name2text-arpabet.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "gpt sovits name2text arpabet"
+verification: "metadata-normalized"
 {"title": "GPT-SoVITS 训练：2-name2text 格式必须用 ARPABET 音素而非中文原文", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-06", "confidence": "0.9", "scope": "narrow", "domain_expert": "hanged-man", "verified_date": "2026-04-06"}
 ---
 

--- a/lessons/contrib/gpt-sovits-ref-free-bug.md
+++ b/lessons/contrib/gpt-sovits-ref-free-bug.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "gpt sovits ref free bug"
+verification: "metadata-normalized"
 {"title": "GPT-SoVITS：ref_free bug——prompt_text 为空时参数被覆盖", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-06", "confidence": "0.9", "scope": "narrow", "domain_expert": "hanged-man", "verified_date": "2026-04-06"}
 ---
 

--- a/lessons/contrib/hub-credential-gateway-vs-hub.md
+++ b/lessons/contrib/hub-credential-gateway-vs-hub.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里"
+verification: "metadata-normalized"
 {"title": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
 ---
 

--- a/lessons/contrib/hub-feishu-wsclient-start-never-called.md
+++ b/lessons/contrib/hub-feishu-wsclient-start-never-called.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "hub feishu wsclient start never called"
+verification: "metadata-normalized"
 {"title": "Hub FeishuWSClient.start() 从未调用 — WebSocket 接收死代码", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
 ---
 

--- a/lessons/contrib/issue-comment-newbie-welcome.md
+++ b/lessons/contrib/issue-comment-newbie-welcome.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Auto-Welcome Newcomers via issue_comment Event"
+verification: "metadata-normalized"
 {"title": "Auto-Welcome Newcomers via issue_comment Event", "domain": "devops", "tags": ["github-actions", "ci", "community", "newbie", "good-first-issue", "automation"], "status": "published", "source": "deepseek", "created": "2026-06-12 00:00:00 UTC", "updated": "2026-06-12 00:00:00 UTC", "domain_expert": "deepseek", "verified_date": "2026-06-12"}
 ---
 

--- a/lessons/contrib/js-dead-code-chain-break.md
+++ b/lessons/contrib/js-dead-code-chain-break.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "js dead code chain break"
+verification: "metadata-normalized"
 {"title": "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效", "domain": "frontend", "tags": ["js", "runtime", "typeerror", "execution-model", "defensive"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/json-parse-failure-handling.md
+++ b/lessons/contrib/json-parse-failure-handling.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "JSON 解析失败Handling — 截断 / 格式Error"
+verification: "metadata-normalized"
+---
 ---{"title": "JSON 解析失败Handling — 截断 / 格式Error", "domain": "devops", "tags": ["json", "parse", "truncated", "llm", "output"]}---
 
 ## 背景

--- a/lessons/contrib/kb-4sigma-quality-audit-pipeline.md
+++ b/lessons/contrib/kb-4sigma-quality-audit-pipeline.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "kb 4sigma quality audit pipeline"
+verification: "metadata-normalized"
 {"title": "知识库 4σ 质量审计流水线", "domain": "rag", "subdomain": "quality", "source": "bootstrap", "status": "draft", "tags": ["project:self-grow-wiki", "severity:medium", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/knowledge-graph-ux-patterns-from-high-star-projects.md
+++ b/lessons/contrib/knowledge-graph-ux-patterns-from-high-star-projects.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "knowledge graph ux patterns from high star projects"
+verification: "metadata-normalized"
 {"title": "知识图谱 UX 增强: 从高星项目提炼的 7 个交互模式", "domain": "development", "tags": ["knowledge-graph", "d3js", "ux", "graph-visualization", "force-directed"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/lesson-management-standardization.md
+++ b/lessons/contrib/lesson-management-standardization.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Lesson Management Standardization — Naming, Content Sanitization, and Automated Submission Pipeline"
+verification: "metadata-normalized"
 {"title": "Lesson Management Standardization — Naming, Content Sanitization, and Automated Submission Pipeline", "domain": "devops", "tags": ["lesson", "naming-convention", "content-sanitization", "automation", "ci", "standardization"], "status": "published", "confidence": "0.95", "created": "2026-06-14", "source": "codewhale", "domain_expert": "codewhale", "verified_date": "2026-06-14"}
 ---
 

--- a/lessons/contrib/lesson_file_line_number_corruption.md
+++ b/lessons/contrib/lesson_file_line_number_corruption.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Before — inspect raw first line"
+verification: "metadata-normalized"
 {"title": "File Content Corrupted by Terminal Line-Number Prefixes", "domain": "devops", "tags": ["terminal", "sed", "line-number", "file-corruption", "html", "debug"], "status": "published", "created": "2026-06-20", "source": "codewhale"}
 ---
 

--- a/lessons/contrib/lessons-md-fix-heading-block-type.md
+++ b/lessons/contrib/lessons-md-fix-heading-block-type.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "lessons md fix heading block type"
+verification: "metadata-normalized"
 {"title": "lessons.md 修正（4 处） 项目 旧结论 修正后 heading block（type=4", "domain": "rag", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
 ---
 

--- a/lessons/contrib/misakanet-heal-engine-bootstrap-workflow.md
+++ b/lessons/contrib/misakanet-heal-engine-bootstrap-workflow.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "MisakaNet --heal Engine Bootstrap Workflow"
+verification: "metadata-normalized"
+---
 ---{"title": "MisakaNet --heal Engine Bootstrap Workflow — From Traceback to Covered Lesson", "domain": "development", "scope": "broad", "tags": ["misakanet", "heal", "bm25", "broad-only", "fixture", "coverage", "lesson-submission", "workflow", "openclaw"], "status": "draft", "confidence": "0.85", "source": "Misaka10004", "created": "2026-06-23", "updated": "2026-06-23"}---
 
 # MisakaNet --heal Engine Bootstrap Workflow

--- a/lessons/contrib/misakanet-heal-ux-gap-queue-lesson-flag-mismatch.md
+++ b/lessons/contrib/misakanet-heal-ux-gap-queue-lesson-flag-mismatch.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag"
+verification: "metadata-normalized"
+---
 ---{"title": "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag (--file not -f)", "domain": "development", "scope": "broad", "tags": ["misakanet", "heal", "ux", "queue-lesson", "cli", "argparse", "fixture", "openclaw", "flag-mismatch"], "status": "draft", "confidence": "0.9", "source": "Misaka10004", "created": "2026-06-23", "updated": "2026-06-23"}---
 
 # MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag

--- a/lessons/contrib/misakanet-refactor-v2-review.md
+++ b/lessons/contrib/misakanet-refactor-v2-review.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "misakanet refactor v2 review"
+verification: "metadata-normalized"
+---
 ---{"title": "MisakaNet Refactoring复盘 — 从中心协调到 Agent 图书馆", "domain": "development", "tags": ["refactor", "architecture", "v2", "misakanet"], "status": "published", "source": "deepseek", "created": "2026-05-30 02:00:00 UTC", "updated": "2026-05-30 02:00:00 UTC"}---
 
 ## 根因

--- a/lessons/contrib/model-output-fix.md
+++ b/lessons/contrib/model-output-fix.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "模型输出截断 / JSON 解析失败Handling"
+verification: "metadata-normalized"
+---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "claude", "source": "hermes_wsl", "status": "published", "tags": "", "title": "模型输出截断 / JSON 解析失败Handling", "updated": "2026-05-01 08:00 UTC"}---
 
 

--- a/lessons/contrib/model-switch-script-pattern.md
+++ b/lessons/contrib/model-switch-script-pattern.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "多模型Switch脚本模式 — 双 Agent 模型管理"
+verification: "metadata-normalized"
+---
 ---{"title": "多模型Switch脚本模式 — 双 Agent 模型管理", "confidence": "0.7", "created": "2026-05-02", "domain": "devops", "source": "bootstrap", "status": "draft", "tags": ""}---
 
 # 多模型Switch脚本模式 — 双 Agent 模型管理

--- a/lessons/contrib/openai-compatible-api-call.md
+++ b/lessons/contrib/openai-compatible-api-call.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "OpenAI 兼容 API 的通用调用格式"
+verification: "metadata-normalized"
 {"title": "OpenAI 兼容 API 的通用调用格式", "domain": "development", "tags": ["api", "openai", "llm", "inference", "chat"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/openclaw-fatal-error-hook-protocol.md
+++ b/lessons/contrib/openclaw-fatal-error-hook-protocol.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks"
+verification: "metadata-normalized"
+---
 ---{"title": "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks", "domain": "development", "tags": ["openclaw", "fatal-error", "child-process", "spawn", "argv", "shell-injection", "fire-and-forget", "protocol", "heal"], "status": "published", "confidence": "0.95", "source": "hermes_wsl2", "created": "2026-06-16", "updated": "2026-06-16"}---
 
 # OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks

--- a/lessons/contrib/openclaw-gateway-dynamic-module-missing.md
+++ b/lessons/contrib/openclaw-gateway-dynamic-module-missing.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "openclaw gateway dynamic module missing"
+verification: "metadata-normalized"
+---
 ---{"title": "OpenClaw Gateway 动态Module Not Found — 飞书Messaging分发失败", "domain": "feishu", "subdomain": "openclaw-debug", "source": "bootstrap", "status": "published", "confidence": "1.0", "created": "2026-05-18", "tags": "node:misaka10004\", \"platform:wsl\", \"severity:critical\", \"project:misakanet"}---
 
 

--- a/lessons/contrib/openclaw-playwright-wsl-libnss3-libnspr4-snap-chromium.md
+++ b/lessons/contrib/openclaw-playwright-wsl-libnss3-libnspr4-snap-chromium.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4"
+verification: "metadata-normalized"
 {"title": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4 - use system snap chromium as executable_path", "domain": "openclaw", "scope": "broad", "source": "openclaw-node-misaka10004", "status": "published", "tags": ["openclaw", "playwright", "chromium", "wsl", "libnss3", "libnspr4", "snap", "browser-automation", "executable_path"], "created": "2026-06-23", "updated": "2026-06-23", "verified_date": "", "domain_expert": ""}
 ---
 

--- a/lessons/contrib/openclaw-prefer-cli-and-policy-over-direct-edit.md
+++ b/lessons/contrib/openclaw-prefer-cli-and-policy-over-direct-edit.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "openclaw prefer cli and policy over direct edit"
+verification: "metadata-normalized"
 {"title": "OpenClaw优先CLI和官方策略", "domain": "agentops", "tags": ["openclaw", "cli", "policy", "config"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/openclaw-reinstall-lesson.md
+++ b/lessons/contrib/openclaw-reinstall-lesson.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "OpenClaw 重装教训 — 删除前先停服务清残留"
+verification: "metadata-normalized"
 {"title": "OpenClaw 重装教训 — 删除前先停服务清残留", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
 ---
 

--- a/lessons/contrib/oss-refactor-lessons.md
+++ b/lessons/contrib/oss-refactor-lessons.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "oss refactor lessons"
+verification: "metadata-normalized"
+---
 ---{"title": "开源项目Refactoring复盘 — 从功能堆砌到减法优先", "domain": "development", "tags": ["refactor", "architecture", "lessons", "open-source", "cleanup", "focus", "repository-management"], "status": "published", "source": "deepseek", "created": "2026-05-30 04:00:00 UTC", "updated": "2026-06-14 00:00:00 UTC"}---
 
 ## 背景

--- a/lessons/contrib/permission-denied-fix.md
+++ b/lessons/contrib/permission-denied-fix.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Permission Denied / WSL NTFS 跨文件系统PermissionFix"
+verification: "metadata-normalized"
+---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix", "updated": "2026-05-01 08:00 UTC"}---
 
 

--- a/lessons/contrib/phase-0-output-gate.md
+++ b/lessons/contrib/phase-0-output-gate.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "phase 0 output gate"
+verification: "metadata-normalized"
 {"title": "Phase 0 Output Gate — Agent 的硬性知识检索规则", "domain": "methodology", "tags": ["output-gate", "knowledge-reuse", "methodology", "core"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/pip-install-failure-fix.md
+++ b/lessons/contrib/pip-install-failure-fix.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "pip install Network Timeout / SSL / 依赖ConflictFix"
+verification: "metadata-normalized"
+---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "pip install Network Timeout / SSL / 依赖ConflictFix", "updated": "2026-05-01 08:00 UTC"}---
 
 

--- a/lessons/contrib/pip-install-timeout-ssl.md
+++ b/lessons/contrib/pip-install-timeout-ssl.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "pip install Network Timeout / SSL ErrorFix"
+verification: "metadata-normalized"
+---
 ---{"title": "pip install Network Timeout / SSL ErrorFix", "domain": "devops", "tags": ["pip", "network", "SSL", "timeout", "proxy"]}---
 
 ## 背景

--- a/lessons/contrib/promo-use-real-examples-not-hypotheticals.md
+++ b/lessons/contrib/promo-use-real-examples-not-hypotheticals.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "promo use real examples not hypotheticals"
+verification: "metadata-normalized"
 {"title": "Promo Copy — Use Real Examples, Don't Fabricate", "domain": "marketing", "subdomain": "content", "source": "Misaka10004", "tags": ["outreach", "content-strategy", "awesome-list", "reddit", "hacker-news"], "confidence": "0.9", "created": "2026-05-21", "domain_expert": "Misaka10004", "verified_date": "2026-05-21"}
 ---
 

--- a/lessons/contrib/python-gbk-encoding-error.md
+++ b/lessons/contrib/python-gbk-encoding-error.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Python GBK Encoding Error — Windows/WSL 跨平台"
+verification: "metadata-normalized"
+---
 ---{"title": "Python GBK Encoding Error — Windows/WSL 跨平台", "domain": "devops", "tags": ["python", "encoding", "gbk", "windows", "wsl"]}---
 
 ## 背景

--- a/lessons/contrib/python-pycache-stale.md
+++ b/lessons/contrib/python-pycache-stale.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Python 代码修改不生效 — stale .pyc Cache"
+verification: "metadata-normalized"
+---
 ---{"title": "Python 代码修改不生效 — stale .pyc Cache", "domain": "devops", "tags": ["python", "pyc", "cache", "debug"]}---
 
 ## 背景

--- a/lessons/contrib/python-sandbox-path-isolation.md
+++ b/lessons/contrib/python-sandbox-path-isolation.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Python 沙箱/受限环境 — PATH 和 sys.path 隔离"
+verification: "metadata-normalized"
 {"title": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离", "domain": "development", "tags": ["python", "sandbox", "path", "import", "venv"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/python-venv-tiktoken-module-not-found.md
+++ b/lessons/contrib/python-venv-tiktoken-module-not-found.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError"
+verification: "metadata-normalized"
 {"title": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError", "domain": "development", "source": "Misaka10019", "tags": ["python", "venv", "tiktoken", "pip", "setuptools"], "domain_expert": "Misaka10019"}
 ---
 

--- a/lessons/contrib/python-venv-troubleshoot.md
+++ b/lessons/contrib/python-venv-troubleshoot.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Python venv 激活失败或路径不匹配"
+verification: "metadata-normalized"
 {"title": "Python venv 激活失败或路径不匹配", "domain": "devops", "tags": ["python", "venv", "virtualenv", "path"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/rag-alarm-code-mandatory-recall.md
+++ b/lessons/contrib/rag-alarm-code-mandatory-recall.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "rag alarm code mandatory recall"
+verification: "metadata-normalized"
 {"title": "RAG 报警代码检索需要关键词强制召回", "domain": "rag", "subdomain": "fanuc", "source": "bootstrap", "status": "draft", "tags": ["project:self-grow-wiki", "severity:high", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/rag-brand-contamination-detection-and-fix.md
+++ b/lessons/contrib/rag-brand-contamination-detection-and-fix.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "RAG 知识库品牌污染Detection与治理"
+verification: "metadata-normalized"
+---
 ---{"title": "RAG 知识库品牌污染Detection与治理", "domain": "rag", "tags": ["rag", "chromadb", "brand-contamination", "data-quality", "metadata"], "confidence": 0.9, "created": "2026-05-29"}---
 
 ## 背景

--- a/lessons/contrib/rag-brand-filter-three-pitfalls.md
+++ b/lessons/contrib/rag-brand-filter-three-pitfalls.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "RAG 品牌Filter三坑：条件触发、文件正则、BM25 Cache"
+verification: "metadata-normalized"
+---
 ---{"title": "RAG 品牌Filter三坑：条件触发、文件正则、BM25 Cache", "domain": "rag", "tags": ["rag", "brand-filter", "architecture", "chromadb", "bm25", "pitfall"], "confidence": 0.88, "created": "2026-05-29"}---
 
 ## 背景

--- a/lessons/contrib/rag-build-strategy-batch.md
+++ b/lessons/contrib/rag-build-strategy-batch.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "rag build strategy batch"
+verification: "metadata-normalized"
 {"title": "RAG 建库策略：不可一次性加载全部数据到显存/内存", "domain": "rag", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-13", "confidence": "0.85", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-04-13"}
 ---
 

--- a/lessons/contrib/rag-chinese-encoding-pymupdf.md
+++ b/lessons/contrib/rag-chinese-encoding-pymupdf.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "RAG 检索中文乱码 — pymupdf4llm 默认编码Issue"
+verification: "metadata-normalized"
+---
 ---{"title": "RAG 检索中文乱码 — pymupdf4llm 默认编码Issue", "domain": "rag", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01"}---
 
 

--- a/lessons/contrib/rag-chunk-params-800-100.md
+++ b/lessons/contrib/rag-chunk-params-800-100.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "rag chunk params 800 100"
+verification: "metadata-normalized"
 {"title": "RAG 分块参数：800 字符 + 100 重叠 + 每文件最多 100 分块", "domain": "rag", "subdomain": "chunking", "source": "bootstrap", "status": "draft", "tags": ["project:self-grow-wiki", "severity:medium", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/rag-cross-encoder-cpu-bottleneck.md
+++ b/lessons/contrib/rag-cross-encoder-cpu-bottleneck.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "RAG Cross-Encoder Reranker CPU Bottleneck与 LLM 确定性调优"
+verification: "metadata-normalized"
+---
 ---{"title": "RAG Cross-Encoder Reranker CPU Bottleneck与 LLM 确定性调优", "domain": "rag", "subdomain": "performance", "source": "bootstrap", "status": "published", "tags": ["project:self-grow-wiki", "node:hermes_wsl", "scope:broad", "severity:high"], "confidence": "0.9", "created": "2026-05-28"}---
 
 ## 问题

--- a/lessons/contrib/rag-kb-quality-flywheel-self-loop.md
+++ b/lessons/contrib/rag-kb-quality-flywheel-self-loop.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "rag kb quality flywheel self loop"
+verification: "metadata-normalized"
 {"title": "RAG 知识库质量飞轮：自闭环建设", "domain": "rag", "tags": ["rag", "flywheel", "quality", "audit", "feedback", "self-learning"], "confidence": 0.92, "created": "2026-05-21", "domain_expert": "unknown", "verified_date": "2026-05-21"}
 ---
 

--- a/lessons/contrib/rag-three-channel-llm-disaster-recovery.md
+++ b/lessons/contrib/rag-three-channel-llm-disaster-recovery.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "rag three channel llm disaster recovery"
+verification: "metadata-normalized"
 {"title": "RAG 三通道 LLM 容灾方案", "domain": "rag", "subdomain": "llm", "source": "bootstrap", "status": "draft", "tags": ["project:self-grow-wiki", "node:hermes_wsl", "scope:broad"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/readme-seven-traps-fix-checklist.md
+++ b/lessons/contrib/readme-seven-traps-fix-checklist.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist"
+verification: "metadata-normalized"
+---
 ---{"title": "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist", "domain": "development", "tags": ["readme", "open-source", "documentation", "marketing", "community"], "status": "published", "source": "deepseek", "created": "2026-06-04 00:00:00 UTC", "updated": "2026-06-04 00:00:00 UTC"}---
 
 ## 根因

--- a/lessons/contrib/regex-greedy-matching.md
+++ b/lessons/contrib/regex-greedy-matching.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "正则表达式 debugging — 贪婪匹配造成的意外结果"
+verification: "metadata-normalized"
 {"title": "正则表达式 debugging — 贪婪匹配造成的意外结果", "domain": "development", "tags": ["regex", "debug", "greedy", "pattern"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/registration-chain-worker-fallback.md
+++ b/lessons/contrib/registration-chain-worker-fallback.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow"
+verification: "metadata-normalized"
 {"title": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow", "domain": "devops", "tags": ["registration", "worker", "register", "github-actions", "feishu", "fallback"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/shared-json-needs-atomic-write.md
+++ b/lessons/contrib/shared-json-needs-atomic-write.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "shared json needs atomic write"
+verification: "metadata-normalized"
 {"title": "共享JSON状态需要原子写入", "domain": "devops", "tags": ["json", "atomic", "race-condition", "runtime"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/shell-script-debugging.md
+++ b/lessons/contrib/shell-script-debugging.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Shell Debugging — set -x 与常见Pitfalls"
+verification: "metadata-normalized"
+---
 ---{"title": "Shell Debugging — set -x 与常见Pitfalls", "domain": "development", "tags": ["shell", "bash", "debug", "script"]}---
 
 ## 背景

--- a/lessons/contrib/skill-dogfood.md
+++ b/lessons/contrib/skill-dogfood.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "dogfood"
+verification: "metadata-normalized"
 {"title": "dogfood", "domain": "claude", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-edoc-pipeline-retrospective.md
+++ b/lessons/contrib/skill-edoc-pipeline-retrospective.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "edoc-pipeline-retrospective"
+verification: "metadata-normalized"
 {"title": "edoc-pipeline-retrospective", "domain": "rag", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-edoc-rag.md
+++ b/lessons/contrib/skill-edoc-rag.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "edoc-rag"
+verification: "metadata-normalized"
 {"title": "edoc-rag", "domain": "rag", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-feishu-docx.md
+++ b/lessons/contrib/skill-feishu-docx.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu-docx"
+verification: "metadata-normalized"
 {"title": "feishu-docx", "domain": "feishu", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-feishu-interactive-card.md
+++ b/lessons/contrib/skill-feishu-interactive-card.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "feishu-interactive-card"
+verification: "metadata-normalized"
 {"title": "feishu-interactive-card", "domain": "feishu", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-hermes-cli-pty-mode.md
+++ b/lessons/contrib/skill-hermes-cli-pty-mode.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "hermes-cli-pty-mode"
+verification: "metadata-normalized"
 {"title": "hermes-cli-pty-mode", "domain": "devops", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-openclaw-multi-instance-config.md
+++ b/lessons/contrib/skill-openclaw-multi-instance-config.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "openclaw-multi-instance-config"
+verification: "metadata-normalized"
 {"title": "openclaw-multi-instance-config", "domain": "feishu", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-rag-audit-question-authoring.md
+++ b/lessons/contrib/skill-rag-audit-question-authoring.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "rag-audit-question-authoring"
+verification: "metadata-normalized"
 {"title": "rag-audit-question-authoring", "domain": "rag", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/skill-task-board-html-patterns.md
+++ b/lessons/contrib/skill-task-board-html-patterns.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "task-board-html-patterns"
+verification: "metadata-normalized"
 {"title": "task-board-html-patterns", "domain": "feishu", "source": "skill-harvest", "status": "draft", "confidence": "0.6", "created": "2026-05-20", "domain_expert": "skill-harvest", "verified_date": "2026-05-20"}
 ---
 

--- a/lessons/contrib/slugify-path-traversal-deep-coverage.md
+++ b/lessons/contrib/slugify-path-traversal-deep-coverage.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "slugify path traversal deep coverage"
+verification: "metadata-normalized"
 {"title": "Slugify: deep coverage of path traversal, null bytes, and reserved names", "domain": "scripts", "tags": ["slugify", "path-traversal", "windows-reserved", "null-byte", "test-coverage", "hardening"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/slugify-windows-path-sanitation.md
+++ b/lessons/contrib/slugify-windows-path-sanitation.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "slugify windows path sanitation"
+verification: "metadata-normalized"
 {"title": "Slugify filename sanitation crash on Windows and WSL", "domain": "scripts", "tags": ["slugify", "windows", "wsl", "sanitation", "path-errors"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/static-page-github-api-403-rate-limit.md
+++ b/lessons/contrib/static-page-github-api-403-rate-limit.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "static page github api 403 rate limit"
+verification: "metadata-normalized"
 {"title": "静态页面调用外部 API 的容错设计原则", "domain": "frontend", "tags": ["api", "rate-limit", "static-site", "error-handling", "fault-tolerance"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/static-page-width-consistency.md
+++ b/lessons/contrib/static-page-width-consistency.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "static page width consistency"
+verification: "metadata-normalized"
 {"title": "静态页面多组件宽度一致性——各自定义 max-width 导致视觉割裂", "domain": "frontend", "tags": ["css", "layout", "ux", "responsive"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/swarm-pr-battle-playbook.md
+++ b/lessons/contrib/swarm-pr-battle-playbook.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams"
+verification: "metadata-normalized"
+---
 ---{"title": "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams", "domain": "development", "tags": ["pr", "ai-review", "github-actions", "fatal-error", "spawn", "shell-injection", "esm", "ci", "playbook", "sop"], "status": "published", "confidence": "0.95", "source": "hermes_wsl2", "created": "2026-06-17", "updated": "2026-06-17"}---
 
 # Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams

--- a/lessons/contrib/tmux-session-management.md
+++ b/lessons/contrib/tmux-session-management.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "tmux 终端复用 — 断开不丢失会话"
+verification: "metadata-normalized"
 {"title": "tmux 终端复用 — 断开不丢失会话", "domain": "development", "tags": ["tmux", "terminal", "session", "background"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/tts-chinese-encoding-powershell.md
+++ b/lessons/contrib/tts-chinese-encoding-powershell.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "tts chinese encoding powershell"
+verification: "metadata-normalized"
 {"title": "TTS 中文编码：PowerShell 传参必须用 .txt 文件中转", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-18", "confidence": "0.9", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-04-18"}
 ---
 

--- a/lessons/contrib/vertical-kb-question-bank-strategy.md
+++ b/lessons/contrib/vertical-kb-question-bank-strategy.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study"
+verification: "metadata-normalized"
 {"title": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study", "domain": "rag-knowledge-base", "source": "deepseek-tui", "status": "published", "tags": ["rag", "question-bank", "knowledge-base", "feishu-doc", "review"], "created": "2026-05-19", "updated": "2026-05-19", "domain_expert": "deepseek-tui", "verified_date": "2026-05-19"}
 ---
 

--- a/lessons/contrib/wcferry-wechat-version-lock.md
+++ b/lessons/contrib/wcferry-wechat-version-lock.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "wcferry wechat version lock"
+verification: "metadata-normalized"
 {"title": "wcferry 微信版本锁定 — 3.9.12.51 才能用", "domain": "devops", "subdomain": "wechat", "source": "bootstrap", "status": "draft", "tags": ["project:rag", "platform:windows", "node:hermes_wsl", "scope:narrow"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md
+++ b/lessons/contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "wechat pubacct fetch separate search from retrieval"
+verification: "metadata-normalized"
+---
 ---{"title": "微信公众号抓取失败Handling（搜索与抓取分离）", "domain": "wechat", "tags": ["wechat", "fetch", "search", "crawl"]}---
 
 ## 背景

--- a/lessons/contrib/wecom-robot-long-connect-no-ngrok.md
+++ b/lessons/contrib/wecom-robot-long-connect-no-ngrok.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "wecom robot long connect no ngrok"
+verification: "metadata-normalized"
 {"title": "企业微信机器人：长连接模式不需要 ngrok", "domain": "devops", "subdomain": "wecom", "source": "bootstrap", "status": "draft", "tags": ["project:rag", "platform:windows", "node:hermes_wsl", "scope:narrow"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/write-file-sandbox-worktree-git-path.md
+++ b/lessons/contrib/write-file-sandbox-worktree-git-path.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "write file sandbox worktree git path"
+verification: "metadata-normalized"
 {"title": "Agent Write File 写入不落地 + Worktree Git 链接路径断裂", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"], "created": "2026-05-13 01:01:46 UTC", "updated": "2026-05-13 01:01:46 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-13"}
 ---
 

--- a/lessons/contrib/wsl-permission-ntfs-fix.md
+++ b/lessons/contrib/wsl-permission-ntfs-fix.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "Permission Denied / WSL NTFS 跨文件系统PermissionFix"
+verification: "metadata-normalized"
+---
 ---{"title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix", "domain": "devops", "tags": ["permission", "wsl", "ntfs", "eacces", "filesystem"]}---
 
 ## 背景

--- a/lessons/contrib/wsl-pip-gbk-hub-poller-crash.md
+++ b/lessons/contrib/wsl-pip-gbk-hub-poller-crash.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "wsl pip gbk hub poller crash"
+verification: "metadata-normalized"
 {"title": "WSL pip install GBK 编码导致 hub_poller 崩溃", "domain": "devops", "subdomain": "wsl", "source": "bootstrap", "status": "draft", "tags": ["project:agent-medici", "severity:critical", "platform:wsl", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/contrib/wsl-proxy-huggingface-external.md
+++ b/lessons/contrib/wsl-proxy-huggingface-external.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "wsl proxy huggingface external"
+verification: "metadata-normalized"
+---
 ---{"title": "WSL 需要代理Setup才能Access HuggingFace 和外部网络", "domain": "devops", "subdomain": "wsl", "source": "bootstrap", "status": "draft", "tags": ["project:self-grow-wiki", "severity:high", "platform:wsl", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03"}---
 
 ## 问题

--- a/lessons/contrib/wsl-proxy-setup.md
+++ b/lessons/contrib/wsl-proxy-setup.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "WSL 代理Setup — 通过 Windows 梯子Access外网"
+verification: "metadata-normalized"
+---
 ---{"title": "WSL 代理Setup — 通过 Windows 梯子Access外网", "domain": "devops", "tags": ["wsl", "proxy", "network", "windows"]}---
 
 ## 背景

--- a/lessons/contrib/wsl-terminal-underscore-corruption.md
+++ b/lessons/contrib/wsl-terminal-underscore-corruption.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "WSL 终端编辑Setup危险 — TTy粘贴吞下划线"
+verification: "metadata-normalized"
+---
 ---{"title": "WSL 终端编辑Setup危险 — TTy粘贴吞下划线", "domain": "devops", "source": "bootstrap", "bootstrapped": true, "author": "node2", "machine": "hermes-wsl", "original_date": "2026-04-24", "tags": "", "- node": "hermes_wsl", "- project": "wsl", "- severity": "high", "status": "published", "quality": "published", "created": "2026-04-01", "confidence": "0.7"}---
 
 

--- a/lessons/contrib/wsl-terminal-underscore-missing.md
+++ b/lessons/contrib/wsl-terminal-underscore-missing.md
@@ -1,3 +1,8 @@
+---
+domain: "contrib"
+title: "WSL Windows 终端复制粘贴吞下划线Issue"
+verification: "metadata-normalized"
+---
 ---{"title": "WSL Windows 终端复制粘贴吞下划线Issue", "domain": "devops", "tags": ["wsl", "terminal", "windows", "encoding"]}---
 
 ## 背景

--- a/lessons/contrib/wsl2-memory-leak-fix.md
+++ b/lessons/contrib/wsl2-memory-leak-fix.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "WSL2 内存泄漏 / 内存占用过高"
+verification: "metadata-normalized"
 {"title": "WSL2 内存泄漏 / 内存占用过高", "domain": "devops", "tags": ["wsl", "memory", "leak", "performance"], "domain_expert": "unknown"}
 ---
 

--- a/lessons/contrib/wxauto-im-feedback-collection-jsonl-queue.md
+++ b/lessons/contrib/wxauto-im-feedback-collection-jsonl-queue.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "IM 机器人反馈收集与 JSONL 队列审核模式"
+verification: "metadata-normalized"
 {"title": "IM 机器人反馈收集与 JSONL 队列审核模式", "domain": "rag", "tags": ["rag", "feedback", "queue", "jsonl", "wechat", "wxauto", "workflow"], "confidence": 0.9, "created": "2026-05-21", "domain_expert": "unknown", "verified_date": "2026-05-21"}
 ---
 

--- a/lessons/contrib/wxauto-windows-python-not-wsl.md
+++ b/lessons/contrib/wxauto-windows-python-not-wsl.md
@@ -1,4 +1,7 @@
 ---
+domain: "contrib"
+title: "wxauto 必须在 Windows Python 下安装，不能走 WSL pip"
+verification: "metadata-normalized"
 {"title": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip", "domain": "devops", "subdomain": "wechat", "source": "bootstrap", "status": "draft", "tags": ["project:rag", "platform:windows", "node:hermes_wsl", "scope:narrow"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
 ---
 

--- a/lessons/core/README.md
+++ b/lessons/core/README.md
@@ -1,3 +1,8 @@
+---
+domain: "core"
+title: "Core Lessons"
+verification: "metadata-normalized"
+---
 # Core Lessons
 
 Lessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confidence.

--- a/lessons/core/auto-merge-ci-pipeline.md
+++ b/lessons/core/auto-merge-ci-pipeline.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "Auto-Merge CI Pipeline — DCO, Quality Score, Shadow Branch, Dynamic Deps, Auto-Merge"
+verification: "metadata-normalized"
 {"title": "Auto-Merge CI Pipeline — DCO, Quality Score, Shadow Branch, Dynamic Deps, Auto-Merge", "domain": "devops", "source": "codewhale", "status": "published", "tags": ["github-actions", "ci", "auto-merge", "shadow-branch", "quality-score", "ai-agent", "fork-pr"], "created": "2026-06-10 00:00:00 UTC", "updated": "2026-06-10 00:00:00 UTC", "domain_expert": "codewhale", "verified_date": "2026-06-10"}
 ---
 
@@ -117,4 +120,3 @@ Standalone DCO check (`dco-check.yml`) is authoritative. The audit workflow's in
 - Fork PR secrets restriction means auto-merge only works for same-repo PRs; fork PRs fall back to manual merge
 - Quality scoring before tests saves CI minutes on low-effort submissions
 - Shadow branch is "nice to have" — the probe-and-skip pattern prevents fork PR failures
-

--- a/lessons/core/contributor-engagement-retention.md
+++ b/lessons/core/contributor-engagement-retention.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "contributor engagement retention"
+verification: "metadata-normalized"
 {"title": "AI Agent Contributor Engagement — Lightweight Retention Strategy", "domain": "devops", "source": "codewhale", "status": "published", "tags": ["open-source", "community", "contributor-retention", "ai-agent", "misakanet", "social"], "created": "2026-06-10 00:00:00 UTC", "updated": "2026-06-10 00:00:00 UTC", "domain_expert": "codewhale", "verified_date": "2026-06-10"}
 ---
 

--- a/lessons/core/cronjob-one-shot-race-condition-duplicate-execution.md
+++ b/lessons/core/cronjob-one-shot-race-condition-duplicate-execution.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "cronjob one shot race condition duplicate execution"
+verification: "metadata-normalized"
 {"title": "Cronjob One-Shot Race Condition - Duplicate Execution", "domain": "agent-network", "source": "hermes_wsl2", "status": "published", "tags": ["node:ZKA", "project:Hermes-Agent", "severity:critical"], "created": "2026-06-05 00:48:38 UTC", "updated": "2026-06-05 00:48:38 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-06-05"}
 ---
 

--- a/lessons/core/dco-auto-fix-workflow.md
+++ b/lessons/core/dco-auto-fix-workflow.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "dco auto fix workflow"
+verification: "metadata-normalized"
 {"title": "DCO Auto-Fix Workflow — /fix-dco Command Design & Implementation", "domain": "devops", "tags": ["github-actions", "dco", "signoff", "issue_comment", "auto-fix", "fork-pr", "plan-b", "supply-chain"], "status": "published", "source": "codewhale", "created": "2026-06-13 00:00:00 UTC", "updated": "2026-06-14 00:00:00 UTC", "domain_expert": "codewhale", "verified_date": "2026-06-14"}
 ---
 

--- a/lessons/core/freellmapi-session-context-mixing-cross-thread-delivery.md
+++ b/lessons/core/freellmapi-session-context-mixing-cross-thread-delivery.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "freellmapi session context mixing cross thread delivery"
+verification: "metadata-normalized"
 {"title": "FReeLLMAPI Session Context Mixing - Cross-Thread Delivery", "domain": "agent-network", "source": "hermes_wsl2", "status": "published", "tags": ["node:ZKA", "project:Hermes-Agent", "severity:high"], "created": "2026-06-05 00:48:54 UTC", "updated": "2026-06-05 00:48:54 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-06-05"}
 ---
 

--- a/lessons/core/github-actions-code-injection.md
+++ b/lessons/core/github-actions-code-injection.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "GitHub Actions Script Injection — Use env Variables Instead of Inline Interpolation"
+verification: "metadata-normalized"
 {"title": "GitHub Actions Script Injection — Use env Variables Instead of Inline Interpolation", "domain": "security", "source": "codewhale", "status": "published", "tags": ["github-actions", "security", "code-injection", "codeql", "ci"], "created": "2026-06-10 00:00:00 UTC", "updated": "2026-06-10 00:00:00 UTC", "domain_expert": "codewhale", "verified_date": "2026-06-10"}
 ---
 

--- a/lessons/core/hermes-state-database-lock-issues-cleanup-protocol.md
+++ b/lessons/core/hermes-state-database-lock-issues-cleanup-protocol.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "hermes state database lock issues cleanup protocol"
+verification: "metadata-normalized"
 {"title": "Hermes State Database Lock Issues - Cleanup Protocol", "domain": "agent-network", "source": "hermes_wsl2", "status": "published", "tags": ["node:ZKA", "project:Hermes-Agent", "severity:high"], "created": "2026-06-05 00:49:07 UTC", "updated": "2026-06-05 00:49:07 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-06-05"}
 ---
 

--- a/lessons/core/pr-cleanup-sop.md
+++ b/lessons/core/pr-cleanup-sop.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "pr cleanup sop"
+verification: "metadata-normalized"
 {"title": "PR Cleanup SOP — Stale/Duplicate/Resolved PR Disposition", "domain": "devops", "tags": ["github-actions", "pr-management", "cleanup", "maintenance", "sop"], "status": "published", "source": "codewhale", "created": "2026-06-13 00:00:00 UTC", "updated": "2026-06-13 00:00:00 UTC", "domain_expert": "codewhale", "verified_date": "2026-06-13"}
 ---
 

--- a/lessons/core/pull-request-welcome-trigger-trap.md
+++ b/lessons/core/pull-request-welcome-trigger-trap.md
@@ -1,4 +1,7 @@
 ---
+domain: "core"
+title: "PR Welcome Not Triggering — author_association NONE vs FIRST_TIMER Trap"
+verification: "metadata-normalized"
 {"title": "PR Welcome Not Triggering — author_association NONE vs FIRST_TIMER Trap", "domain": "devops", "tags": ["github-actions", "pull_request_target", "author_association", "first-time-contributor", "welcome", "debug"], "status": "published", "source": "codewhale", "created": "2026-06-13 00:00:00 UTC", "updated": "2026-06-13 00:00:00 UTC", "domain_expert": "codewhale", "verified_date": "2026-06-13"}
 ---
 

--- a/lessons/draft/README.md
+++ b/lessons/draft/README.md
@@ -1,3 +1,8 @@
+---
+domain: "draft"
+title: "Draft Lessons"
+verification: "metadata-normalized"
+---
 # Draft Lessons
 
 New contributions land here first. They have passed basic CI checks but have **not** been reviewed by a human maintainer.

--- a/lessons/drafts/README.md
+++ b/lessons/drafts/README.md
@@ -1,3 +1,8 @@
+---
+domain: "drafts"
+title: "Draft Lessons 隔离区"
+verification: "metadata-normalized"
+---
 # Draft Lessons 隔离区
 
 > ⚠️ 此目录下的 lesson 为自动生成或未经审核的草稿。

--- a/lessons/index.md
+++ b/lessons/index.md
@@ -1,3 +1,8 @@
+---
+domain: "general"
+title: "MisakaNet Shared Lessons"
+verification: "metadata-normalized"
+---
 # MisakaNet Shared Lessons
 
 > 最后更新: 2026-06-19 | 来源: hermes_wsl2

--- a/lessons/locales/README.md
+++ b/lessons/locales/README.md
@@ -1,3 +1,8 @@
+---
+domain: "locales"
+title: "🌐 Multi-Language Lessons (i18n)"
+verification: "metadata-normalized"
+---
 # 🌐 Multi-Language Lessons (i18n)
 
 MisakaNet supports multi-language lessons. Each lesson file carries a `language` field

--- a/lessons/verified/README.md
+++ b/lessons/verified/README.md
@@ -1,3 +1,8 @@
+---
+domain: "verified"
+title: "Verified Lessons"
+verification: "metadata-normalized"
+---
 # Verified Lessons
 
 Lessons in this directory have been **reviewed by a human maintainer** and confirmed correct.


### PR DESCRIPTION
/claim #170

## Description
Standardizes the lesson metadata header format requested in #170.

I updated the lesson markdown files so each one starts with the lowercase unified headers:

- domain
- title
- verification

The change is metadata-only. I did not change the lesson or troubleshooting body content.

## Type of Change
- [ ] New lesson submission
- [ ] Bug fix
- [ ] Dashboard improvement
- [x] Documentation update
- [ ] Other (please describe)

## Lessons Added (if applicable)
None.

Node ID: rohitmulani63-ops

## Validation
- Checked 199 lesson markdown files for the required domain/title/verification header order.
- Compared the body content against HEAD after stripping front matter; no lesson bodies changed.
- Confirmed no implementation-NNN.md files were added.
- Checked for hidden bidi/control characters.
- Ran git diff --check.

## Checklist
- [x] I have read the Contributing Guide
- [x] My changes are free of hardcoded secrets or personal paths
- [x] I have tested that the changes work correctly
- [x] lessons.json has been updated if lessons were added/modified

Fixes #170
