### PR TITLE
Add Continue MisakaNet search integration

### DIFF
--- a/integrations/continue/README.md
+++ b/integrations/continue/README.md
@@ -1,0 +1,65 @@
+# Continue.dev MisakaNet Search Context Provider
+
+This integration lets Continue users search MisakaNet lessons from inside the AI
+chat panel by typing `@misaka <query>`. It returns the lesson title, score, file
+path, and a relevant snippet so the model can ground its answer in swarm
+knowledge instead of asking you to leave the editor.
+
+## What it provides
+
+- **AI-tool integration:** runs inside Continue as a custom context provider.
+- **Stable result shape:** each item includes `title`, `score`, `path`, and
+  `snippet`.
+- **Local/offline search:** uses the checked-out MisakaNet repository and the
+  existing BM25/RRF search engine.
+
+## Install
+
+1. Clone MisakaNet and install its core dependency:
+
+   ```bash
+   git clone https://github.com/Ikalus1988/MisakaNet.git ~/MisakaNet
+   cd ~/MisakaNet
+   python3 -m pip install misakanet-core
+   ```
+
+2. Copy [`config.ts`](./config.ts) into your Continue configuration, or merge the
+   `contextProviders` entry into your existing `~/.continue/config.ts`.
+
+3. If your checkout is somewhere else, update `MISAKANET_REPO` in `config.ts`.
+
+4. Restart Continue.
+
+## Usage
+
+In Continue chat, type:
+
+```text
+@misaka database locked sqlite
+```
+
+Continue will inject results like:
+
+```text
+MisakaNet search results for "database locked sqlite":
+
+1. SQLite database locked on WSL/NTFS
+   Score: 0.92
+   Path: lessons/contrib/sqlite-database-locked-wsl-ntfs.md
+   Snippet: ... move the sqlite database to the ext4 filesystem ...
+```
+
+You can then ask the assistant to apply the relevant fix in your project.
+
+## Standalone JSON helper
+
+The provider shells out to [`scripts/misaka_search_json.py`](../../scripts/misaka_search_json.py),
+which is also useful for other AI tools:
+
+```bash
+cd ~/MisakaNet
+python3 scripts/misaka_search_json.py "database locked" --top 3
+```
+
+The command prints JSON containing lesson titles, normalized scores, paths, and
+snippets.

--- a/integrations/continue/config.ts
+++ b/integrations/continue/config.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from "child_process";
+import os from "os";
+import path from "path";
+import type { ContinueConfig } from "@continuedev/config-yaml";
+
+const MISAKANET_REPO = process.env.MISAKANET_REPO ?? path.join(os.homedir(), "MisakaNet");
+const MISAKANET_SEARCH = path.join(MISAKANET_REPO, "scripts", "misaka_search_json.py");
+
+type MisakaResult = {
+  title: string;
+  score: number;
+  path: string;
+  domain?: string;
+  status?: string;
+  snippet: string;
+};
+
+function formatMisakaResults(query: string, results: MisakaResult[]): string {
+  if (!results.length) {
+    return `No MisakaNet results found for "${query}".`;
+  }
+
+  const lines = [`MisakaNet search results for "${query}":`, ""];
+  results.forEach((result, index) => {
+    const score = Math.round(result.score * 100);
+    const tags = [result.domain, result.status].filter(Boolean).join(" · ");
+    lines.push(`${index + 1}. ${result.title}`);
+    lines.push(`   Score: ${score}%${tags ? ` (${tags})` : ""}`);
+    lines.push(`   Path: ${result.path}`);
+    lines.push(`   Snippet: ${result.snippet}`);
+    lines.push("");
+  });
+  return lines.join("\n").trim();
+}
+
+const config: ContinueConfig = {
+  contextProviders: [
+    {
+      title: "misaka",
+      displayTitle: "MisakaNet Search",
+      description: "Search local MisakaNet lessons and inject title, score, path, and snippet.",
+      type: "query",
+      getContextItems: async (query: string) => {
+        const raw = execFileSync(
+          "python3",
+          [MISAKANET_SEARCH, query, "--top", "5"],
+          {
+            cwd: MISAKANET_REPO,
+            encoding: "utf8",
+            maxBuffer: 1024 * 1024,
+          },
+        );
+        const payload = JSON.parse(raw) as { results: MisakaResult[] };
+        return [
+          {
+            name: `MisakaNet: ${query}`,
+            description: "Top MisakaNet lesson matches",
+            content: formatMisakaResults(query, payload.results),
+          },
+        ];
+      },
+    },
+  ],
+};
+
+export default config;

--- a/scripts/misaka_search_json.py
+++ b/scripts/misaka_search_json.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Emit MisakaNet search results as JSON for editor/agent integrations.
+
+The regular ``search_knowledge.py`` command is optimized for humans. Integrations
+such as Continue custom context providers need stable, machine-readable records
+that include title, score, and a compact relevant snippet.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# Allow running this file directly from any working directory.
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from misakanet.search.engine import LESSONS, REFERENCES, _load_docs, _rank_docs  # noqa: E402
+
+
+def _tokens(query: str) -> list[str]:
+    return [t.lower() for t in re.findall(r"[\w\u00c0-\u024f]+|[\u4e00-\u9fff]", query)]
+
+
+def _strip_frontmatter(text: str) -> str:
+    return re.sub(r"^---\s*\n.*?\n---\s*\n", "", text, flags=re.DOTALL).strip()
+
+
+def make_snippet(content: str, query: str, max_chars: int = 260) -> str:
+    """Return a compact snippet near the first query token match."""
+    text = re.sub(r"\s+", " ", _strip_frontmatter(content)).strip()
+    if len(text) <= max_chars:
+        return text
+
+    lowered = text.lower()
+    hit = -1
+    for token in sorted(_tokens(query), key=len, reverse=True):
+        if not token:
+            continue
+        hit = lowered.find(token)
+        if hit >= 0:
+            break
+
+    if hit < 0:
+        return text[: max_chars - 1].rstrip() + "…"
+
+    start = max(0, hit - max_chars // 3)
+    end = min(len(text), start + max_chars)
+    if end - start < max_chars:
+        start = max(0, end - max_chars)
+    snippet = text[start:end].strip()
+    if start:
+        snippet = "…" + snippet
+    if end < len(text):
+        snippet += "…"
+    return snippet
+
+
+def search(query: str, top: int = 5, include_reference: bool = True) -> list[dict]:
+    """Search lessons/reference and return serializable result dictionaries."""
+    # The cache layer may print cache migration/status messages. Keep stdout pure
+    # JSON for callers that parse this command.
+    with contextlib.redirect_stdout(io.StringIO()):
+        docs = _load_docs(LESSONS, is_lesson=True)
+        if include_reference:
+            docs += _load_docs(REFERENCES, is_lesson=False)
+        ranked = _rank_docs(query, docs, titles_only=False, broad_only=False)
+
+    results = []
+    for score, doc in ranked[:top]:
+        rel_path = doc.filepath.relative_to(REPO).as_posix()
+        results.append(
+            {
+                "title": doc.title,
+                "score": round(float(score), 4),
+                "path": rel_path,
+                "domain": doc.domain,
+                "status": doc.status,
+                "source": doc.source,
+                "snippet": make_snippet(doc.content, query),
+            }
+        )
+    return results
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Search MisakaNet and emit JSON results.")
+    parser.add_argument("query", help="Search query, for example: 'database locked'")
+    parser.add_argument("--top", type=int, default=5, help="Number of results to emit (default: 5)")
+    parser.add_argument(
+        "--lessons-only",
+        action="store_true",
+        help="Search only lessons, excluding reference documents.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = {
+        "query": args.query,
+        "top": args.top,
+        "results": search(args.query, top=args.top, include_reference=not args.lessons_only),
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_misaka_search_json.py
+++ b/tests/test_misaka_search_json.py
@@ -1,0 +1,56 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import misaka_search_json
+
+
+class TestMisakaSearchJson(unittest.TestCase):
+    def test_make_snippet_prefers_query_match(self):
+        content = "---\ntitle: Example\n---\n" + "prefix " * 40 + "sqlite database locked fix " + "suffix " * 40
+
+        snippet = misaka_search_json.make_snippet(content, "database locked", max_chars=120)
+
+        self.assertIn("database locked", snippet)
+        self.assertLessEqual(len(snippet), 122)  # allow leading/trailing ellipses
+
+    def test_search_returns_title_score_path_and_snippet(self):
+        results = misaka_search_json.search("pip install", top=2, include_reference=False)
+
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertIsInstance(result["title"], str)
+            self.assertIsInstance(result["score"], float)
+            self.assertIsInstance(result["path"], str)
+            self.assertIsInstance(result["snippet"], str)
+            self.assertTrue(result["title"])
+            self.assertTrue(result["path"].startswith("lessons/"))
+            self.assertTrue(result["snippet"])
+
+    def test_main_emits_parseable_json(self):
+        # Exercise the CLI code path with a small top-k and parse the same payload
+        # Continue consumes from stdout.
+        import io
+        import contextlib
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = misaka_search_json.main(["pip install", "--top", "1", "--lessons-only"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["query"], "pip install")
+        self.assertEqual(payload["top"], 1)
+        self.assertEqual(len(payload["results"]), 1)
+        self.assertIn("title", payload["results"][0])
+        self.assertIn("score", payload["results"][0])
+        self.assertIn("snippet", payload["results"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Continue.dev custom context provider for `@misaka <query>` inside AI chat
- add `scripts/misaka_search_json.py` for machine-readable MisakaNet search results with title, score, path, and snippet
- document installation and standalone usage for the integration

/claim #268

## Verification
- `python3 scripts/misaka_search_json.py "database locked" --top 2 > /tmp/misaka-json-output.json`
- `python3 -m json.tool /tmp/misaka-json-output.json > /tmp/misaka-json-check.json`
- `python3 -m pytest -q tests/test_misaka_search_json.py tests/test_search_knowledge_stdout.py tests/test_search_edge_cases.py` (31 passed)
- `git diff --check`
