### PR TITLE
Fix leaderboard top-change notifications

### DIFF
--- a/scripts/leaderboard_watch.py
+++ b/scripts/leaderboard_watch.py
@@ -32,6 +32,7 @@ DRY_RUN = "--dry-run" in sys.argv
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LESSONS_DIR = REPO_ROOT / "lessons"
 LEADERBOARD_FILE = REPO_ROOT / "data" / "leaderboard.json"
+LEADERBOARD_META_FILE = REPO_ROOT / "data" / "leaderboard_meta.json"
 
 GRAPHQL_QUERY = """
 query($owner: String!, $repo: String!, $cursor: String) {
@@ -212,11 +213,49 @@ def load_previous_leaderboard():
     return None
 
 
+def atomic_write_json(path: Path, data):
+    """Write JSON through a temp file so readers never see partial data."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def leaderboard_top(leaderboard):
+    if not leaderboard:
+        return None
+    top = leaderboard[0]
+    return {
+        "login": top["login"],
+        "score": top["score"],
+    }
+
+
 def save_leaderboard(data):
     """保存排行榜快照"""
-    LEADERBOARD_FILE.parent.mkdir(parents=True, exist_ok=True)
-    json.dump(data, LEADERBOARD_FILE.open("w"), indent=2)
+    atomic_write_json(LEADERBOARD_FILE, data)
     print(f"  Leaderboard saved to {LEADERBOARD_FILE}")
+
+
+def save_leaderboard_meta(current, previous, issue_created):
+    """Persist the latest top contributor transition for the next workflow run."""
+    meta = {
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "current_top": leaderboard_top(current),
+        "previous_top": leaderboard_top(previous) if previous else None,
+        "issue_created": bool(issue_created),
+    }
+    atomic_write_json(LEADERBOARD_META_FILE, meta)
+    print(f"  Leaderboard metadata saved to {LEADERBOARD_META_FILE}")
+
+
+def has_leader_changed(previous, current):
+    """Return True only when the #1 contributor login changes."""
+    if not current:
+        return False
+    if not previous:
+        return True
+    return previous[0]["login"] != current[0]["login"]
 
 
 def create_notification_issue(new_top, old_top, changed):
@@ -298,21 +337,20 @@ def main():
         print("  No previous leaderboard found (first run)")
 
     # 3. 对比
-    changed = previous is None or (
-        previous[0]["login"] != current[0]["login"] and
-        abs(previous[0]["score"] - current[0]["score"]) > 0.5
-    )
+    changed = has_leader_changed(previous, current)
 
+    issue_created = False
     if changed:
         print(f"\n🔔 Leaderboard changed! Creating notification...")
         old_top = previous[0] if previous else None
         new_top = current[0]
-        create_notification_issue(new_top, old_top, current)
+        issue_created = create_notification_issue(new_top, old_top, current)
     else:
         print(f"\n✅ Leaderboard unchanged. No notification needed.")
 
     # 4. 保存新快照
     save_leaderboard(current)
+    save_leaderboard_meta(current, previous, issue_created)
     print("\nDone.")
 
 

--- a/tests/test_leaderboard_watch.py
+++ b/tests/test_leaderboard_watch.py
@@ -1,0 +1,53 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import leaderboard_watch
+
+
+class LeaderboardWatchTests(unittest.TestCase):
+    def test_has_leader_changed_tracks_login_only(self):
+        previous = [{"login": "alice", "score": 10.0}]
+
+        self.assertTrue(leaderboard_watch.has_leader_changed(None, previous))
+        self.assertFalse(
+            leaderboard_watch.has_leader_changed(previous, [{"login": "alice", "score": 4.0}])
+        )
+        self.assertTrue(
+            leaderboard_watch.has_leader_changed(previous, [{"login": "bob", "score": 10.1}])
+        )
+
+    def test_save_leaderboard_writes_snapshot_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "leaderboard.json"
+            leaderboard_watch.atomic_write_json(target, [{"login": "alice", "score": 1.5}])
+
+            self.assertEqual(json.loads(target.read_text(encoding="utf-8"))[0]["login"], "alice")
+            self.assertFalse(target.with_suffix(".json.tmp").exists())
+
+    def test_save_leaderboard_meta_records_previous_and_current_top(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_meta_file = leaderboard_watch.LEADERBOARD_META_FILE
+            leaderboard_watch.LEADERBOARD_META_FILE = Path(tmp) / "leaderboard_meta.json"
+            try:
+                leaderboard_watch.save_leaderboard_meta(
+                    [{"login": "bob", "score": 2.0}],
+                    [{"login": "alice", "score": 1.0}],
+                    True,
+                )
+
+                meta = json.loads(
+                    leaderboard_watch.LEADERBOARD_META_FILE.read_text(encoding="utf-8")
+                )
+            finally:
+                leaderboard_watch.LEADERBOARD_META_FILE = old_meta_file
+
+        self.assertEqual(meta["current_top"], {"login": "bob", "score": 2.0})
+        self.assertEqual(meta["previous_top"], {"login": "alice", "score": 1.0})
+        self.assertTrue(meta["issue_created"])
+        self.assertIn("updated_at", meta)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the leaderboard watcher so every #1 contributor login change creates the notification issue and each run stores metadata about the latest top-contributor transition.

Fixes #219.

## Changes

- Compare the top contributor by login only, without suppressing small score-delta changes.
- Save `data/leaderboard.json` through an atomic temp-file replacement.
- Add `data/leaderboard_meta.json` generation with current top, previous top, timestamp, and issue-created status.
- Add focused unit tests for top-change detection, atomic writes, and metadata output.

## Testing

- `python -m unittest tests.test_leaderboard_watch -v`
- `GH_TOKEN=<token> PYTHONIOENCODING=utf-8 python scripts/leaderboard_watch.py --dry-run`