### PR TITLE
docs: add missing status to lesson template

### DIFF
--- a/lessons/TEMPLATE.md
+++ b/lessons/TEMPLATE.md
@@ -1,6 +1,7 @@
 ---
 domain: "general"
 title: "<English Title>"
+status: "draft"
 verification: "metadata-normalized"
 {"title": "<English Title: 4-120 chars>", "domain": "<domain>", "tags": ["tag1", "tag2", "tag3"], "status": "published", "confidence": "0.9", "created": "<YYYY-MM-DD>", "updated": "<YYYY-MM-DD>", "source": "<your-source>", "verified_date": "", "domain_expert": ""}
 ---


### PR DESCRIPTION
/claim #258

## Description

Adds the missing `status: "draft"` frontmatter field to `lessons/TEMPLATE.md`.

The lesson schema requires `title`, `domain`, and `status`; the template already documents that rule later in the file but its own frontmatter was missing `status`, so validating the template directly failed.

## Type of Change

- [ ] New lesson submission
- [ ] Bug fix
- [ ] Dashboard improvement
- [x] Documentation update
- [ ] Other (please describe)

## Lessons Added (if applicable)

None.

## Validation

- [x] `PYTHONIOENCODING=utf-8 python scripts/validate_lessons.py lessons/TEMPLATE.md` -> `Total: 1 Passed: 1 Failed: 0`
- [x] `PYTHONIOENCODING=utf-8 python scripts/validate_lessons.py` -> exit 0; legacy `lessons/contrib` warnings remain non-blocking
- [x] `git diff --check`
- [x] DCO sign-off included in the commit.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes are free of hardcoded secrets or personal paths
- [x] I have tested that the changes work correctly
- [x] lessons.json has been updated if lessons were added/modified