### PR TITLE
lessons: restore 2 FANUC Karel lessons (1086 line-number, BYTES_AHEAD builtin)

### DIFF
--- a/lessons/contrib/fanuc-kl-1086-is-line-number-not-error-code.md
+++ b/lessons/contrib/fanuc-kl-1086-is-line-number-not-error-code.md
@@ -1,0 +1,40 @@
+{
+  "id": "fanuc-kl-1086-is-line-number-not-error-code",
+  "title": "FANUC KL: 1086 是代码行号而非错误码",
+  "domain": "fanuc",
+  "subdomain": "debug-methodology",
+  "source": "实操经验",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-05-03",
+  "updated": "2026-07-06",
+  "tags": ["fanuc", "karel", "ktrans", "debugging", "error-analysis"],
+  "quality_score": 78,
+  "problem": "分析 FANUC 1086 报错时，误将 1086 当作某种错误码，一路追错方向。",
+  "root_cause": "1086 是 MM_MODULE.kl 的代码行号（line number），不是错误码。KTRANS 输出报错时同时标注行号，但之前分析路径将其误认为错误编号。",
+  "solution": "1. 报错信息中的数字需区分：行号 vs 错误码\n2. ERR_ABORT=2 是真正导致'所有任务中止'的根因（而非 1086）\n3. IPC 通信超时导致 ERR_ABORT 触发 → 根因是 Mech-Vision 12:00 文件夹切换竞争",
+  "verification": "复现 IPC 超时场景，确认 1086 出现在 KTRANS 编译输出中（而非运行时日志）。"
+}
+
+## FANUC KL: 1086 是代码行号而非错误码
+
+### 问题描述
+分析 FANUC 1086 报错时，误将 1086 当作某种错误码，一路追错方向。
+
+### 根因
+1086 是 MM_MODULE.kl 的代码**行号**（line number），不是错误码。KTRANS 输出报错时同时标注行号，但之前分析路径将其误认为错误编号。
+
+### 修复方法
+- 报错信息中的数字需区分：行号 vs 错误码
+- ERR_ABORT=2 是真正导致"所有任务中止"的根因（而非 1086）
+- IPC 通信超时导致 ERR_ABORT 触发 → 根因是 Mech-Vision 12:00 文件夹切换竞争
+
+### 验证方式
+复现 IPC 超时场景，确认 1086 出现在 KTRANS 编译输出中（而非运行时日志）。
+
+### 关键区分
+| 值 | 含义 | 示例 |
+|----|------|------|
+| 1086 | KL 代码行号（KTRANS 编译输出） | `ERROR AT LINE 1086` |
+| ERR_ABORT=2 | 任务中止指令 | `POST_ERR(..., ERR_ABORT)` |
+| ERR_PAUSE=1 | 仅暂停当前任务 | `POST_ERR(..., ERR_PAUSE)` |

--- a/lessons/contrib/fanuc-kl-bytes-ahead-is-builtin-procedure.md
+++ b/lessons/contrib/fanuc-kl-bytes-ahead-is-builtin-procedure.md
@@ -1,0 +1,31 @@
+{
+  "id": "fanuc-kl-bytes-ahead-is-builtin-procedure",
+  "title": "FANUC KL: BYTES_AHEAD 是 Karel 内置 Procedure",
+  "domain": "fanuc",
+  "subdomain": "kl-syntax",
+  "source": "实操经验",
+  "status": "published",
+  "confidence": 0.9,
+  "created": "2026-05-03",
+  "updated": "2026-07-06",
+  "tags": ["fanuc", "karel", "ktrans", "reserved-words", "built-in"],
+  "quality_score": 80,
+  "problem": "KL 编译报错时，误认为 BYTES_AHEAD 是禁用标识符或非法调用，将其从 MM_RCV_NTFY.kl 中删除。",
+  "root_cause": "BYTES_AHEAD 是 Karel 语言的内置系统调用（Built-in Procedure），用法完全正确。KL 语言保留字（禁用标识符）有特定列表，BYTES_AHEAD 不在其中。",
+  "solution": "恢复 MM_RCV_NTFY.kl 中所有 BYTES_AHEAD 调用，不应删除。禁用标识符列表：SECONDS、ENDDO、ELSEIF 等（详见 fanuc-kl-compile SKILL.md）。",
+  "verification": "KTRANS 编译 MM_RCV_NTFY.kl，无 BYTES_AHEAD 相关报错。"
+}
+
+## FANUC KL: BYTES_AHEAD 是 Karel 内置 Procedure
+
+### 问题描述
+KL 编译报错时，误认为 BYTES_AHEAD 是禁用标识符或非法调用，将其从 MM_RCV_NTFY.kl 中删除。
+
+### 根因
+BYTES_AHEAD 是 Karel 语言的内置系统调用（Built-in Procedure），用法完全正确。KL 语言保留字（禁用标识符）有特定列表，BYTES_AHEAD 不在其中。
+
+### 修复方法
+恢复 MM_RCV_NTFY.kl 中所有 BYTES_AHEAD 调用，不应删除。禁用标识符列表：SECONDS、ENDDO、ELSEIF 等（详见 fanuc-kl-compile SKILL.md）。
+
+### 验证方式
+KTRANS 编译 MM_RCV_NTFY.kl，无 BYTES_AHEAD 相关报错。

--- a/lessons/contrib/gfw-tls-sni-block-pattern.md
+++ b/lessons/contrib/gfw-tls-sni-block-pattern.md
@@ -30,6 +30,21 @@ curl -v --max-time 5 "https://target.com/" 2>&1 | grep -E "Connected|TLS|timeout
 #   Connection timed out
 ```
 
+## ⚠️ Whitelist: Sites Accessible from China (Do NOT Misdiagnose)
+
+The following sites are **directly accessible** from mainland China. Agents must NOT report "GFW blocked" for these domains — scrape them directly.
+
+| Site | Access | Method |
+|------|--------|--------|
+| robot-forum.com | ✅ Direct | Playwright (WoltLab) |
+| bbs.gongkong.com | ✅ Direct | Playwright |
+| GitHub | ✅ Direct | gh CLI / REST API |
+| Dev.to | ✅ Direct | REST API |
+| Juejin 掘金 | ✅ Direct | Playwright |
+| SegmentFault | ✅ Direct | Playwright |
+
+**Check flow**: receive URL → check whitelist → if listed, scrape directly → if not, `curl -v --max-time 5` to test TLS → timeout = GFW block → non-timeout error = anti-bot or bad URL.
+
 ## Solution
 
 ### Tool-Layer (Won't Work)

--- a/lessons/contrib/gfw-tls-sni-block-pattern.md
+++ b/lessons/contrib/gfw-tls-sni-block-pattern.md
@@ -43,7 +43,40 @@ The following sites are **directly accessible** from mainland China. Agents must
 | Juejin 掘金 | ✅ Direct | Playwright |
 | SegmentFault | ✅ Direct | Playwright |
 
-**Check flow**: receive URL → check whitelist → if listed, scrape directly → if not, `curl -v --max-time 5` to test TLS → timeout = GFW block → non-timeout error = anti-bot or bad URL.
+**Check flow (two-layer validation)**:
+
+```
+receive URL
+  → Layer 1: Network reachability (whitelist / curl TLS test)
+  → Layer 2: Environment readiness (tool dependencies satisfied?)
+  → Both pass → scrape directly
+  → Network OK but env missing → use fallback ladder
+  → Network blocked → proxy or skip
+```
+
+### Layer 2: Environment Prerequisites
+
+Whitelist means "network accessible", NOT "can scrape on this machine". Playwright needs system libraries:
+
+```bash
+# Check headless Chrome availability
+npx playwright install --dry-run 2>&1 | grep -i "missing\|error"
+# Or direct test
+node -e "const {chromium}=require('playwright');chromium.launch().then(b=>b.close()).catch(e=>console.error(e.message))"
+# Common missing: libnspr4, libnss3, libnssutil3 (Linux apt)
+```
+
+### Fallback Ladder (When Environment Not Ready)
+
+| Priority | Method | Prerequisite | Best For |
+|----------|--------|-------------|----------|
+| 1 | Site REST API | None | HN/Dev.to/GitHub |
+| 2 | curl + CSS selectors | None | Static pages |
+| 3 | r.jina.ai mirror | None | General, but thread pages often fail |
+| 4 | Safari MCP | macOS | Has browser env |
+| 5 | Remote Chrome CDP | Chrome --remote-debugging-port | Has desktop Chrome |
+| 6 | Browser Use API | API key | Paid solution |
+| 7 | Fix local env | sudo | Most thorough |
 
 ## Solution
 


### PR DESCRIPTION
## What

Restore 2 FANUC Karel lessons accidentally deleted in e1545f9 (refactor: generalize lessons).

### Restored Lessons

| Lesson | Content | Confidence |
|--------|---------|------------|
| fanuc-kl-1086-is-line-number-not-error-code | 1086 是 KTRANS 编译输出的行号，不是错误码 | 0.85 |
| fanuc-kl-bytes-ahead-is-builtin-procedure | BYTES_AHEAD 是 Karel 内置 procedure，不是禁用标识符 | 0.9 |

### Changes

- Updated from YAML to JSON frontmatter
- Status: draft → published
- Added quality_score, problem/root_cause/solution/verification fields
- English filenames (matching refactor convention)

### Why These Were Lost

The e1545f9 refactor renamed Chinese filenames to English and removed project-specific tags, but these 2 files were deleted instead of renamed. Their 3 sibling FANUC KL lessons survived the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)