### PR TITLE
fix(lessons): convert bare JSON to YAML frontmatter on20 files

### DIFF
--- a/lessons/contrib/fanuc-auto-abort-on-fault-restart.md
+++ b/lessons/contrib/fanuc-auto-abort-on-fault-restart.md
@@ -1,4 +1,15 @@
-{"title": "FANUC Auto Abort on Fault — Restart $SHELL_WRK Program", "domain": "fanuc", "subdomain": "error-handling", "tags": ["abort", "fault", "restart", "shell-wrk", "bg-logic", "error-severity", "auto-recovery"], "source": "robot-forum.com", "status": "published", "confidence": "0.8", "created": "2026-07-01", "verified_date": "", "domain_expert": "pdl"}
+---
+title: "FANUC Auto Abort on Fault — Restart $SHELL_WRK Program"
+domain: "fanuc"
+subdomain: "error-handling"
+tags: ["abort", "fault", "restart", "shell-wrk", "bg-logic", "error-severity", "auto-recovery"]
+source: "robot-forum.com"
+status: "published"
+confidence: "0.8"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: "pdl"
+---
 
 
 ## Problem

--- a/lessons/contrib/fanuc-do-not-found-in-program-reference-position.md
+++ b/lessons/contrib/fanuc-do-not-found-in-program-reference-position.md
@@ -1,4 +1,15 @@
-{"title": "FANUC DO Not Found in Program — Check Reference Position", "domain": "fanuc", "subdomain": "troubleshooting", "tags": ["do", "digital-output", "reference-position", "background-logic", "space-function", "search"], "source": "robot-forum.com", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": "Nation"}
+---
+title: "FANUC DO Not Found in Program — Check Reference Position"
+domain: "fanuc"
+subdomain: "troubleshooting"
+tags: ["do", "digital-output", "reference-position", "background-logic", "space-function", "search"]
+source: "robot-forum.com"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: "Nation"
+---
 
 
 ## Problem

--- a/lessons/contrib/fanuc-intp-102-detect-joint-olp-whitespace.md
+++ b/lessons/contrib/fanuc-intp-102-detect-joint-olp-whitespace.md
@@ -1,4 +1,15 @@
-{"title": "FANUC INTP-102 DETECT JOINT — OLP Whitespace Bug", "domain": "fanuc", "subdomain": "olp", "tags": ["intp-102", "detect-joint", "olp", "robodk", "ls-format", "whitespace", "arc-sensor"], "source": "robot-forum.com", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "FANUC INTP-102 DETECT JOINT — OLP Whitespace Bug"
+domain: "fanuc"
+subdomain: "olp"
+tags: ["intp-102", "detect-joint", "olp", "robodk", "ls-format", "whitespace", "arc-sensor"]
+source: "robot-forum.com"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-10-microservices-latency-math.md
+++ b/lessons/contrib/lesson-10-microservices-latency-math.md
@@ -1,4 +1,15 @@
-{"title": "微服务延迟成本分析 — 何时不该用微服务", "domain": "ops", "subdomain": "architecture", "tags": ["microservices", "architecture", "latency", "performance", "monolith"], "source": "dev.to", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "微服务延迟成本分析 — 何时不该用微服务"
+domain: "ops"
+subdomain: "architecture"
+tags: ["microservices", "architecture", "latency", "performance", "monolith"]
+source: "dev.to"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-11-github-commit-signing.md
+++ b/lessons/contrib/lesson-11-github-commit-signing.md
@@ -1,4 +1,15 @@
-{"title": "GitHub Commit Signing — GPG 防止提交伪造", "domain": "ops", "subdomain": "security", "tags": ["git", "github", "gpg", "security", "commit-signing", "impersonation"], "source": "dev.to", "status": "published", "confidence": "0.95", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "GitHub Commit Signing — GPG 防止提交伪造"
+domain: "ops"
+subdomain: "security"
+tags: ["git", "github", "gpg", "security", "commit-signing", "impersonation"]
+source: "dev.to"
+status: "published"
+confidence: "0.95"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-13-aws-lambda-microvms.md
+++ b/lessons/contrib/lesson-13-aws-lambda-microvms.md
@@ -1,4 +1,15 @@
-{"title": "AWS Lambda MicroVMs — 隔离沙箱与 Firecracker", "domain": "ops", "subdomain": "serverless", "tags": ["aws", "lambda", "microvm", "firecracker", "sandbox", "isolation"], "source": "aws.amazon.com/blogs", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "AWS Lambda MicroVMs — 隔离沙箱与 Firecracker"
+domain: "ops"
+subdomain: "serverless"
+tags: ["aws", "lambda", "microvm", "firecracker", "sandbox", "isolation"]
+source: "aws.amazon.com/blogs"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-14-api-pagination-design.md
+++ b/lessons/contrib/lesson-14-api-pagination-design.md
@@ -1,4 +1,15 @@
-{"title": "API 分页设计 — Cursor vs Offset vs Keyset", "domain": "ops", "subdomain": "api", "tags": ["api", "pagination", "cursor", "offset", "keyset", "design"], "source": "solovyov.net", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "API 分页设计 — Cursor vs Offset vs Keyset"
+domain: "ops"
+subdomain: "api"
+tags: ["api", "pagination", "cursor", "offset", "keyset", "design"]
+source: "solovyov.net"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-15-cloudflare-workflows-durable.md
+++ b/lessons/contrib/lesson-15-cloudflare-workflows-durable.md
@@ -1,4 +1,15 @@
-{"title": "Cloudflare Workflows — 持久化多步骤执行", "domain": "ops", "subdomain": "workflow", "tags": ["cloudflare", "workflows", "durable", "serverless", "state-machine"], "source": "blog.cloudflare.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "Cloudflare Workflows — 持久化多步骤执行"
+domain: "ops"
+subdomain: "workflow"
+tags: ["cloudflare", "workflows", "durable", "serverless", "state-machine"]
+source: "blog.cloudflare.com"
+status: "published"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-16-aws-ecs-high-resolution-metrics.md
+++ b/lessons/contrib/lesson-16-aws-ecs-high-resolution-metrics.md
@@ -1,4 +1,15 @@
-{"title": "AWS ECS 高分辨率指标 — 更快的自动扩缩容", "domain": "ops", "subdomain": "kubernetes", "tags": ["aws", "ecs", "metrics", "auto-scaling", "monitoring"], "source": "aws.amazon.com/blogs", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "AWS ECS 高分辨率指标 — 更快的自动扩缩容"
+domain: "ops"
+subdomain: "kubernetes"
+tags: ["aws", "ecs", "metrics", "auto-scaling", "monitoring"]
+source: "aws.amazon.com/blogs"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-17-segmentfault-mcp-standardization.md
+++ b/lessons/contrib/lesson-17-segmentfault-mcp-standardization.md
@@ -1,4 +1,15 @@
-{"title": "MCP — AI Agent 工具调用标准化协议", "domain": "mcp", "subdomain": "standardization", "tags": ["mcp", "agent", "tool-calling", "standardization", "protocol"], "source": "segmentfault.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "MCP — AI Agent 工具调用标准化协议"
+domain: "mcp"
+subdomain: "standardization"
+tags: ["mcp", "agent", "tool-calling", "standardization", "protocol"]
+source: "segmentfault.com"
+status: "published"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-18-database-performance-indexing.md
+++ b/lessons/contrib/lesson-18-database-performance-indexing.md
@@ -1,4 +1,15 @@
-{"title": "数据库性能 — 索引与查询优化实践", "domain": "ops", "subdomain": "database", "tags": ["database", "postgresql", "indexing", "performance", "query-optimization"], "source": "practical-experience", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "数据库性能 — 索引与查询优化实践"
+domain: "ops"
+subdomain: "database"
+tags: ["database", "postgresql", "indexing", "performance", "query-optimization"]
+source: "practical-experience"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-19-grpc-openapi-rest-comparison.md
+++ b/lessons/contrib/lesson-19-grpc-openapi-rest-comparison.md
@@ -1,4 +1,15 @@
-{"title": "gRPC vs OpenAPI vs REST — API 协议选择指南", "domain": "ops", "subdomain": "api", "tags": ["grpc", "openapi", "rest", "api", "protocol", "architecture"], "source": "cloud.google.com/blog", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "gRPC vs OpenAPI vs REST — API 协议选择指南"
+domain: "ops"
+subdomain: "api"
+tags: ["grpc", "openapi", "rest", "api", "protocol", "architecture"]
+source: "cloud.google.com/blog"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-20-api-design-principles.md
+++ b/lessons/contrib/lesson-20-api-design-principles.md
@@ -1,4 +1,15 @@
-{"title": "API 设计原则 — 无抽象、一致性、幂等性", "domain": "ops", "subdomain": "api", "tags": ["api", "design", "principles", "rest", "consistency"], "source": "increase.com/articles", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "API 设计原则 — 无抽象、一致性、幂等性"
+domain: "ops"
+subdomain: "api"
+tags: ["api", "design", "principles", "rest", "consistency"]
+source: "increase.com/articles"
+status: "published"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-9-redis-postgresql-replacement.md
+++ b/lessons/contrib/lesson-9-redis-postgresql-replacement.md
@@ -1,4 +1,15 @@
-{"title": "Redis → PostgreSQL 替换 — 缓存/PubSub/队列统一", "domain": "ops", "subdomain": "database", "tags": ["redis", "postgresql", "caching", "pubsub", "database", "performance"], "source": "dev.to", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "Redis → PostgreSQL 替换 — 缓存/PubSub/队列统一"
+domain: "ops"
+subdomain: "database"
+tags: ["redis", "postgresql", "caching", "pubsub", "database", "performance"]
+source: "dev.to"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-review-3-devops-platform-engineering.md
+++ b/lessons/contrib/lesson-review-3-devops-platform-engineering.md
@@ -1,4 +1,15 @@
-{"title": "DevOps Platform Engineering — Golden Paths to Reduce Cognitive Load", "domain": "ops", "subdomain": "devops", "tags": ["devops", "platform-engineering", "golden-paths", "cognitive-load", "idp"], "source": "dev.to", "status": "published", "confidence": "0.8", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "DevOps Platform Engineering — Golden Paths to Reduce Cognitive Load"
+domain: "ops"
+subdomain: "devops"
+tags: ["devops", "platform-engineering", "golden-paths", "cognitive-load", "idp"]
+source: "dev.to"
+status: "published"
+confidence: "0.8"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-review-4-mcp-bedrock-integration.md
+++ b/lessons/contrib/lesson-review-4-mcp-bedrock-integration.md
@@ -1,4 +1,15 @@
-{"title": "MCP 协议 + Bedrock 实战 — Agent 外部工具调用标准化", "domain": "mcp", "subdomain": "integration", "tags": ["mcp", "bedrock", "aws", "agent", "tool-calling", "standardization"], "source": "segmentfault.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "MCP 协议 + Bedrock 实战 — Agent 外部工具调用标准化"
+domain: "mcp"
+subdomain: "integration"
+tags: ["mcp", "bedrock", "aws", "agent", "tool-calling", "standardization"]
+source: "segmentfault.com"
+status: "published"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-review-5-eks-version-rollback.md
+++ b/lessons/contrib/lesson-review-5-eks-version-rollback.md
@@ -1,4 +1,15 @@
-{"title": "EKS Kubernetes 版本回滚 — 安全升级集群", "domain": "ops", "subdomain": "kubernetes", "tags": ["kubernetes", "eks", "aws", "upgrade", "rollback", "cluster-management"], "source": "aws.amazon.com/blogs", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "EKS Kubernetes 版本回滚 — 安全升级集群"
+domain: "ops"
+subdomain: "kubernetes"
+tags: ["kubernetes", "eks", "aws", "upgrade", "rollback", "cluster-management"]
+source: "aws.amazon.com/blogs"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-review-6-cloudflare-x402-monetization.md
+++ b/lessons/contrib/lesson-review-6-cloudflare-x402-monetization.md
@@ -1,4 +1,15 @@
-{"title": "Cloudflare Monetization Gateway — x402 API 支付协议", "domain": "ops", "subdomain": "api", "tags": ["cloudflare", "x402", "api", "monetization", "payment", "mcp"], "source": "blog.cloudflare.com", "status": "published", "confidence": "0.8", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "Cloudflare Monetization Gateway — x402 API 支付协议"
+domain: "ops"
+subdomain: "api"
+tags: ["cloudflare", "x402", "api", "monetization", "payment", "mcp"]
+source: "blog.cloudflare.com"
+status: "published"
+confidence: "0.8"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-review-7-cloudflare-saga-rollbacks.md
+++ b/lessons/contrib/lesson-review-7-cloudflare-saga-rollbacks.md
@@ -1,4 +1,15 @@
-{"title": "Cloudflare Workflows Saga Rollback — Durable Multi-Step Compensation", "domain": "ops", "subdomain": "workflow", "tags": ["cloudflare", "workflows", "saga", "rollback", "durable", "compensation"], "source": "blog.cloudflare.com", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "Cloudflare Workflows Saga Rollback — Durable Multi-Step Compensation"
+domain: "ops"
+subdomain: "workflow"
+tags: ["cloudflare", "workflows", "saga", "rollback", "durable", "compensation"]
+source: "blog.cloudflare.com"
+status: "published"
+confidence: "0.9"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem

--- a/lessons/contrib/lesson-review-8-cloudflare-ai-traffic-options.md
+++ b/lessons/contrib/lesson-review-8-cloudflare-ai-traffic-options.md
@@ -1,4 +1,15 @@
-{"title": "Cloudflare AI Traffic Options — Content Monetization for the Agentic Internet", "domain": "ops", "subdomain": "api", "tags": ["cloudflare", "ai", "monetization", "crawling", "pay-per-crawl", "content"], "source": "blog.cloudflare.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: "Cloudflare AI Traffic Options — Content Monetization for the Agentic Internet"
+domain: "ops"
+subdomain: "api"
+tags: ["cloudflare", "ai", "monetization", "crawling", "pay-per-crawl", "content"]
+source: "blog.cloudflare.com"
+status: "published"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 
 ## Problem


### PR DESCRIPTION
## Summary\n\nBatch 1 of legacy lesson schema cleanup. Convert line-1 JSON metadata objects to proper YAML frontmatter on20 files.\n\n### Files changed\n\n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n- \n\n### What changed\n\nEach file had a bare JSON object on line 1 (not wrapped in ). Converted to proper YAML frontmatter with title, domain, tags, status, source fields.\n\n### Verification\n\n- All files now start with  on line 1\n- Body content unchanged\n- DCO signed\n\nCo-Authored-By: Claude <noreply@anthropic.com>