### PR TITLE
feat(federation): HMAC-SHA256 auth for hub-to-node communication

### DIFF
--- a/hub/federation/__init__.py
+++ b/hub/federation/__init__.py
@@ -2,6 +2,21 @@
 
 from .registry import FederationRegistry, PeerNode
 from .sync_protocol import FederationSync, LessonManifest, SyncResult
+from .hmac_auth import (
+    sign_request,
+    verify_request,
+    build_auth_headers,
+    extract_auth_headers,
+    HEADER_SIGNATURE,
+    HEADER_TIMESTAMP,
+    HEADER_KEY_VERSION,
+)
+from .secrets import (
+    generate_shared_secret,
+    get_shared_secret,
+    get_key_version,
+    revoke_secret,
+)
 
 __all__ = [
     "FederationRegistry",
@@ -9,4 +24,17 @@ __all__ = [
     "FederationSync",
     "LessonManifest",
     "SyncResult",
+    # HMAC auth
+    "sign_request",
+    "verify_request",
+    "build_auth_headers",
+    "extract_auth_headers",
+    "HEADER_SIGNATURE",
+    "HEADER_TIMESTAMP",
+    "HEADER_KEY_VERSION",
+    # Secrets
+    "generate_shared_secret",
+    "get_shared_secret",
+    "get_key_version",
+    "revoke_secret",
 ]

--- a/hub/federation/hmac_auth.py
+++ b/hub/federation/hmac_auth.py
@@ -1,0 +1,207 @@
+"""
+HMAC-SHA256 authentication for federated endpoints.
+
+Replaces raw token passing with signed requests. Each request includes:
+  - X-HMAC-Signature: hex HMAC-SHA256 of canonical payload
+  - X-HMAC-Timestamp: Unix epoch seconds (string)
+  - X-HMAC-Key-Version: integer key version for rotation support
+
+Canonical payload = "{timestamp}\n{method}\n{path}\n{body_hash}"
+
+Replay protection: requests with timestamp older than MAX_AGE_SECONDS
+or with a previously-seen nonce are rejected.
+
+Dependencies: Python stdlib only (hmac, hashlib, time, threading).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import threading
+import time
+from typing import Optional, Tuple
+
+from . import secrets as secret_store
+
+# Replay window: 5 minutes
+MAX_AGE_SECONDS = 300
+
+# Nonce cache cleanup interval
+_NONCE_CLEANUP_INTERVAL = 60
+
+# Header names
+HEADER_SIGNATURE = "X-HMAC-Signature"
+HEADER_TIMESTAMP = "X-HMAC-Timestamp"
+HEADER_KEY_VERSION = "X-HMAC-Key-Version"
+
+
+class _NonceCache:
+    """
+    Thread-safe in-memory nonce cache for replay protection.
+
+    Stores (nonce, expiry) pairs. Nonces are derived from timestamp + body hash
+    so the same request body at the same second produces the same nonce.
+    """
+
+    def __init__(self, max_age: int = MAX_AGE_SECONDS):
+        self._seen: dict[str, float] = {}
+        self._lock = threading.Lock()
+        self._max_age = max_age
+        self._last_cleanup = time.time()
+
+    def check_and_record(self, nonce: str) -> bool:
+        """
+        Return True if nonce is fresh (not seen within max_age window).
+        Records the nonce on success.
+        """
+        now = time.time()
+        with self._lock:
+            self._maybe_cleanup(now)
+            if nonce in self._seen:
+                return False
+            self._seen[nonce] = now + self._max_age
+            return True
+
+    def _maybe_cleanup(self, now: float) -> None:
+        """Evict expired nonces periodically."""
+        if now - self._last_cleanup < _NONCE_CLEANUP_INTERVAL:
+            return
+        self._last_cleanup = now
+        expired = [k for k, exp in self._seen.items() if exp < now]
+        for k in expired:
+            del self._seen[k]
+
+
+# Module-level nonce cache (shared across all verifications)
+_nonce_cache = _NonceCache()
+
+
+def _canonical_payload(
+    timestamp: str,
+    method: str,
+    path: str,
+    body: bytes,
+) -> str:
+    """
+    Build the canonical string that gets signed.
+
+    Format: "{timestamp}\n{METHOD}\n{path}\n{body_sha256_hex}"
+    """
+    body_hash = hashlib.sha256(body).hexdigest()
+    return f"{timestamp}\n{method.upper()}\n{path}\n{body_hash}"
+
+
+def sign_request(
+    node_id: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    *,
+    timestamp: Optional[float] = None,
+) -> Tuple[str, str, str, int]:
+    """
+    Sign an outgoing request.
+
+    Returns (signature_hex, timestamp_str, body, key_version) for setting headers.
+    """
+    ts = str(int(timestamp or time.time()))
+    key_version = secret_store.get_key_version(node_id)
+    shared_secret = secret_store.get_shared_secret(node_id)
+
+    if shared_secret is None:
+        raise ValueError(f"No shared secret for node '{node_id}'. Register the node first.")
+
+    payload = _canonical_payload(ts, method, path, body)
+    sig = hmac.new(
+        shared_secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return sig, ts, body, key_version
+
+
+def verify_request(
+    node_id: str,
+    method: str,
+    path: str,
+    body: bytes,
+    signature: str,
+    timestamp: str,
+    key_version: int = 0,
+) -> Tuple[bool, str]:
+    """
+    Verify an incoming request's HMAC signature.
+
+    Returns (ok, reason). On failure, reason describes what went wrong.
+    """
+    # 1. Timestamp freshness
+    try:
+        ts_int = int(timestamp)
+    except (ValueError, TypeError):
+        return False, "invalid_timestamp"
+
+    now = int(time.time())
+    age = abs(now - ts_int)
+    if age > MAX_AGE_SECONDS:
+        return False, f"timestamp_expired (age={age}s, max={MAX_AGE_SECONDS}s)"
+
+    # 2. Retrieve shared secret
+    shared_secret = secret_store.get_shared_secret(node_id)
+    if shared_secret is None:
+        return False, f"unknown_node '{node_id}'"
+
+    # 3. Compute expected signature
+    payload = _canonical_payload(timestamp, method, path, body)
+    expected = hmac.new(
+        shared_secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    # 4. Constant-time comparison
+    if not hmac.compare_digest(signature, expected):
+        return False, "signature_mismatch"
+
+    # 5. Replay protection — nonce = timestamp + body hash
+    body_hash = hashlib.sha256(body).hexdigest()
+    nonce = f"{timestamp}:{body_hash}"
+    if not _nonce_cache.check_and_record(nonce):
+        return False, "replay_detected"
+
+    return True, "ok"
+
+
+def build_auth_headers(
+    node_id: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+) -> dict:
+    """
+    Convenience: build the three auth headers for an outgoing request.
+    """
+    sig, ts, _, kv = sign_request(node_id, method, path, body)
+    return {
+        HEADER_SIGNATURE: sig,
+        HEADER_TIMESTAMP: ts,
+        HEADER_KEY_VERSION: str(kv),
+    }
+
+
+def extract_auth_headers(headers: dict) -> Tuple[str, str, int]:
+    """
+    Convenience: extract auth headers from a request.
+
+    Returns (signature, timestamp, key_version).
+    Raises ValueError if headers are missing.
+    """
+    sig = headers.get(HEADER_SIGNATURE)
+    ts = headers.get(HEADER_TIMESTAMP)
+    kv = headers.get(HEADER_KEY_VERSION, "0")
+
+    if not sig or not ts:
+        raise ValueError("Missing HMAC auth headers")
+
+    return sig, ts, int(kv)

--- a/hub/federation/registry.py
+++ b/hub/federation/registry.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import yaml
 
+from . import secrets as secret_store
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,7 +71,7 @@ class FederationRegistry:
             yaml.dump(config, f, default_flow_style=False)
 
     def add_peer(self, node_id: str, repo_url: str, public_key_fingerprint: str | None = None) -> PeerNode:
-        """Add a new peer to the registry."""
+        """Add a new peer to the registry and generate an HMAC shared secret."""
         peer = PeerNode(
             node_id=node_id,
             repo_url=repo_url,
@@ -77,15 +79,19 @@ class FederationRegistry:
         )
         self.peers[node_id] = peer
         self.save()
-        logger.info("Added peer: %s (%s)", node_id, repo_url)
+
+        # Generate shared secret for HMAC-SHA256 authentication
+        secret_store.generate_shared_secret(node_id)
+        logger.info("Added peer: %s (%s) with HMAC secret", node_id, repo_url)
         return peer
 
     def remove_peer(self, node_id: str) -> bool:
-        """Remove a peer from the registry."""
+        """Remove a peer from the registry and revoke its HMAC secret."""
         if node_id in self.peers:
             del self.peers[node_id]
             self.save()
-            logger.info("Removed peer: %s", node_id)
+            secret_store.revoke_secret(node_id)
+            logger.info("Removed peer: %s (HMAC secret revoked)", node_id)
             return True
         return False
 

--- a/hub/federation/secrets.py
+++ b/hub/federation/secrets.py
@@ -1,0 +1,114 @@
+"""
+Federation key management.
+
+Stores per-node shared secrets in hub/federation/secrets/<node_id>.key.
+Keys are generated on node registration and rotated on demand.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Optional
+
+# Default secrets directory: hub/federation/secrets/
+_SECRETS_DIR = Path(__file__).parent / "secrets"
+
+# Key metadata file per node
+_KEY_FILE = "key.json"
+
+
+def _secrets_dir() -> Path:
+    """Return the secrets directory, creating it if needed."""
+    d = _get_secrets_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _get_secrets_dir() -> Path:
+    """Return the configured secrets directory."""
+    env = os.environ.get("MISAKA_SECRETS_DIR")
+    return Path(env) if env else _SECRETS_DIR
+
+
+def generate_shared_secret(node_id: str, *, rotate: bool = False) -> str:
+    """
+    Generate (or rotate) a shared secret for a federated node.
+
+    Returns the hex-encoded secret string.
+    Metadata (node_id, created_at, rotated_at) is persisted alongside.
+    """
+    node_dir = _secrets_dir() / _safe_filename(node_id)
+    node_dir.mkdir(parents=True, exist_ok=True)
+    key_path = node_dir / _KEY_FILE
+
+    now = time.time()
+    hex_secret = secrets.token_hex(32)  # 256-bit key
+
+    meta: dict = {
+        "node_id": node_id,
+        "created_at": now,
+        "rotated_at": now if rotate else None,
+        "key_version": 1,
+    }
+
+    # If rotating, bump version and preserve original creation time
+    if rotate and key_path.exists():
+        try:
+            old = json.loads(key_path.read_text())
+            meta["created_at"] = old.get("created_at", now)
+            meta["key_version"] = old.get("key_version", 1) + 1
+            meta["rotated_at"] = now
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    record = {"secret": hex_secret, **meta}
+    key_path.write_text(json.dumps(record, indent=2))
+    return hex_secret
+
+
+def get_shared_secret(node_id: str) -> Optional[str]:
+    """
+    Retrieve the shared secret for a node.
+
+    Returns None if no key exists (node not registered).
+    """
+    key_path = _secrets_dir() / _safe_filename(node_id) / _KEY_FILE
+    if not key_path.exists():
+        return None
+    try:
+        data = json.loads(key_path.read_text())
+        return data.get("secret")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def get_key_version(node_id: str) -> int:
+    """Return the current key version for a node (0 if not found)."""
+    key_path = _secrets_dir() / _safe_filename(node_id) / _KEY_FILE
+    if not key_path.exists():
+        return 0
+    try:
+        data = json.loads(key_path.read_text())
+        return data.get("key_version", 1)
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+
+def revoke_secret(node_id: str) -> bool:
+    """Delete the shared secret for a node. Returns True if deleted."""
+    key_path = _secrets_dir() / _safe_filename(node_id) / _KEY_FILE
+    if key_path.exists():
+        key_path.unlink()
+        return True
+    return False
+
+
+def _safe_filename(node_id: str) -> str:
+    """Sanitize node_id for use as a directory name."""
+    # Allow alphanumeric, hyphens, underscores, dots
+    safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in node_id)
+    return safe[:128]  # cap length

--- a/hub/federation/secrets/.gitignore
+++ b/hub/federation/secrets/.gitignore
@@ -1,0 +1,2 @@
+# Generated at runtime by secrets.generate_shared_secret()
+*

--- a/tests/test_hmac_auth.py
+++ b/tests/test_hmac_auth.py
@@ -1,0 +1,371 @@
+"""Tests for HMAC-SHA256 federation authentication.
+
+Covers:
+  1. Sign and verify round-trip
+  2. Replay protection (duplicate nonce rejection)
+  3. Timestamp expiry (stale request rejection)
+  4. Key rotation (version bump, old key invalid)
+  5. Signature mismatch (tampered body)
+  6. Integration with registry (auto-generate on add_peer)
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hub.federation.hmac_auth import (
+    sign_request,
+    verify_request,
+    build_auth_headers,
+    extract_auth_headers,
+    _NonceCache,
+    MAX_AGE_SECONDS,
+)
+from hub.federation import secrets as secret_store
+from hub.federation.registry import FederationRegistry
+
+
+@pytest.fixture
+def secrets_dir(tmp_path):
+    """Isolate secrets to a temp directory."""
+    with patch.object(secret_store, "_SECRETS_DIR", tmp_path / "secrets"):
+        yield tmp_path / "secrets"
+
+
+@pytest.fixture
+def node_with_secret(secrets_dir):
+    """Register a node and return its ID."""
+    node_id = "test-node-alpha"
+    secret_store.generate_shared_secret(node_id)
+    return node_id
+
+
+def _now():
+    """Current time as float, for test convenience."""
+    return time.time()
+
+
+# ── 1. Sign & Verify Round-Trip ──────────────────────────────────────────────
+
+
+class TestSignAndVerify:
+    def test_sign_produces_valid_headers(self, node_with_secret):
+        """sign_request returns (sig, timestamp, body, key_version)."""
+        sig, ts, body, kv = sign_request(
+            node_with_secret, "POST", "/api/sync", b'{"data": 1}'
+        )
+        assert len(sig) == 64  # SHA-256 hex = 64 chars
+        assert ts.isdigit()
+        assert kv >= 1
+
+    def test_verify_accepts_valid_request(self, node_with_secret):
+        """verify_request accepts a properly signed request."""
+        body = b'{"lesson": "test"}'
+        sig, ts, _, kv = sign_request(node_with_secret, "POST", "/federation/sync", body)
+
+        ok, reason = verify_request(
+            node_with_secret, "POST", "/federation/sync", body, sig, ts, kv
+        )
+        assert ok is True
+        assert reason == "ok"
+
+    def test_build_auth_headers_round_trip(self, node_with_secret):
+        """build_auth_headers + extract_auth_headers round-trips correctly."""
+        body = b"hello"
+        headers = build_auth_headers(node_with_secret, "PUT", "/api/lesson", body)
+
+        sig, ts, kv = extract_auth_headers(headers)
+        ok, reason = verify_request(
+            node_with_secret, "PUT", "/api/lesson", body, sig, ts, kv
+        )
+        assert ok is True
+
+    def test_different_methods_produce_different_signatures(self, node_with_secret):
+        """GET and POST to the same path produce different signatures."""
+        body = b""
+        ts_fixed = _now()
+        sig_get, _, _, _ = sign_request(node_with_secret, "GET", "/api/x", body, timestamp=ts_fixed)
+        sig_post, _, _, _ = sign_request(node_with_secret, "POST", "/api/x", body, timestamp=ts_fixed)
+        assert sig_get != sig_post
+
+
+# ── 2. Replay Protection ─────────────────────────────────────────────────────
+
+
+class TestReplayProtection:
+    def test_duplicate_request_rejected(self, node_with_secret):
+        """Sending the same signed request twice is rejected as replay."""
+        body = b'{"data": "replay-me"}'
+        ts_fixed = _now()
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "POST", "/api/sync", body, timestamp=ts_fixed
+        )
+
+        # First time: ok
+        ok1, _ = verify_request(
+            node_with_secret, "POST", "/api/sync", body, sig, ts, kv
+        )
+        assert ok1 is True
+
+        # Second time: replay detected
+        ok2, reason = verify_request(
+            node_with_secret, "POST", "/api/sync", body, sig, ts, kv
+        )
+        assert ok2 is False
+        assert "replay" in reason
+
+    def test_different_body_not_replay(self, node_with_secret):
+        """Same timestamp but different body is not a replay."""
+        ts_fixed = _now()
+        body_a = b'{"id": 1}'
+        body_b = b'{"id": 2}'
+
+        sig_a, ts_a, _, kv_a = sign_request(
+            node_with_secret, "POST", "/api/x", body_a, timestamp=ts_fixed
+        )
+        sig_b, ts_b, _, kv_b = sign_request(
+            node_with_secret, "POST", "/api/x", body_b, timestamp=ts_fixed
+        )
+
+        ok1, _ = verify_request(
+            node_with_secret, "POST", "/api/x", body_a, sig_a, ts_a, kv_a
+        )
+        ok2, _ = verify_request(
+            node_with_secret, "POST", "/api/x", body_b, sig_b, ts_b, kv_b
+        )
+        assert ok1 is True
+        assert ok2 is True
+
+
+# ── 3. Timestamp Expiry ──────────────────────────────────────────────────────
+
+
+class TestTimestampExpiry:
+    def test_expired_timestamp_rejected(self, node_with_secret):
+        """Request with timestamp older than MAX_AGE_SECONDS is rejected."""
+        old_ts = _now() - MAX_AGE_SECONDS - 10
+        body = b"stale"
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "GET", "/api/status", body, timestamp=old_ts
+        )
+
+        ok, reason = verify_request(
+            node_with_secret, "GET", "/api/status", body, sig, ts, kv
+        )
+        assert ok is False
+        assert "expired" in reason
+
+    def test_future_timestamp_within_window_accepted(self, node_with_secret):
+        """Request with timestamp slightly in the future is accepted (clock skew)."""
+        future_ts = _now() + 30  # 30s in future, within 5min window
+        body = b"future"
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "GET", "/api/ping", body, timestamp=future_ts
+        )
+
+        ok, reason = verify_request(
+            node_with_secret, "GET", "/api/ping", body, sig, ts, kv
+        )
+        assert ok is True
+
+    def test_invalid_timestamp_format_rejected(self, node_with_secret):
+        """Non-numeric timestamp is rejected."""
+        ok, reason = verify_request(
+            node_with_secret, "GET", "/api/x", b"", "bad-sig", "not-a-number", 1
+        )
+        assert ok is False
+        assert "invalid_timestamp" in reason
+
+
+# ── 4. Key Rotation ──────────────────────────────────────────────────────────
+
+
+class TestKeyRotation:
+    def test_key_version_bumps_on_rotation(self, secrets_dir, node_with_secret):
+        """Rotating a key increments the version."""
+        assert secret_store.get_key_version(node_with_secret) == 1
+
+        secret_store.generate_shared_secret(node_with_secret, rotate=True)
+        assert secret_store.get_key_version(node_with_secret) == 2
+
+    def test_old_key_invalid_after_rotation(self, secrets_dir, node_with_secret):
+        """After rotation, signatures made with the old key are rejected."""
+        ts_fixed = _now()
+        body = b"old-key-data"
+        sig_v1, ts, _, kv_v1 = sign_request(
+            node_with_secret, "POST", "/api/sync", body, timestamp=ts_fixed
+        )
+        assert kv_v1 == 1
+
+        # Rotate key
+        secret_store.generate_shared_secret(node_with_secret, rotate=True)
+        assert secret_store.get_key_version(node_with_secret) == 2
+
+        # Verify with v1 signature should fail (server now has v2 key)
+        ok, reason = verify_request(
+            node_with_secret, "POST", "/api/sync", body, sig_v1, ts, kv_v1
+        )
+        assert ok is False
+        assert "signature_mismatch" in reason
+
+    def test_new_key_signs_and_verifies(self, secrets_dir, node_with_secret):
+        """After rotation, new key signs and verifies correctly."""
+        secret_store.generate_shared_secret(node_with_secret, rotate=True)
+
+        body = b"new-key-data"
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "POST", "/api/sync", body, timestamp=_now()
+        )
+        assert kv == 2
+
+        ok, reason = verify_request(
+            node_with_secret, "POST", "/api/sync", body, sig, ts, kv
+        )
+        assert ok is True
+
+
+# ── 5. Signature Mismatch ────────────────────────────────────────────────────
+
+
+class TestSignatureMismatch:
+    def test_tampered_body_rejected(self, node_with_secret):
+        """Changing the body after signing invalidates the signature."""
+        ts_fixed = _now()
+        original_body = b'{"lesson": "original"}'
+        tampered_body = b'{"lesson": "TAMPERED"}'
+
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "POST", "/api/sync", original_body, timestamp=ts_fixed
+        )
+
+        ok, reason = verify_request(
+            node_with_secret, "POST", "/api/sync", tampered_body, sig, ts, kv
+        )
+        assert ok is False
+        assert "signature_mismatch" in reason
+
+    def test_tampered_path_rejected(self, node_with_secret):
+        """Changing the path after signing invalidates the signature."""
+        ts_fixed = _now()
+        body = b"data"
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "POST", "/api/sync", body, timestamp=ts_fixed
+        )
+
+        ok, reason = verify_request(
+            node_with_secret, "POST", "/api/DIFFERENT", body, sig, ts, kv
+        )
+        assert ok is False
+        assert "signature_mismatch" in reason
+
+    def test_unknown_node_rejected(self, secrets_dir):
+        """Request from an unregistered node is rejected."""
+        ok, reason = verify_request(
+            "nonexistent-node", "GET", "/api/x", b"", "fake-sig", str(int(_now())), 0
+        )
+        assert ok is False
+        assert "unknown_node" in reason
+
+
+# ── 6. Registry Integration ──────────────────────────────────────────────────
+
+
+class TestRegistryIntegration:
+    def test_add_peer_generates_secret(self, secrets_dir):
+        """FederationRegistry.add_peer auto-generates an HMAC shared secret."""
+        config_path = secrets_dir.parent / "config.yaml"
+        registry = FederationRegistry.from_config(config_path)
+        registry.add_peer("hub-node-1", "https://github.com/peer/repo")
+
+        secret = secret_store.get_shared_secret("hub-node-1")
+        assert secret is not None
+        assert len(secret) == 64  # 256-bit hex
+
+    def test_remove_peer_revokes_secret(self, secrets_dir):
+        """FederationRegistry.remove_peer revokes the HMAC shared secret."""
+        config_path = secrets_dir.parent / "config.yaml"
+        registry = FederationRegistry.from_config(config_path)
+        registry.add_peer("hub-node-2", "https://github.com/peer/repo")
+
+        assert secret_store.get_shared_secret("hub-node-2") is not None
+
+        registry.remove_peer("hub-node-2")
+        assert secret_store.get_shared_secret("hub-node-2") is None
+
+    def test_full_flow_register_sign_verify(self, secrets_dir):
+        """End-to-end: register peer → sign request → verify request."""
+        config_path = secrets_dir.parent / "config.yaml"
+        registry = FederationRegistry.from_config(config_path)
+        registry.add_peer("federation-hub", "https://hub.misaka.net")
+
+        body = b'{"lessons": ["pip-ssl-fix", "git-rebase"]}'
+        headers = build_auth_headers("federation-hub", "POST", "/api/federation/sync", body)
+
+        sig, ts, kv = extract_auth_headers(headers)
+        ok, reason = verify_request(
+            "federation-hub", "POST", "/api/federation/sync", body, sig, ts, kv
+        )
+        assert ok is True
+
+
+# ── 7. NonceCache Unit Tests ─────────────────────────────────────────────────
+
+
+class TestNonceCache:
+    def test_fresh_nonce_accepted(self):
+        cache = _NonceCache(max_age=60)
+        assert cache.check_and_record("nonce-1") is True
+
+    def test_duplicate_nonce_rejected(self):
+        cache = _NonceCache(max_age=60)
+        cache.check_and_record("nonce-2")
+        assert cache.check_and_record("nonce-2") is False
+
+    def test_expired_nonce_cleaned_up(self):
+        cache = _NonceCache(max_age=0)  # instant expiry
+        cache.check_and_record("nonce-3")
+        # Force cleanup by advancing time
+        with patch("time.time", return_value=cache._last_cleanup + 120):
+            assert cache.check_and_record("nonce-3") is True  # should be cleaned
+
+
+# ── 8. Edge Cases ────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_empty_body(self, node_with_secret):
+        """Empty body (b'') is valid."""
+        sig, ts, _, kv = sign_request(node_with_secret, "GET", "/health", b"")
+        ok, _ = verify_request(node_with_secret, "GET", "/health", b"", sig, ts, kv)
+        assert ok is True
+
+    def test_large_body(self, node_with_secret):
+        """Large body (1MB) signs and verifies correctly."""
+        body = b"x" * (1024 * 1024)
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "POST", "/api/upload", body
+        )
+        ok, _ = verify_request(
+            node_with_secret, "POST", "/api/upload", body, sig, ts, kv
+        )
+        assert ok is True
+
+    def test_unicode_body(self, node_with_secret):
+        """UTF-8 body with CJK characters signs correctly."""
+        body = '{"lesson": "pip SSL 证书修复"}'.encode("utf-8")
+        sig, ts, _, kv = sign_request(
+            node_with_secret, "POST", "/api/lesson", body
+        )
+        ok, _ = verify_request(
+            node_with_secret, "POST", "/api/lesson", body, sig, ts, kv
+        )
+        assert ok is True
+
+    def test_missing_headers_raises(self):
+        """extract_auth_headers raises on missing headers."""
+        with pytest.raises(ValueError, match="Missing HMAC"):
+            extract_auth_headers({})


### PR DESCRIPTION
## Summary

Replace raw token passing with HMAC-SHA256 signed requests for federated endpoint authentication.

Each request includes:
- `X-HMAC-Signature`: hex HMAC-SHA256 of canonical payload
- `X-HMAC-Timestamp`: Unix epoch seconds
- `X-HMAC-Key-Version`: integer for key rotation support

Canonical payload: `"{timestamp}\n{METHOD}\n{path}\n{body_sha256_hex}"`

Closes #179

## Changes

| File | Description |
|------|-------------|
| `hub/federation/hmac_auth.py` | Sign, verify, build/extract header helpers |
| `hub/federation/secrets.py` | Per-node key management (generate/get/rotate/revoke) |
| `hub/federation/registry.py` | Auto-generate secret on `add_peer`, revoke on `remove_peer` |
| `hub/federation/__init__.py` | Export new public API |
| `tests/test_hmac_auth.py` | 25 tests across 8 test classes |

## Acceptance Criteria (from #179)

- [x] HMAC-SHA256 signatures replace raw token passing
- [x] `X-HMAC-Signature` header on hub-to-node communication
- [x] Key exchange: node registration generates shared secret in `hub/federation/secrets/`
- [x] Python stdlib only — `hmac` + `hashlib`, no `cryptography` or `pyjwt`
- [x] Tests: 25 cases covering sign, verify, replay protection, key rotation, tampered body/path, unknown node, registry integration, edge cases
- [x] Does NOT modify `search_knowledge.py`
- [x] Preserves existing `hub/federation/` structure

## Test Results

```
25 passed in 0.08s
```

## Design Decisions

1. **Replay protection**: In-memory `_NonceCache` with 5-minute window. Nonce = `{timestamp}:{body_sha256}`. Thread-safe with periodic cleanup.
2. **Key storage**: JSON files per node in `hub/federation/secrets/<node_id>/key.json`. Supports version tracking for rotation.
3. **Clock skew tolerance**: `abs(now - timestamp) <= 300s` (5 minutes both directions).
4. **Constant-time comparison**: `hmac.compare_digest` prevents timing attacks.