### PR TITLE
fix: resolve relative paths in validate_lessons.py

### DIFF
--- a/data/leaderboard.json
+++ b/data/leaderboard.json
@@ -1,31 +1,31 @@
 [
   {
     "login": "misakanet-bot",
-    "score": 86.2
+    "score": 87.06
   },
   {
     "login": "ikalus1988",
-    "score": 81.14
+    "score": 80.84
   },
   {
     "login": "claude",
-    "score": 46.94
+    "score": 46.68
   },
   {
     "login": "sheldonisspark-lab",
-    "score": 15.91
+    "score": 18.91
   },
   {
     "login": "zsxh1990",
-    "score": 8.19
+    "score": 8.13
   },
   {
     "login": "zeroknowledge0x",
-    "score": 7.43
+    "score": 7.37
   },
   {
     "login": "actions-user",
-    "score": 3.24
+    "score": 4.24
   },
   {
     "login": "votienduong2208",

--- a/scripts/validate_lessons.py
+++ b/scripts/validate_lessons.py
@@ -125,7 +125,8 @@ def validate_lesson(path: Path, schema: dict) -> tuple[int, list[str]]:
 def main():
     schema = load_schema()
     if len(sys.argv) > 1:
-        paths = [Path(sys.argv[1])]
+        # Resolve relative paths to absolute so relative_to(REPO_ROOT) works
+        paths = [Path(sys.argv[1]).resolve()]
     else:
         paths = sorted(LESSONS_DIR.glob("**/*.md"))
 


### PR DESCRIPTION
Fixes the ValueError when CI passes relative paths to validate_lessons.py:

ValueError: 'lessons/contrib/templates/database.md' is not in the subpath of '/home/runner/work/MisakaNet/MisakaNet'

Root cause: Path(sys.argv[1]) creates a relative Path object, but relative_to(REPO_ROOT) requires an absolute path that is a subpath of REPO_ROOT.

Fix: Add .resolve() to convert relative paths to absolute before processing.

Signed-off-by: zsxh1990 <445655361@qq.com>