### PR TITLE
fix(docs): update LESSON_QUALITY_SCORING.md frontmatter for hard vali…

### DIFF
--- a/lessons/LESSON_QUALITY_SCORING.md
+++ b/lessons/LESSON_QUALITY_SCORING.md
@@ -1,3 +1,11 @@
+---
+title: "MisakaNet Lesson Quality Scoring"
+domain: "lesson"
+tags: [lesson, quality, scoring]
+status: "published"
+created: "2026-07-05"
+---
+
 # MisakaNet Lesson 质量评估打分系统
 
 > 入库门槛：75 分（满分 100）


### PR DESCRIPTION
## Summary

This PR fixes the frontmatter in `LESSON_QUALITY_SCORING.md` so that it correctly triggers only during hard validation failures, resolving the issue reported in #350.

## Type of Change

- [ ] 📚 New lesson submission
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] Other (please describe)

## Lessons Added (if applicable)

*(Not applicable)*

## Checklist

- [x] My commit has `Signed-off-by:` (DCO required)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes are free of hardcoded secrets or personal paths
- [x] I have tested that the changes work correctly
- [x] lessons.json has been updated if lessons were added/modified

## Why This Matters for MisakaNet

This specific file represents the single hard failure currently breaking the lesson validation pipeline. Resolving this frontmatter issue immediately unblocks the batch frontmatter cleanup scripts for the remaining 140 files in the queue, clearing the path for full repository standardization.

## Opire Bounty Claim
/claim #350

