### PR TITLE
feat: add "This helped me" button to lesson search results (#218)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1452,6 +1452,31 @@
     .agent-selector { grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); }
     .register-form { padding: 20px 16px; }
   }
+
+  /* "This helped me" button */
+  .helpful-btn {
+    background: transparent;
+    color: var(--text-dim);
+    border: 1px solid rgba(0, 229, 255, 0.15);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 10px;
+    cursor: pointer;
+    transition: all 0.15s;
+    font-family: inherit;
+  }
+  .helpful-btn:hover:not(:disabled) {
+    border-color: var(--cyan-dim);
+    color: var(--cyan);
+  }
+  .helpful-btn:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+  .helpful-btn.voted {
+    color: var(--green);
+    border-color: rgba(34, 197, 94, 0.3);
+  }
 </style>
 </head>
 <body>
@@ -2062,6 +2087,9 @@ function searchLessons() {
     const safeSummary = DOMPurify.sanitize((l.summary || '').slice(0, 80));
     const safeDomain = DOMPurify.sanitize(l.domain || '');
     const safeTags = DOMPurify.sanitize((l.tags || []).slice(0, 3).join(', '));
+    const safeId = DOMPurify.sanitize(l.id || '').replace(/'/g, '');
+    const votedClass = hasVoted(safeId) ? ' voted' : '';
+    const votedDisabled = hasVoted(safeId) ? 'disabled' : '';
     return `<div style="padding:8px 12px;border-bottom:1px solid #21262d;cursor:pointer;transition:background 0.15s;"
            onmouseover="this.style.background='#161b22'"
            onmouseout="this.style.background=''"
@@ -2069,8 +2097,13 @@ function searchLessons() {
         <div style="font-size:13px;color:#58a6ff;">${safeTitle}</div>
         <div style="font-size:11px;color:#8b949e;margin-top:2px;">${safeSummary}</div>
         <div style="font-size:10px;color:#484f58;margin-top:1px;">${safeDomain} · ${safeTags}</div>
+        <button class="helpful-btn${votedClass}" data-lesson="${safeId}" ${votedDisabled} onclick="event.stopPropagation();handleHelpfulClick('${safeId}', this)">This helped me</button>
       </div>`;
   }).join("");
+  // Load helpful counts for each result button
+  container.querySelectorAll('.helpful-btn').forEach(btn => {
+    loadHelpfulCount(btn.getAttribute('data-lesson'), btn);
+  });
 }
 
 // ── Request collapsing: reuse in-flight promise for same URL ──
@@ -2108,6 +2141,89 @@ const fetchJSON = (url) => {
   _pendingPromises.set(url, p);
   return p;
 };
+
+// ── POST helper (same timeout/error pattern as fetchWithTimeout) ──
+async function fetchPOST(url, body, timeoutMs = 8000) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await fetch(url, {
+      method: 'POST',
+      signal: ctrl.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    clearTimeout(timer);
+    if (r.status === 429) {
+      const retryAfter = r.headers.get('Retry-After');
+      if (DEBUG) console.log(`[MisakaNet] 429 rate limited on POST ${url}, retry after ${retryAfter || '?'}s`);
+      throw new Error(`HTTP 429${retryAfter ? ` (retry after ${retryAfter}s)` : ''}`);
+    }
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    if (DEBUG) console.log(`[MisakaNet] POST ${url} (${r.status})`);
+    return r.json();
+  } catch(e) {
+    clearTimeout(timer);
+    if (e.name === 'AbortError') {
+      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    }
+    throw e;
+  }
+}
+
+// ── "This helped me" helpful vote system ──
+const HELPFUL_STORAGE_KEY = 'misaka_helpful_voted';
+
+function getVotedLessons() {
+  try {
+    return JSON.parse(localStorage.getItem(HELPFUL_STORAGE_KEY) || '[]');
+  } catch { return []; }
+}
+
+function hasVoted(lessonId) {
+  return getVotedLessons().includes(lessonId);
+}
+
+function markVoted(lessonId) {
+  const voted = getVotedLessons();
+  if (!voted.includes(lessonId)) {
+    voted.push(lessonId);
+    try { localStorage.setItem(HELPFUL_STORAGE_KEY, JSON.stringify(voted)); } catch {}
+  }
+}
+
+async function handleHelpfulClick(lessonId, btnEl) {
+  if (hasVoted(lessonId)) return;
+  btnEl.disabled = true;
+  btnEl.textContent = '...';
+  try {
+    const result = await fetchPOST(getHelpfulUrl(), { lesson_id: lessonId });
+    markVoted(lessonId);
+    const count = result.count || 0;
+    btnEl.textContent = `♥ ${count} found helpful`;
+    btnEl.classList.add('voted');
+  } catch (e) {
+    btnEl.disabled = false;
+    btnEl.textContent = 'This helped me';
+    if (DEBUG) console.log(`[MisakaNet] helpful vote failed: ${e.message}`);
+  }
+}
+
+async function loadHelpfulCount(lessonId, btnEl) {
+  if (!lessonId) return;
+  try {
+    const url = `${getHelpfulUrl()}?lesson_id=${encodeURIComponent(lessonId)}`;
+    const result = await fetchJSON(url);
+    const count = result.count || 0;
+    if (hasVoted(lessonId)) {
+      btnEl.textContent = `♥ ${count} found helpful`;
+      btnEl.classList.add('voted');
+      btnEl.disabled = true;
+    } else if (count > 0) {
+      btnEl.textContent = `♥ ${count} found helpful`;
+    }
+  } catch { /* silently fail — count is non-critical */ }
+}
 
 // ── Counter animation ──
 function animateCounter(el, target, duration = 800) {
@@ -2231,6 +2347,10 @@ function getCounterUrl() {
 /** 返回 lessons 数据 URL：同域 /api/lessons（WORKER_BASE 已切换为同域模式） */
 function getLessonsUrl() {
   return WORKER_BASE ? `${WORKER_BASE}/api/lessons` : `/api/lessons`;
+}
+/** 返回 helpful vote API URL：同域 /api/helpful */
+function getHelpfulUrl() {
+  return WORKER_BASE ? `${WORKER_BASE}/api/helpful` : `/api/helpful`;
 }
 
 async function loadStats() {

--- a/tests/test_helpful_button.py
+++ b/tests/test_helpful_button.py
@@ -1,0 +1,107 @@
+"""Tests for the 'This helped me' helpful button feature (Issue #218).
+
+Validates that the frontend and worker code contain the required elements
+for the helpful vote system: button in search results, POST endpoint,
+localStorage dedup, and count display.
+"""
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestHelpfulButtonFrontend(unittest.TestCase):
+    """Verify docs/index.html contains the helpful button implementation."""
+
+    def setUp(self):
+        self.html = (REPO_ROOT / "docs" / "index.html").read_text()
+
+    def test_helpful_button_css_exists(self):
+        """CSS class .helpful-btn is defined."""
+        self.assertIn(".helpful-btn", self.html)
+
+    def test_helpful_button_in_search_results(self):
+        """Search results template includes a helpful button."""
+        self.assertIn("helpful-btn", self.html)
+        self.assertIn("handleHelpfulClick", self.html)
+
+    def test_helpful_url_helper_exists(self):
+        """getHelpfulUrl() function is defined."""
+        self.assertIn("function getHelpfulUrl()", self.html)
+
+    def test_fetch_post_function_exists(self):
+        """fetchPOST helper follows the same timeout pattern as fetchWithTimeout."""
+        self.assertIn("async function fetchPOST(", self.html)
+
+    def test_localstorage_dedup_exists(self):
+        """localStorage-based dedup prevents duplicate votes."""
+        self.assertIn("HELPFUL_STORAGE_KEY", self.html)
+        self.assertIn("function hasVoted(", self.html)
+        self.assertIn("function markVoted(", self.html)
+
+    def test_load_helpful_count_exists(self):
+        """loadHelpfulCount fetches and displays existing counts."""
+        self.assertIn("function loadHelpfulCount(", self.html)
+
+    def test_count_display_format(self):
+        """Count is displayed in 'N found helpful' format."""
+        self.assertIn("found helpful", self.html)
+
+    def test_event_stop_propagation_on_button(self):
+        """Button click does not trigger parent div's onclick (opens new window)."""
+        self.assertIn("event.stopPropagation()", self.html)
+
+    def test_no_external_dependencies(self):
+        """No npm imports or external JS module imports for helpful feature."""
+        # The helpful button code section should not import external modules
+        helpful_section_start = self.html.find("HELPFUL_STORAGE_KEY")
+        helpful_section_end = self.html.find("// ── Counter animation")
+        if helpful_section_start >= 0 and helpful_section_end >= 0:
+            section = self.html[helpful_section_start:helpful_section_end]
+            self.assertNotIn("import ", section)
+            self.assertNotIn("require(", section)
+
+
+class TestHelpfulButtonWorker(unittest.TestCase):
+    """Verify workers/register-proxy.js contains the helpful API endpoint."""
+
+    def setUp(self):
+        self.js = (REPO_ROOT / "workers" / "register-proxy.js").read_text()
+
+    def test_get_helpful_endpoint_exists(self):
+        """GET /api/helpful returns count for a lesson_id."""
+        self.assertIn('case "/api/helpful"', self.js)
+
+    def test_post_helpful_endpoint_exists(self):
+        """POST /api/helpful increments count for a lesson_id."""
+        self.assertIn('url.pathname === "/api/helpful"', self.js)
+
+    def test_handle_helpful_vote_function_exists(self):
+        """handleHelpfulVote function processes POST requests."""
+        self.assertIn("async function handleHelpfulVote(", self.js)
+
+    def test_kv_key_format(self):
+        """Votes are stored in KV with 'helpful:{lesson_id}' key format."""
+        self.assertIn("helpful:${lessonId}", self.js)
+
+    def test_kv_count_increment(self):
+        """POST handler reads current count and increments by 1."""
+        self.assertIn("current + 1", self.js)
+
+    def test_input_sanitization(self):
+        """lesson_id is sanitized to prevent injection."""
+        self.assertIn("sanitizeIdentifier(body.lesson_id", self.js)
+
+    def test_error_handling_for_missing_kv(self):
+        """Returns 503 when KV is not configured."""
+        self.assertIn('"KV not configured"', self.js)
+
+    def test_cors_headers_on_helpful(self):
+        """Helpful endpoint responses include CORS headers."""
+        # jsonResponse already includes CORS_HEADERS, verify it's used
+        self.assertIn("CORS_HEADERS", self.js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workers/register-proxy.js
+++ b/workers/register-proxy.js
@@ -146,6 +146,22 @@ async function handleApiRequest(pathWithQuery, env) {
         timestamp: new Date().toISOString(),
       });
 
+    case "/api/helpful": {
+      // GET /api/helpful?lesson_id=<id> — return helpful count for a lesson
+      if (!env.MISAKANET_KV) {
+        return jsonResponse({ error: "KV not configured" }, 503);
+      }
+      const params = new URLSearchParams(search);
+      const lessonId = sanitizeIdentifier(params.get("lesson_id"), 100);
+      if (!lessonId) {
+        return jsonResponse({ error: "Missing lesson_id" }, 400);
+      }
+      const kvKey = `helpful:${lessonId}`;
+      const raw = await env.MISAKANET_KV.get(kvKey, "text");
+      const count = raw ? parseInt(raw, 10) || 0 : 0;
+      return jsonResponse({ lesson_id: lessonId, count });
+    }
+
     default:
       // 通用 GitHub API 代理: /api/github/* → api.github.com/*
       if (pathname.startsWith("/api/github/")) {
@@ -342,6 +358,41 @@ async function handleRegistration(request, env) {
   });
 }
 
+// ── "This helped me" 投票处理 ──
+async function handleHelpfulVote(request, env) {
+  if (!env.MISAKANET_KV) {
+    return jsonResponse({ error: "KV not configured" }, 503);
+  }
+
+  // 解析请求体
+  let body;
+  try {
+    if (parseInt(request.headers.get("content-length") || "0") > 10000) {
+      return jsonResponse({ error: "Request too large" }, 413);
+    }
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  const lessonId = sanitizeIdentifier(body.lesson_id, 100);
+  if (!lessonId) {
+    return jsonResponse({ error: "Missing or invalid lesson_id" }, 400);
+  }
+
+  const kvKey = `helpful:${lessonId}`;
+  try {
+    const raw = await env.MISAKANET_KV.get(kvKey, "text");
+    const current = raw ? parseInt(raw, 10) || 0 : 0;
+    const newCount = current + 1;
+    await env.MISAKANET_KV.put(kvKey, String(newCount));
+    return jsonResponse({ lesson_id: lessonId, count: newCount });
+  } catch (err) {
+    console.error("helpful vote failed:", err.message);
+    return jsonResponse({ error: "Failed to record vote" }, 500);
+  }
+}
+
 // ── 主入口 (仅 API + 注册，静态文件由 Cloudflare Pages 独立服务) ──
 export default {
   async fetch(request, env) {
@@ -365,6 +416,11 @@ export default {
     // POST / 或 POST /api/register — 注册
     if (request.method === "POST" && (url.pathname === "/" || url.pathname === "/api/register")) {
       return await handleRegistration(request, env);
+    }
+
+    // POST /api/helpful — "This helped me" vote
+    if (request.method === "POST" && url.pathname === "/api/helpful") {
+      return await handleHelpfulVote(request, env);
     }
 
     // GET /ping — 保持 Worker 热实例


### PR DESCRIPTION
## Description

Implements the "This helped me" helpful button on lesson search results as specified in issue #218.

### Frontend (docs/index.html)
- **CSS**: Added  class with hover and voted states (uses existing CSS variables)
- **URL helper**:  follows the same pattern as  / 
- **POST helper**:  follows the same timeout/error pattern as  (8s timeout, 429 Retry-After parsing, AbortController)
- **localStorage dedup**:  stores voted lesson IDs;  /  manage the list
- **Click handler**:  POSTs to , updates button text to show count, marks as voted
- **Count loader**:  fetches existing count via  (through the unified gateway, per guardrails)
- **Search results**: Each result now includes a helpful button with  to prevent triggering the parent div onclick
- **Post-render**: After rendering search results, loads helpful counts for all buttons

### Backend (workers/register-proxy.js)
- **GET /api/helpful?lesson_id=\<id\>**: Returns  from Cloudflare KV
- **POST /api/helpful**: Accepts , increments count in KV at key , returns new count
- **Input sanitization**: Reuses existing  to prevent injection
- **Error handling**: Returns 503 if KV not configured, 400 for missing/invalid lesson_id, 500 for KV errors
- **CORS**: Uses existing  which includes 

### Tests (tests/test_helpful_button.py)
- 17 tests validating frontend elements, worker endpoints, and acceptance criteria

## Type of Change

- [x] Dashboard improvement

## Acceptance Criteria (from issue #218)
- [x] Button appears on each search result
- [x] Click increments count (localStorage dedup)
- [x] Count displayed: "N found helpful"
- [x] No external dependencies (pure JS + KV)
- [x] Fork required | DCO sign-off

## Frontend Architecture Guardrails Compliance
- [x] No npm install — pure vanilla JS, native Web APIs only
- [x] Network goes through unified gateway — uses  for GET counts,  (same timeout pattern) for POST votes
- [x] No data mutations outside safeFetchLessons validation whitelist — helpful counts are separate from lesson data

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes are free of hardcoded secrets or personal paths
- [x] I have tested that the changes work correctly
- [x] Every commit has  trailer (DCO)

**Node ID**: andrianbalanesq

Closes #218