### PR TITLE
feat: normalize lesson metadata across 125 files (#306)

### DIFF
--- a/lessons/contrib/ai-agent-project-outreach-guide.md
+++ b/lessons/contrib/ai-agent-project-outreach-guide.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "AI Agent Project Outreach Guide"
-verification: "metadata-normalized"
-{"title": "AI Agent Project Outreach Guide", "domain": "marketing", "subdomain": "outreach", "source": "Misaka10004", "tags": ["outreach", "github", "awesome-list", "pr", "promotion", "agent", "marketing"], "confidence": "0.95", "created": "2026-05-11", "domain_expert": "Misaka10004", "verified_date": "2026-05-11"}
+{
+  "domain": "contrib",
+  "title": "AI Agent Project Outreach Guide",
+  "verification": "metadata-normalized",
+  "{\"title\"": "AI Agent Project Outreach Guide\", \"domain\": \"marketing\", \"subdomain\": \"outreach\", \"source\": \"Misaka10004\", \"tags\": [\"outreach\", \"github\", \"awesome-list\", \"pr\", \"promotion\", \"agent\", \"marketing\"], \"confidence\": \"0.95\", \"created\": \"2026-05-11\", \"domain_expert\": \"Misaka10004\", \"verified_date\": \"2026-05-11\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/aily-feishu-mcp-pull-only.md
+++ b/lessons/contrib/aily-feishu-mcp-pull-only.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "aily feishu mcp pull only"
-verification: "metadata-normalized"
-{"title": "aily 飞书 MCP 通道：只能拉取不能推送", "domain": "feishu", "subdomain": "mcp-capability", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "aily feishu mcp pull only",
+  "verification": "metadata-normalized",
+  "{\"title\"": "aily 飞书 MCP 通道：只能拉取不能推送\", \"domain\": \"feishu\", \"subdomain\": \"mcp-capability\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/anthropic-proxy-internal-gateway.md
+++ b/lessons/contrib/anthropic-proxy-internal-gateway.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy"
-verification: "metadata-normalized"
-{"created": "2026-04-30 09:00 UTC", "domain": "devops", "machine": "hp-wsl", "source": "hermes_wsl", "status": "published", "tags": "", "title": "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy", "updated": "2026-04-30 09:00 UTC", "domain_expert": "hermes_wsl", "verified_date": "2026-04-30"}
+{
+  "domain": "contrib",
+  "title": "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy",
+  "verification": "metadata-normalized",
+  "{\"created\"": "2026-04-30 09:00 UTC\", \"domain\": \"devops\", \"machine\": \"hp-wsl\", \"source\": \"hermes_wsl\", \"status\": \"published\", \"tags\": \"\", \"title\": \"Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy\", \"updated\": \"2026-04-30 09:00 UTC\", \"domain_expert\": \"hermes_wsl\", \"verified_date\": \"2026-04-30\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/api-gateway-anthropic-incompatibility.md
+++ b/lessons/contrib/api-gateway-anthropic-incompatibility.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "api gateway anthropic incompatibility"
-verification: "metadata-normalized"
-{"title": "InternalGateway API 网关不兼容 Anthropic 原生格式", "domain": "devops", "subdomain": "api", "source": "bootstrap", "status": "published", "tags": ["project:rag", "severity:medium", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "api gateway anthropic incompatibility",
+  "verification": "metadata-normalized",
+  "{\"title\"": "InternalGateway API 网关不兼容 Anthropic 原生格式\", \"domain\": \"devops\", \"subdomain\": \"api\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"severity:medium\", \"node:hermes_wsl\"], \"confidence\": \"0.8\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/api-rate-limit-handling-best-practices.md
+++ b/lessons/contrib/api-rate-limit-handling-best-practices.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "api rate limit handling best practices"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "api rate limit handling best practices",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "API限流Handling最佳实践", "domain": "devops", "tags": ["api", "rate-limit", "backoff", "batch"]}---
 

--- a/lessons/contrib/api-rate-limit-handling.md
+++ b/lessons/contrib/api-rate-limit-handling.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "API 请求限流 (Rate Limit) Handling方案"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "API 请求限流 (Rate Limit) Handling方案",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "API 请求限流 (Rate Limit) Handling方案", "domain": "devops", "tags": ["api", "rate-limit", "retry", "429"]}---
 

--- a/lessons/contrib/audit-sampling-stratified-sampling-for-kb-inspection.md
+++ b/lessons/contrib/audit-sampling-stratified-sampling-for-kb-inspection.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "audit sampling stratified sampling for kb inspection"
-verification: "metadata-normalized"
-{"title": "巡检题库分层抽样策略", "domain": "rag", "tags": ["rag", "audit", "sampling", "quality", "test-bank"], "confidence": 0.88, "created": "2026-05-21", "domain_expert": "unknown", "verified_date": "2026-05-21"}
+{
+  "domain": "contrib",
+  "title": "audit sampling stratified sampling for kb inspection",
+  "verification": "metadata-normalized",
+  "{\"title\"": "巡检题库分层抽样策略\", \"domain\": \"rag\", \"tags\": [\"rag\", \"audit\", \"sampling\", \"quality\", \"test-bank\"], \"confidence\": 0.88, \"created\": \"2026-05-21\", \"domain_expert\": \"unknown\", \"verified_date\": \"2026-05-21\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/bge-embedding-fallback-crash.md
+++ b/lessons/contrib/bge-embedding-fallback-crash.md
@@ -7,7 +7,7 @@
   "tags": [
     "project:agent-medici",
     "severity:high",
-    "node:hermes_wsl"
+    "node:hermes-wsl"
   ],
   "language": "en",
   "created": "2026-05-03",

--- a/lessons/contrib/browser-harness-cdp-browser-automation.md
+++ b/lessons/contrib/browser-harness-cdp-browser-automation.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation", "domain": "devops", "source": "skill-harvest", "status": "published", "confidence": "0.6", "created": "2026-05-20"}---
 

--- a/lessons/contrib/cc-connect-feishu-display-optimization.md
+++ b/lessons/contrib/cc-connect-feishu-display-optimization.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "cc connect feishu display optimization"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "cc connect feishu display optimization",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "cc-connect 飞书显示Optimization：禁用工具调用和上下文提示", "domain": "feishu", "subdomain": "cc-connect", "source": "bootstrap", "status": "published", "confidence": "0.9", "created": "2026-05-19"}---
 

--- a/lessons/contrib/cc-connect-feishu-setup-complete.md
+++ b/lessons/contrib/cc-connect-feishu-setup-complete.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "cc connect feishu setup complete"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "cc connect feishu setup complete",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "cc-connect 飞书机器人完整SetupGuide", "domain": "feishu", "subdomain": "cc-connect", "source": "bootstrap", "status": "published", "confidence": "0.95", "created": "2026-05-19"}---
 ## Verification

--- a/lessons/contrib/ccswitch-hermes-switch.md
+++ b/lessons/contrib/ccswitch-hermes-switch.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "ccswitch-hermes-switch 踩坑Notes"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "ccswitch-hermes-switch 踩坑Notes",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"confidence": "0.7", "created": "2026-05-02", "domain": "devops", "source": "bootstrap", "status": "published", "tags": "", "- node": "cc_haha", "title": "ccswitch-hermes-switch 踩坑Notes"}---
 

--- a/lessons/contrib/chroma-rebuild-no-checkpoint-cn.md
+++ b/lessons/contrib/chroma-rebuild-no-checkpoint-cn.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Chroma 建库无 Checkpoint — 进程一死全部丢失"
-verification: "metadata-normalized"
-{"title": "Chroma 建库无 Checkpoint — 进程一死全部丢失", "domain": "rag", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
+{
+  "domain": "contrib",
+  "title": "Chroma 建库无 Checkpoint — 进程一死全部丢失",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Chroma 建库无 Checkpoint — 进程一死全部丢失\", \"domain\": \"rag\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/chroma-rebuild-no-checkpoint.md
+++ b/lessons/contrib/chroma-rebuild-no-checkpoint.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Chroma 建库无 Checkpoint — 进程一死全部丢失"
-verification: "metadata-normalized"
-{"title": "Chroma 建库无 Checkpoint — 进程一死全部丢失", "domain": "rag", "source": "bootstrap", "bootstrapped": true, "author": "node2", "machine": "hermes-wsl", "original_date": "2026-04-12", "tags": "", "- node": "hermes_wsl", "- project": "edoc", "- severity": "high", "status": "published", "quality": "published", "created": "2026-04-01", "confidence": "0.7", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
+{
+  "domain": "contrib",
+  "title": "Chroma 建库无 Checkpoint — 进程一死全部丢失",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Chroma 建库无 Checkpoint — 进程一死全部丢失\", \"domain\": \"rag\", \"source\": \"bootstrap\", \"bootstrapped\": true, \"author\": \"node2\", \"machine\": \"hermes-wsl\", \"original_date\": \"2026-04-12\", \"tags\": \"\", \"- node\": \"hermes_wsl\", \"- project\": \"edoc\", \"- severity\": \"high\", \"status\": \"published\", \"quality\": \"published\", \"created\": \"2026-04-01\", \"confidence\": \"0.7\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/chrome-relay-browser-automation.md
+++ b/lessons/contrib/chrome-relay-browser-automation.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器", "domain": "development", "tags": ["chrome", "browser", "automation", "cdp", "websocket", "openclaw"], "contributor": "hermes-agent"}---
 

--- a/lessons/contrib/ci-dco-decouple-pythonpath-fork-pr.md
+++ b/lessons/contrib/ci-dco-decouple-pythonpath-fork-pr.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix", "domain": "devops", "tags": ["github-actions", "ci", "dco", "python", "ai-agent", "fork-pr", "pytest", "coverage"], "status": "published", "source": "deepseek", "created": "2026-06-04 00:00:00 UTC", "updated": "2026-06-12 00:00:00 UTC"}---
 

--- a/lessons/contrib/cloudflare-email-worker-registration-trap.md
+++ b/lessons/contrib/cloudflare-email-worker-registration-trap.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF", "domain": "devops", "tags": ["cloudflare", "email-worker", "kv", "turnstile", "registration", "spf"]}---
 

--- a/lessons/contrib/codewhale-git-push-yolo-task.md
+++ b/lessons/contrib/codewhale-git-push-yolo-task.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI"
-verification: "metadata-normalized"
-{"title": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI", "domain": "devops", "tags": ["codewhale", "git", "yolo", "push", "lesson"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI",
+  "verification": "metadata-normalized",
+  "{\"title\"": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI\", \"domain\": \"devops\", \"tags\": [\"codewhale\", \"git\", \"yolo\", \"push\", \"lesson\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/cron-job-not-running.md
+++ b/lessons/contrib/cron-job-not-running.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Cron 作业不执行 / 不生效排障"
-verification: "metadata-normalized"
-{"title": "Cron 作业不执行 / 不生效排障", "domain": "devops", "tags": ["cron", "scheduler", "not-running", "debug"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "Cron 作业不执行 / 不生效排障",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Cron 作业不执行 / 不生效排障\", \"domain\": \"devops\", \"tags\": [\"cron\", \"scheduler\", \"not-running\", \"debug\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/curl-request-troubleshoot.md
+++ b/lessons/contrib/curl-request-troubleshoot.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "curl / wget 请求失败通用Diagnosis"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "curl / wget 请求失败通用Diagnosis",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "curl / wget 请求失败通用Diagnosis", "domain": "devops", "tags": ["network", "curl", "wget", "debug", "troubleshoot"]}---
 

--- a/lessons/contrib/deepseek-tui-write-file-sandbox-worktree-git-path.md
+++ b/lessons/contrib/deepseek-tui-write-file-sandbox-worktree-git-path.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "deepseek tui write file sandbox worktree git path"
-verification: "metadata-normalized"
-{"title": "DeepSeek TUI — write_file Sandbox + Worktree Git Path Breakage", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["deepseek-tui", "agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"], "created": "2026-05-13 01:01:46 UTC", "updated": "2026-05-13 01:01:46 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-13"}
+{
+  "domain": "contrib",
+  "title": "deepseek tui write file sandbox worktree git path",
+  "verification": "metadata-normalized",
+  "{\"title\"": "DeepSeek TUI — write_file Sandbox + Worktree Git Path Breakage\", \"domain\": \"devops\", \"source\": \"hermes_wsl2\", \"status\": \"published\", \"tags\": [\"deepseek-tui\", \"agent-mode\", \"write-file\", \"worktree\", \"wsl\", \"git\", \"lesson-written\"], \"created\": \"2026-05-13 01:01:46 UTC\", \"updated\": \"2026-05-13 01:01:46 UTC\", \"domain_expert\": \"hermes_wsl2\", \"verified_date\": \"2026-05-13\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/disk-space-cleanup.md
+++ b/lessons/contrib/disk-space-cleanup.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "磁盘空间不足 / chroma_db_v4 CacheCleanup"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "磁盘空间不足 / chroma_db_v4 CacheCleanup",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "磁盘空间不足 / chroma_db_v4 CacheCleanup", "updated": "2026-05-01 08:00 UTC"}---
 

--- a/lessons/contrib/feishu-agent-display-settings.md
+++ b/lessons/contrib/feishu-agent-display-settings.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "feishu agent display settings"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "feishu agent display settings",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "飞书 Agent 显示Optimization：禁用工具调用和上下文提示", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.9", "created": "2026-05-19"}---
 

--- a/lessons/contrib/feishu-block-batch-limit.md
+++ b/lessons/contrib/feishu-block-batch-limit.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "feishu block batch limit"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "feishu block batch limit",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "飞书 Block Batch写入上限", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03"}---
 

--- a/lessons/contrib/feishu-block-type-values-limits.md
+++ b/lessons/contrib/feishu-block-type-values-limits.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "feishu block type values limits"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "feishu block type values limits",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "飞书 Block Type 正确值与已知Limit", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-05-03"}---
 

--- a/lessons/contrib/feishu-bot-setup-complete.md
+++ b/lessons/contrib/feishu-bot-setup-complete.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "feishu bot setup complete"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "feishu bot setup complete",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "飞书机器人完整SetupGuide", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.95", "created": "2026-05-19"}---
 ## Verification

--- a/lessons/contrib/feishu-doc-url-use-api-return.md
+++ b/lessons/contrib/feishu-doc-url-use-api-return.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "feishu doc url use api return"
-verification: "metadata-normalized"
-{"title": "Feishu 文档 URL：必须用 API 返回值，不要拼接", "domain": "feishu", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-03-29", "confidence": "0.95", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-03-29"}
+{
+  "domain": "contrib",
+  "title": "feishu doc url use api return",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Feishu 文档 URL：必须用 API 返回值，不要拼接\", \"domain\": \"feishu\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-03-29\", \"confidence\": \"0.95\", \"scope\": \"broad\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-03-29\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/feishu-markdown-table-not-rendered.md
+++ b/lessons/contrib/feishu-markdown-table-not-rendered.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "feishu markdown table not rendered"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "feishu markdown table not rendered",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "飞书 post Messaging中 Markdown 表格不渲染", "domain": "development", "source": "Misaka10019", "tags": ["feishu", "markdown", "table", "post", "lark"]}---
 

--- a/lessons/contrib/feishu-mcp-server-deepseek-tui-setup.md
+++ b/lessons/contrib/feishu-mcp-server-deepseek-tui-setup.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries"
-verification: "metadata-normalized"
-{"title": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries", "domain": "feishu", "source": "deepseek-tui", "status": "published", "tags": ["feishu", "mcp", "deepseek", "docx-api", "permissions"], "created": "2026-05-19", "updated": "2026-05-19", "domain_expert": "deepseek-tui", "verified_date": "2026-05-19"}
+{
+  "domain": "contrib",
+  "title": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries",
+  "verification": "metadata-normalized",
+  "{\"title\"": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries\", \"domain\": \"feishu\", \"source\": \"deepseek-tui\", \"status\": \"published\", \"tags\": [\"feishu\", \"mcp\", \"deepseek\", \"docx-api\", \"permissions\"], \"created\": \"2026-05-19\", \"updated\": \"2026-05-19\", \"domain_expert\": \"deepseek-tui\", \"verified_date\": \"2026-05-19\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/feishu-upload-file-type-opus.md
+++ b/lessons/contrib/feishu-upload-file-type-opus.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "feishu upload file type opus"
-verification: "metadata-normalized"
-{"title": "Feishu 文件上传：file_type 必须用 opus", "domain": "feishu", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-03-29", "confidence": "0.95", "scope": "broad", "alternative_of": "None", "related": "", "domain_expert": "hanged-man", "verified_date": "2026-03-29"}
+{
+  "domain": "contrib",
+  "title": "feishu upload file type opus",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Feishu 文件上传：file_type 必须用 opus\", \"domain\": \"feishu\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-03-29\", \"confidence\": \"0.95\", \"scope\": \"broad\", \"alternative_of\": \"None\", \"related\": \"\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-03-29\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/feishu-webhook-url-env-config.md
+++ b/lessons/contrib/feishu-webhook-url-env-config.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "feishu webhook url env config"
-verification: "metadata-normalized"
-{"title": "飞书 webhook URL 必须用环境变量或 gitignored 的 config.yaml", "domain": "devops", "subdomain": "feishu", "source": "bootstrap", "status": "published", "tags": ["project:agent-medici", "severity:critical", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "feishu webhook url env config",
+  "verification": "metadata-normalized",
+  "{\"title\"": "飞书 webhook URL 必须用环境变量或 gitignored 的 config.yaml\", \"domain\": \"devops\", \"subdomain\": \"feishu\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:agent-medici\", \"severity:critical\", \"node:hermes_wsl\"], \"confidence\": \"0.8\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
+++ b/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "feishu websocket 404 error http webhook required"
-verification: "metadata-normalized"
-{"title": "Feishu WebSocket 404 Error - HTTP Webhook Required", "domain": "feishu-integration", "source": "hermes_wsl2", "status": "published", "tags": [], "created": "2026-05-19 01:19:29 UTC", "updated": "2026-05-19 01:19:29 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-19"}
+{
+  "domain": "contrib",
+  "title": "feishu websocket 404 error http webhook required",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Feishu WebSocket 404 Error - HTTP Webhook Required\", \"domain\": \"feishu-integration\", \"source\": \"hermes_wsl2\", \"status\": \"published\", \"tags\": [], \"created\": \"2026-05-19 01:19:29 UTC\", \"updated\": \"2026-05-19 01:19:29 UTC\", \"domain_expert\": \"hermes_wsl2\", \"verified_date\": \"2026-05-19\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 问题: 飞书 WebSocket 接收消息 API 返回 404 错误。测试端点: wss://open.feishu.cn/open-apis/bot/v3/ws, /bot/v2/ws, /im/v1/ws, /im/v2/ws, /webhook/v1/ws。所有端点均返回 404。修复: 消息发送功能正常 (通过 HTTP API with receive_id_type=chat_id), 但接收消息必须使用 HTTP Webhook 回调方式。验证: 2026-05-19 测试确认。

--- a/lessons/contrib/feishu-wiki-batch-download.md
+++ b/lessons/contrib/feishu-wiki-batch-download.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Feishu WikiBatch Download：文件类型Handling策略"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Feishu WikiBatch Download：文件类型Handling策略",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Feishu WikiBatch Download：文件类型Handling策略", "domain": "devops", "tags": "feishu, wiki, batch-download, file-type, pdf, docx, safari", "status": "published", "source": "hermes_wsl2", "updated": "2026-05-19 15:40:11 UTC"}---
 

--- a/lessons/contrib/ffmpeg-audio-libopus-not-ogg.md
+++ b/lessons/contrib/ffmpeg-audio-libopus-not-ogg.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "ffmpeg audio libopus not ogg"
-verification: "metadata-normalized"
-{"title": "FFmpeg 音频转码：必须用 libopus 而非 -format ogg", "domain": "audio", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-03-29", "confidence": "0.9", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-03-29"}
+{
+  "domain": "contrib",
+  "title": "ffmpeg audio libopus not ogg",
+  "verification": "metadata-normalized",
+  "{\"title\"": "FFmpeg 音频转码：必须用 libopus 而非 -format ogg\", \"domain\": \"audio\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-03-29\", \"confidence\": \"0.9\", \"scope\": \"broad\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-03-29\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/firewall-port-open-not-public.md
+++ b/lessons/contrib/firewall-port-open-not-public.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "firewall port open not public"
-verification: "metadata-normalized"
-{"title": "防火墙端口开放不等于内网穿透", "domain": "devops", "subdomain": "network", "source": "bootstrap", "status": "published", "tags": ["project:rag", "platform:wsl", "node:hermes_wsl", "scope:broad"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "firewall port open not public",
+  "verification": "metadata-normalized",
+  "{\"title\"": "防火墙端口开放不等于内网穿透\", \"domain\": \"devops\", \"subdomain\": \"network\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:wsl\", \"node:hermes_wsl\", \"scope:broad\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/game-mcp-end-turn-conflict-409.md
+++ b/lessons/contrib/game-mcp-end-turn-conflict-409.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Game MCP: End Turn Returns 409 Conflict"
-verification: "metadata-normalized"
-{"title": "Game MCP: End Turn Returns 409 Conflict", "domain": "mcp", "source": "hanged-man", "status": "published", "domain_expert": "hanged-man"}
+{
+  "domain": "contrib",
+  "title": "Game MCP: End Turn Returns 409 Conflict",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Game MCP: End Turn Returns 409 Conflict\", \"domain\": \"mcp\", \"source\": \"hanged-man\", \"status\": \"published\", \"domain_expert\": \"hanged-man\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Game MCP: End Turn Returns 409 Conflict

--- a/lessons/contrib/game-mcp-game-over-restart-flow.md
+++ b/lessons/contrib/game-mcp-game-over-restart-flow.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Game MCP: GAME OVER Restart Flow"
-verification: "metadata-normalized"
-{"title": "Game MCP: GAME OVER Restart Flow", "domain": "mcp", "source": "hanged-man", "status": "published", "domain_expert": "hanged-man"}
+{
+  "domain": "contrib",
+  "title": "Game MCP: GAME OVER Restart Flow",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Game MCP: GAME OVER Restart Flow\", \"domain\": \"mcp\", \"source\": \"hanged-man\", \"status\": \"published\", \"domain_expert\": \"hanged-man\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Game MCP: GAME OVER Restart Flow

--- a/lessons/contrib/game-mcp-rare-relic-freeze.md
+++ b/lessons/contrib/game-mcp-rare-relic-freeze.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "game mcp rare relic freeze"
-verification: "metadata-normalized"
-{"title": "Game MCP: Rare Relic Selection Freeze", "domain": "mcp", "source": "hanged-man", "status": "published", "domain_expert": "hanged-man"}
+{
+  "domain": "contrib",
+  "title": "game mcp rare relic freeze",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Game MCP: Rare Relic Selection Freeze\", \"domain\": \"mcp\", \"source\": \"hanged-man\", \"status\": \"published\", \"domain_expert\": \"hanged-man\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Game MCP: Rare Relic Selection Freeze

--- a/lessons/contrib/gateway-hang-watchdog-recovery.md
+++ b/lessons/contrib/gateway-hang-watchdog-recovery.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Gateway 进程挂死未崩溃 — watchdog 自动Recovery"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Gateway 进程挂死未崩溃 — watchdog 自动Recovery",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Gateway 进程挂死未崩溃 — watchdog 自动Recovery", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01"}---
 

--- a/lessons/contrib/git-credential-helper-gh-path-mismatch.md
+++ b/lessons/contrib/git-credential-helper-gh-path-mismatch.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "gh credential helper 路径Error导致 git push 静默失败"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "gh credential helper 路径Error导致 git push 静默失败",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "gh credential helper 路径Error导致 git push 静默失败", "domain": "devops", "tags": ["git", "github", "credential", "gh", "auth", "push"]}---
 

--- a/lessons/contrib/git-credentials-and-node-id-setup.md
+++ b/lessons/contrib/git-credentials-and-node-id-setup.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Git Credentials 和 Node ID Setup"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Git Credentials 和 Node ID Setup",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Git Credentials 和 Node ID Setup", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["git", "credentials", "node-id", "setup"]}---
 

--- a/lessons/contrib/git-credentials-automation.md
+++ b/lessons/contrib/git-credentials-automation.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Git 凭证Setup — Automation push 免密码"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Git 凭证Setup — Automation push 免密码",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Git 凭证Setup — Automation push 免密码", "domain": "devops", "tags": ["git", "credentials", "auth", "github"]}---
 

--- a/lessons/contrib/git-merge-conflict-resolution.md
+++ b/lessons/contrib/git-merge-conflict-resolution.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Git 合并ConflictHandling — 手动解决最佳实践"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Git 合并ConflictHandling — 手动解决最佳实践",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Git 合并ConflictHandling — 手动解决最佳实践", "domain": "development", "tags": ["git", "merge", "conflict", "rebase"]}---
 

--- a/lessons/contrib/git-push-without-shell-agent.md
+++ b/lessons/contrib/git-push-without-shell-agent.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Git Push 的正确方式 — 在受限 Agent 环境中推送代码"
-verification: "metadata-normalized"
-{"title": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码", "domain": "devops", "tags": ["git", "push", "agent", "gh-cli", "lesson"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码\", \"domain\": \"devops\", \"tags\": [\"git\", \"push\", \"agent\", \"gh-cli\", \"lesson\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/git-tls-handshake-failure.md
+++ b/lessons/contrib/git-tls-handshake-failure.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "GitHub TLS 握手失败 — gnutls_handshake() Error"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "GitHub TLS 握手失败 — gnutls_handshake() Error",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "GitHub TLS 握手失败 — gnutls_handshake() Error", "domain": "devops", "tags": ["git", "github", "TLS", "SSL", "network"]}---
 

--- a/lessons/contrib/github-401-credential-lookup.md
+++ b/lessons/contrib/github-401-credential-lookup.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "GitHub API 401 后本地凭证查找顺序"
-verification: "metadata-normalized"
-{"title": "GitHub API 401 后本地凭证查找顺序", "domain": "devops", "tags": ["github", "api", "credential", "401", "auth", "pat"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "GitHub API 401 后本地凭证查找顺序",
+  "verification": "metadata-normalized",
+  "{\"title\"": "GitHub API 401 后本地凭证查找顺序\", \"domain\": \"devops\", \"tags\": [\"github\", \"api\", \"credential\", \"401\", \"auth\", \"pat\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/github-dns-443-block-hosts-workaround.md
+++ b/lessons/contrib/github-dns-443-block-hosts-workaround.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案"
-verification: "metadata-normalized"
-{"title": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案", "domain": "devops", "tags": ["git", "github", "TLS", "network", "DNS", "hosts", "connectivity"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案",
+  "verification": "metadata-normalized",
+  "{\"title\"": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案\", \"domain\": \"devops\", \"tags\": [\"git\", \"github\", \"TLS\", \"network\", \"DNS\", \"hosts\", \"connectivity\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/gpt-sovits-hubert-16khz.md
+++ b/lessons/contrib/gpt-sovits-hubert-16khz.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "gpt sovits hubert 16khz"
-verification: "metadata-normalized"
-{"title": "GPT-SoVITS：HuBERT 必须 16kHz 且 get_model() 返回单体", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-05", "confidence": "0.9", "scope": "narrow", "domain_expert": "hanged-man", "verified_date": "2026-04-05"}
+{
+  "domain": "contrib",
+  "title": "gpt sovits hubert 16khz",
+  "verification": "metadata-normalized",
+  "{\"title\"": "GPT-SoVITS：HuBERT 必须 16kHz 且 get_model() 返回单体\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-05\", \"confidence\": \"0.9\", \"scope\": \"narrow\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-05\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/gpt-sovits-name2text-arpabet.md
+++ b/lessons/contrib/gpt-sovits-name2text-arpabet.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "gpt sovits name2text arpabet"
-verification: "metadata-normalized"
-{"title": "GPT-SoVITS 训练：2-name2text 格式必须用 ARPABET 音素而非中文原文", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-06", "confidence": "0.9", "scope": "narrow", "domain_expert": "hanged-man", "verified_date": "2026-04-06"}
+{
+  "domain": "contrib",
+  "title": "gpt sovits name2text arpabet",
+  "verification": "metadata-normalized",
+  "{\"title\"": "GPT-SoVITS 训练：2-name2text 格式必须用 ARPABET 音素而非中文原文\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-06\", \"confidence\": \"0.9\", \"scope\": \"narrow\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-06\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/gpt-sovits-ref-free-bug.md
+++ b/lessons/contrib/gpt-sovits-ref-free-bug.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "gpt sovits ref free bug"
-verification: "metadata-normalized"
-{"title": "GPT-SoVITS：ref_free bug——prompt_text 为空时参数被覆盖", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-06", "confidence": "0.9", "scope": "narrow", "domain_expert": "hanged-man", "verified_date": "2026-04-06"}
+{
+  "domain": "contrib",
+  "title": "gpt sovits ref free bug",
+  "verification": "metadata-normalized",
+  "{\"title\"": "GPT-SoVITS：ref_free bug——prompt_text 为空时参数被覆盖\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-06\", \"confidence\": \"0.9\", \"scope\": \"narrow\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-06\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/hub-credential-gateway-vs-hub.md
+++ b/lessons/contrib/hub-credential-gateway-vs-hub.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里"
-verification: "metadata-normalized"
-{"title": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
+{
+  "domain": "contrib",
+  "title": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里\", \"domain\": \"devops\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/hub-feishu-wsclient-start-never-called.md
+++ b/lessons/contrib/hub-feishu-wsclient-start-never-called.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "hub feishu wsclient start never called"
-verification: "metadata-normalized"
-{"title": "Hub FeishuWSClient.start() 从未调用 — WebSocket 接收死代码", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
+{
+  "domain": "contrib",
+  "title": "hub feishu wsclient start never called",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Hub FeishuWSClient.start() 从未调用 — WebSocket 接收死代码\", \"domain\": \"feishu\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/issue-comment-newbie-welcome.md
+++ b/lessons/contrib/issue-comment-newbie-welcome.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Auto-Welcome Newcomers via issue_comment Event"
-verification: "metadata-normalized"
-{"title": "Auto-Welcome Newcomers via issue_comment Event", "domain": "devops", "tags": ["github-actions", "ci", "community", "newbie", "good-first-issue", "automation"], "status": "published", "source": "deepseek", "created": "2026-06-12 00:00:00 UTC", "updated": "2026-06-12 00:00:00 UTC", "domain_expert": "deepseek", "verified_date": "2026-06-12"}
+{
+  "domain": "contrib",
+  "title": "Auto-Welcome Newcomers via issue_comment Event",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Auto-Welcome Newcomers via issue_comment Event\", \"domain\": \"devops\", \"tags\": [\"github-actions\", \"ci\", \"community\", \"newbie\", \"good-first-issue\", \"automation\"], \"status\": \"published\", \"source\": \"deepseek\", \"created\": \"2026-06-12 00:00:00 UTC\", \"updated\": \"2026-06-12 00:00:00 UTC\", \"domain_expert\": \"deepseek\", \"verified_date\": \"2026-06-12\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/js-dead-code-chain-break.md
+++ b/lessons/contrib/js-dead-code-chain-break.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "js dead code chain break"
-verification: "metadata-normalized"
-{"title": "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效", "domain": "frontend", "tags": ["js", "runtime", "typeerror", "execution-model", "defensive"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "js dead code chain break",
+  "verification": "metadata-normalized",
+  "{\"title\"": "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效\", \"domain\": \"frontend\", \"tags\": [\"js\", \"runtime\", \"typeerror\", \"execution-model\", \"defensive\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/json-parse-failure-handling.md
+++ b/lessons/contrib/json-parse-failure-handling.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "JSON 解析失败Handling — 截断 / 格式Error"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "JSON 解析失败Handling — 截断 / 格式Error",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "JSON 解析失败Handling — 截断 / 格式Error", "domain": "devops", "tags": ["json", "parse", "truncated", "llm", "output"]}---
 

--- a/lessons/contrib/kb-4sigma-quality-audit-pipeline.md
+++ b/lessons/contrib/kb-4sigma-quality-audit-pipeline.md
@@ -7,7 +7,7 @@
   "tags": [
     "project:self-grow-wiki",
     "severity:medium",
-    "node:hermes_wsl"
+    "node:hermes-wsl"
   ],
   "language": "en",
   "created": "2026-05-03",

--- a/lessons/contrib/knowledge-graph-ux-patterns-from-high-star-projects.md
+++ b/lessons/contrib/knowledge-graph-ux-patterns-from-high-star-projects.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "knowledge graph ux patterns from high star projects"
-verification: "metadata-normalized"
-{"title": "知识图谱 UX 增强: 从高星项目提炼的 7 个交互模式", "domain": "development", "tags": ["knowledge-graph", "d3js", "ux", "graph-visualization", "force-directed"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "knowledge graph ux patterns from high star projects",
+  "verification": "metadata-normalized",
+  "{\"title\"": "知识图谱 UX 增强: 从高星项目提炼的 7 个交互模式\", \"domain\": \"development\", \"tags\": [\"knowledge-graph\", \"d3js\", \"ux\", \"graph-visualization\", \"force-directed\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/lesson-06-git-push-credential-helper-403.md
+++ b/lessons/contrib/lesson-06-git-push-credential-helper-403.md
@@ -1,8 +1,12 @@
 ---
-domain: "devops"
-title: "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper"
-verification: "metadata-normalized"
-{"title": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper", "domain": "devops", "tags": ["git", "github", "credentials-helper", "pat", "multi-account", "403", "fork-workflow"], "status": "published", "confidence": "0.95", "created": "2026-07-03", "updated": "2026-07-03", "source": "https://github.com/zsxh1990/pr-genius (commit history, 2026-07-02T23:36 GMT+8)", "verified_date": "", "domain_expert": ""}
+{
+  "domain": "devops",
+  "title": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper\", \"domain\": \"devops\", \"tags\": [\"git\", \"github\", \"credentials-helper\", \"pat\", \"multi-account\", \"403\", \"fork-workflow\"], \"status\": \"published\", \"confidence\": \"0.95\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"https://github.com/zsxh1990/pr-genius (commit history, 2026-07-02T23:36 GMT+8)\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 # Git Push to Fork Repo: "Permission Denied to Other User" — Wrong PAT Selected by Helper

--- a/lessons/contrib/lesson-07-uv-venv-seed-fix-no-pip.md
+++ b/lessons/contrib/lesson-07-uv-venv-seed-fix-no-pip.md
@@ -1,8 +1,12 @@
 ---
-domain: "devops"
-title: "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo"
-verification: "metadata-normalized"
-{"title": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo", "domain": "devops", "tags": ["python", "venv", "uv", "pip", "wsl", "ubuntu", "pep-668", "agent-reach-install"], "status": "published", "confidence": "0.92", "created": "2026-07-03", "updated": "2026-07-03", "source": "Real incident, agent-reach install (2026-07-03T00:25 GMT+8)", "verified_date": "", "domain_expert": ""}
+{
+  "domain": "devops",
+  "title": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo\", \"domain\": \"devops\", \"tags\": [\"python\", \"venv\", \"uv\", \"pip\", \"wsl\", \"ubuntu\", \"pep-668\", \"agent-reach-install\"], \"status\": \"published\", \"confidence\": \"0.92\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real incident, agent-reach install (2026-07-03T00:25 GMT+8)\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 # Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo

--- a/lessons/contrib/lesson-08-pip-https-proxy-clash.md
+++ b/lessons/contrib/lesson-08-pip-https-proxy-clash.md
@@ -1,8 +1,12 @@
 ---
-domain: "devops"
-title: "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890"
-verification: "metadata-normalized"
-{"title": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890", "domain": "devops", "tags": ["pip", "proxy", "wsl", "clash", "github-timeout", "agent-reach-install", "network-config"], "status": "published", "confidence": "0.94", "created": "2026-07-03", "updated": "2026-07-03", "source": "Real incident, agent-reach install (2026-07-03T00:30 GMT+8)", "verified_date": "", "domain_expert": ""}
+{
+  "domain": "devops",
+  "title": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890",
+  "verification": "metadata-normalized",
+  "{\"title\"": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890\", \"domain\": \"devops\", \"tags\": [\"pip\", \"proxy\", \"wsl\", \"clash\", \"github-timeout\", \"agent-reach-install\", \"network-config\"], \"status\": \"published\", \"confidence\": \"0.94\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real incident, agent-reach install (2026-07-03T00:30 GMT+8)\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 # pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890

--- a/lessons/contrib/lesson-09-v2ex-api-show-endpoint-unstable.md
+++ b/lessons/contrib/lesson-09-v2ex-api-show-endpoint-unstable.md
@@ -1,8 +1,12 @@
 ---
-domain: "scraping"
-title: "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead"
-verification: "metadata-normalized"
-{"title": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead", "domain": "scraping", "tags": ["v2ex", "api", "json-parse-error", "jina-reader", "fallback-strategy", "agent-reach"], "status": "published", "confidence": "0.85", "created": "2026-07-03", "updated": "2026-07-03", "source": "Real incident, lesson fetching from V2EX 2026-07-03T00:42 GMT+8", "verified_date": "", "domain_expert": ""}
+{
+  "domain": "scraping",
+  "title": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead",
+  "verification": "metadata-normalized",
+  "{\"title\"": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead\", \"domain\": \"scraping\", \"tags\": [\"v2ex\", \"api\", \"json-parse-error\", \"jina-reader\", \"fallback-strategy\", \"agent-reach\"], \"status\": \"published\", \"confidence\": \"0.85\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real incident, lesson fetching from V2EX 2026-07-03T00:42 GMT+8\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 # V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead

--- a/lessons/contrib/lesson-10-agent-reach-doctor-baseline.md
+++ b/lessons/contrib/lesson-10-agent-reach-doctor-baseline.md
@@ -1,8 +1,12 @@
 ---
-domain: "tooling"
-title: "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login"
-verification: "metadata-normalized"
-{"title": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login", "domain": "tooling", "tags": ["agent-reach", "doctor", "channel-availability", "baseline", "v2ex", "rss", "jina", "bilibili", "cookie-required"], "status": "published", "confidence": "0.88", "created": "2026-07-03", "updated": "2026-07-03", "source": "Real test output 2026-07-03T00:32 GMT+8 on WSL Ubuntu", "verified_date": "", "domain_expert": ""}
+{
+  "domain": "tooling",
+  "title": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login\", \"domain\": \"tooling\", \"tags\": [\"agent-reach\", \"doctor\", \"channel-availability\", \"baseline\", \"v2ex\", \"rss\", \"jina\", \"bilibili\", \"cookie-required\"], \"status\": \"published\", \"confidence\": \"0.88\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real test output 2026-07-03T00:32 GMT+8 on WSL Ubuntu\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 # Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login

--- a/lessons/contrib/lesson_file_line_number_corruption.md
+++ b/lessons/contrib/lesson_file_line_number_corruption.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Before — inspect raw first line"
-verification: "metadata-normalized"
-{"title": "File Content Corrupted by Terminal Line-Number Prefixes", "domain": "devops", "tags": ["terminal", "sed", "line-number", "file-corruption", "html", "debug"], "status": "published", "created": "2026-06-20", "source": "codewhale"}
+{
+  "domain": "contrib",
+  "title": "Before — inspect raw first line",
+  "verification": "metadata-normalized",
+  "{\"title\"": "File Content Corrupted by Terminal Line-Number Prefixes\", \"domain\": \"devops\", \"tags\": [\"terminal\", \"sed\", \"line-number\", \"file-corruption\", \"html\", \"debug\"], \"status\": \"published\", \"created\": \"2026-06-20\", \"source\": \"codewhale\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/lessons-md-fix-heading-block-type.md
+++ b/lessons/contrib/lessons-md-fix-heading-block-type.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "lessons md fix heading block type"
-verification: "metadata-normalized"
-{"title": "lessons.md 修正（4 处） 项目 旧结论 修正后 heading block（type=4", "domain": "rag", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
+{
+  "domain": "contrib",
+  "title": "lessons md fix heading block type",
+  "verification": "metadata-normalized",
+  "{\"title\"": "lessons.md 修正（4 处） 项目 旧结论 修正后 heading block（type=4\", \"domain\": \"rag\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/misakanet-heal-engine-bootstrap-workflow.md
+++ b/lessons/contrib/misakanet-heal-engine-bootstrap-workflow.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "MisakaNet --heal Engine Bootstrap Workflow"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "MisakaNet --heal Engine Bootstrap Workflow",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "MisakaNet --heal Engine Bootstrap Workflow — From Traceback to Covered Lesson", "domain": "development", "scope": "broad", "tags": ["misakanet", "heal", "bm25", "broad-only", "fixture", "coverage", "lesson-submission", "workflow", "openclaw"], "status": "published", "confidence": "0.85", "source": "Misaka10004", "created": "2026-06-23", "updated": "2026-06-23"}---
 

--- a/lessons/contrib/misakanet-heal-ux-gap-queue-lesson-flag-mismatch.md
+++ b/lessons/contrib/misakanet-heal-ux-gap-queue-lesson-flag-mismatch.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag (--file not -f)", "domain": "development", "scope": "broad", "tags": ["misakanet", "heal", "ux", "queue-lesson", "cli", "argparse", "fixture", "openclaw", "flag-mismatch"], "status": "published", "confidence": "0.9", "source": "Misaka10004", "created": "2026-06-23", "updated": "2026-06-23"}---
 

--- a/lessons/contrib/misakanet-refactor-v2-review.md
+++ b/lessons/contrib/misakanet-refactor-v2-review.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "misakanet refactor v2 review"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "misakanet refactor v2 review",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "MisakaNet Refactoring复盘 — 从中心协调到 Agent 图书馆", "domain": "development", "tags": ["refactor", "architecture", "v2", "misakanet"], "status": "published", "source": "deepseek", "created": "2026-05-30 02:00:00 UTC", "updated": "2026-05-30 02:00:00 UTC"}---
 

--- a/lessons/contrib/model-output-fix.md
+++ b/lessons/contrib/model-output-fix.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "模型输出截断 / JSON 解析失败Handling"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "模型输出截断 / JSON 解析失败Handling",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "claude", "source": "hermes_wsl", "status": "published", "tags": "", "title": "模型输出截断 / JSON 解析失败Handling", "updated": "2026-05-01 08:00 UTC"}---
 

--- a/lessons/contrib/model-switch-script-pattern.md
+++ b/lessons/contrib/model-switch-script-pattern.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "多模型Switch脚本模式 — 双 Agent 模型管理"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "多模型Switch脚本模式 — 双 Agent 模型管理",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "多模型Switch脚本模式 — 双 Agent 模型管理", "confidence": "0.7", "created": "2026-05-02", "domain": "devops", "source": "bootstrap", "status": "published", "tags": ""}---
 

--- a/lessons/contrib/openai-compatible-api-call.md
+++ b/lessons/contrib/openai-compatible-api-call.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "OpenAI 兼容 API 的通用调用格式"
-verification: "metadata-normalized"
-{"title": "OpenAI 兼容 API 的通用调用格式", "domain": "development", "tags": ["api", "openai", "llm", "inference", "chat"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "OpenAI 兼容 API 的通用调用格式",
+  "verification": "metadata-normalized",
+  "{\"title\"": "OpenAI 兼容 API 的通用调用格式\", \"domain\": \"development\", \"tags\": [\"api\", \"openai\", \"llm\", \"inference\", \"chat\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/openclaw-fatal-error-hook-protocol.md
+++ b/lessons/contrib/openclaw-fatal-error-hook-protocol.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks", "domain": "development", "tags": ["openclaw", "fatal-error", "child-process", "spawn", "argv", "shell-injection", "fire-and-forget", "protocol", "heal"], "status": "published", "confidence": "0.95", "source": "hermes_wsl2", "created": "2026-06-16", "updated": "2026-06-16"}---
 

--- a/lessons/contrib/openclaw-gateway-dynamic-module-missing.md
+++ b/lessons/contrib/openclaw-gateway-dynamic-module-missing.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "openclaw gateway dynamic module missing"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "openclaw gateway dynamic module missing",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "OpenClaw Gateway 动态Module Not Found — 飞书Messaging分发失败", "domain": "feishu", "subdomain": "openclaw-debug", "source": "bootstrap", "status": "published", "confidence": "1.0", "created": "2026-05-18", "tags": "node:misaka10004\", \"platform:wsl\", \"severity:critical\", \"project:misakanet"}---
 

--- a/lessons/contrib/openclaw-playwright-wsl-libnss3-libnspr4-snap-chromium.md
+++ b/lessons/contrib/openclaw-playwright-wsl-libnss3-libnspr4-snap-chromium.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4"
-verification: "metadata-normalized"
-{"title": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4 - use system snap chromium as executable_path", "domain": "openclaw", "scope": "broad", "source": "openclaw-node-misaka10004", "status": "published", "tags": ["openclaw", "playwright", "chromium", "wsl", "libnss3", "libnspr4", "snap", "browser-automation", "executable_path"], "created": "2026-06-23", "updated": "2026-06-23", "verified_date": "", "domain_expert": ""}
+{
+  "domain": "contrib",
+  "title": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4 - use system snap chromium as executable_path\", \"domain\": \"openclaw\", \"scope\": \"broad\", \"source\": \"openclaw-node-misaka10004\", \"status\": \"published\", \"tags\": [\"openclaw\", \"playwright\", \"chromium\", \"wsl\", \"libnss3\", \"libnspr4\", \"snap\", \"browser-automation\", \"executable_path\"], \"created\": \"2026-06-23\", \"updated\": \"2026-06-23\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 # Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4

--- a/lessons/contrib/openclaw-prefer-cli-and-policy-over-direct-edit.md
+++ b/lessons/contrib/openclaw-prefer-cli-and-policy-over-direct-edit.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "openclaw prefer cli and policy over direct edit"
-verification: "metadata-normalized"
-{"title": "OpenClaw优先CLI和官方策略", "domain": "agentops", "tags": ["openclaw", "cli", "policy", "config"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "openclaw prefer cli and policy over direct edit",
+  "verification": "metadata-normalized",
+  "{\"title\"": "OpenClaw优先CLI和官方策略\", \"domain\": \"agentops\", \"tags\": [\"openclaw\", \"cli\", \"policy\", \"config\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/openclaw-reinstall-lesson.md
+++ b/lessons/contrib/openclaw-reinstall-lesson.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "OpenClaw 重装教训 — 删除前先停服务清残留"
-verification: "metadata-normalized"
-{"title": "OpenClaw 重装教训 — 删除前先停服务清残留", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01", "domain_expert": "bootstrap", "verified_date": "2026-04-01"}
+{
+  "domain": "contrib",
+  "title": "OpenClaw 重装教训 — 删除前先停服务清残留",
+  "verification": "metadata-normalized",
+  "{\"title\"": "OpenClaw 重装教训 — 删除前先停服务清残留\", \"domain\": \"devops\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 

--- a/lessons/contrib/oss-refactor-lessons.md
+++ b/lessons/contrib/oss-refactor-lessons.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "oss refactor lessons"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "oss refactor lessons",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "开源项目Refactoring复盘 — 从功能堆砌到减法优先", "domain": "development", "tags": ["refactor", "architecture", "lessons", "open-source", "cleanup", "focus", "repository-management"], "status": "published", "source": "deepseek", "created": "2026-05-30 04:00:00 UTC", "updated": "2026-06-14 00:00:00 UTC"}---
 

--- a/lessons/contrib/permission-denied-fix.md
+++ b/lessons/contrib/permission-denied-fix.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Permission Denied / WSL NTFS 跨文件系统PermissionFix"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix", "updated": "2026-05-01 08:00 UTC"}---
 

--- a/lessons/contrib/phase-0-output-gate.md
+++ b/lessons/contrib/phase-0-output-gate.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "phase 0 output gate"
-verification: "metadata-normalized"
-{"title": "Phase 0 Output Gate — Agent 的硬性知识检索规则", "domain": "methodology", "tags": ["output-gate", "knowledge-reuse", "methodology", "core"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "phase 0 output gate",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Phase 0 Output Gate — Agent 的硬性知识检索规则\", \"domain\": \"methodology\", \"tags\": [\"output-gate\", \"knowledge-reuse\", \"methodology\", \"core\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/pip-install-failure-fix.md
+++ b/lessons/contrib/pip-install-failure-fix.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "pip install Network Timeout / SSL / 依赖ConflictFix"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "pip install Network Timeout / SSL / 依赖ConflictFix",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "pip install Network Timeout / SSL / 依赖ConflictFix", "updated": "2026-05-01 08:00 UTC"}---
 

--- a/lessons/contrib/pip-install-timeout-ssl.md
+++ b/lessons/contrib/pip-install-timeout-ssl.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "pip install Network Timeout / SSL ErrorFix"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "pip install Network Timeout / SSL ErrorFix",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "pip install Network Timeout / SSL ErrorFix", "domain": "devops", "tags": ["pip", "network", "SSL", "timeout", "proxy"]}---
 

--- a/lessons/contrib/promo-use-real-examples-not-hypotheticals.md
+++ b/lessons/contrib/promo-use-real-examples-not-hypotheticals.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "promo use real examples not hypotheticals"
-verification: "metadata-normalized"
-{"title": "Promo Copy — Use Real Examples, Don't Fabricate", "domain": "marketing", "subdomain": "content", "source": "Misaka10004", "tags": ["outreach", "content-strategy", "awesome-list", "reddit", "hacker-news"], "confidence": "0.9", "created": "2026-05-21", "domain_expert": "Misaka10004", "verified_date": "2026-05-21"}
+{
+  "domain": "contrib",
+  "title": "promo use real examples not hypotheticals",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Promo Copy — Use Real Examples, Don't Fabricate\", \"domain\": \"marketing\", \"subdomain\": \"content\", \"source\": \"Misaka10004\", \"tags\": [\"outreach\", \"content-strategy\", \"awesome-list\", \"reddit\", \"hacker-news\"], \"confidence\": \"0.9\", \"created\": \"2026-05-21\", \"domain_expert\": \"Misaka10004\", \"verified_date\": \"2026-05-21\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/python-gbk-encoding-error.md
+++ b/lessons/contrib/python-gbk-encoding-error.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Python GBK Encoding Error — Windows/WSL 跨平台"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Python GBK Encoding Error — Windows/WSL 跨平台",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Python GBK Encoding Error — Windows/WSL 跨平台", "domain": "devops", "tags": ["python", "encoding", "gbk", "windows", "wsl"]}---
 

--- a/lessons/contrib/python-pycache-stale.md
+++ b/lessons/contrib/python-pycache-stale.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Python 代码修改不生效 — stale .pyc Cache"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Python 代码修改不生效 — stale .pyc Cache",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Python 代码修改不生效 — stale .pyc Cache", "domain": "devops", "tags": ["python", "pyc", "cache", "debug"]}---
 

--- a/lessons/contrib/python-sandbox-path-isolation.md
+++ b/lessons/contrib/python-sandbox-path-isolation.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Python 沙箱/受限环境 — PATH 和 sys.path 隔离"
-verification: "metadata-normalized"
-{"title": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离", "domain": "development", "tags": ["python", "sandbox", "path", "import", "venv"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离\", \"domain\": \"development\", \"tags\": [\"python\", \"sandbox\", \"path\", \"import\", \"venv\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/python-venv-tiktoken-module-not-found.md
+++ b/lessons/contrib/python-venv-tiktoken-module-not-found.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError"
-verification: "metadata-normalized"
-{"title": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError", "domain": "development", "source": "Misaka10019", "tags": ["python", "venv", "tiktoken", "pip", "setuptools"], "domain_expert": "Misaka10019"}
+{
+  "domain": "contrib",
+  "title": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError\", \"domain\": \"development\", \"source\": \"Misaka10019\", \"tags\": [\"python\", \"venv\", \"tiktoken\", \"pip\", \"setuptools\"], \"domain_expert\": \"Misaka10019\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/python-venv-troubleshoot.md
+++ b/lessons/contrib/python-venv-troubleshoot.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Python venv 激活失败或路径不匹配"
-verification: "metadata-normalized"
-{"title": "Python venv 激活失败或路径不匹配", "domain": "devops", "tags": ["python", "venv", "virtualenv", "path"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "Python venv 激活失败或路径不匹配",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Python venv 激活失败或路径不匹配\", \"domain\": \"devops\", \"tags\": [\"python\", \"venv\", \"virtualenv\", \"path\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/rag-alarm-code-mandatory-recall.md
+++ b/lessons/contrib/rag-alarm-code-mandatory-recall.md
@@ -7,7 +7,7 @@
   "tags": [
     "project:self-grow-wiki",
     "severity:high",
-    "node:hermes_wsl"
+    "node:hermes-wsl"
   ],
   "language": "en",
   "created": "2026-05-03",

--- a/lessons/contrib/rag-brand-contamination-detection-and-fix.md
+++ b/lessons/contrib/rag-brand-contamination-detection-and-fix.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "RAG 知识库品牌污染Detection与治理"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "RAG 知识库品牌污染Detection与治理",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "RAG 知识库品牌污染Detection与治理", "domain": "rag", "tags": ["rag", "chromadb", "brand-contamination", "data-quality", "metadata"], "confidence": 0.9, "created": "2026-05-29"}---
 

--- a/lessons/contrib/rag-brand-filter-three-pitfalls.md
+++ b/lessons/contrib/rag-brand-filter-three-pitfalls.md
@@ -9,7 +9,8 @@
     "project:self-grow-wiki",
     "severity:medium",
     "node:hermes-wsl"
-  ]
+  ],
+  "created": "2026-07-06"
 }
 ---
 

--- a/lessons/contrib/rag-chinese-encoding-pymupdf.md
+++ b/lessons/contrib/rag-chinese-encoding-pymupdf.md
@@ -9,7 +9,8 @@
     "project:self-grow-wiki",
     "severity:medium",
     "node:hermes-wsl"
-  ]
+  ],
+  "created": "2026-07-06"
 }
 ---
 

--- a/lessons/contrib/rag-chunk-params-800-100.md
+++ b/lessons/contrib/rag-chunk-params-800-100.md
@@ -7,7 +7,7 @@
   "tags": [
     "project:self-grow-wiki",
     "severity:medium",
-    "node:hermes_wsl"
+    "node:hermes-wsl"
   ],
   "language": "en",
   "created": "2026-05-03",

--- a/lessons/contrib/rag-three-channel-llm-disaster-recovery.md
+++ b/lessons/contrib/rag-three-channel-llm-disaster-recovery.md
@@ -6,7 +6,7 @@
   "status": "published",
   "tags": [
     "project:self-grow-wiki",
-    "node:hermes_wsl",
+    "node:hermes-wsl",
     "scope:broad"
   ],
   "language": "en",

--- a/lessons/contrib/readme-seven-traps-fix-checklist.md
+++ b/lessons/contrib/readme-seven-traps-fix-checklist.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist", "domain": "development", "tags": ["readme", "open-source", "documentation", "marketing", "community"], "status": "published", "source": "deepseek", "created": "2026-06-04 00:00:00 UTC", "updated": "2026-06-04 00:00:00 UTC"}---
 

--- a/lessons/contrib/regex-greedy-matching.md
+++ b/lessons/contrib/regex-greedy-matching.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "正则表达式 debugging — 贪婪匹配造成的意外结果"
-verification: "metadata-normalized"
-{"title": "正则表达式 debugging — 贪婪匹配造成的意外结果", "domain": "development", "tags": ["regex", "debug", "greedy", "pattern"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "正则表达式 debugging — 贪婪匹配造成的意外结果",
+  "verification": "metadata-normalized",
+  "{\"title\"": "正则表达式 debugging — 贪婪匹配造成的意外结果\", \"domain\": \"development\", \"tags\": [\"regex\", \"debug\", \"greedy\", \"pattern\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/registration-chain-worker-fallback.md
+++ b/lessons/contrib/registration-chain-worker-fallback.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow"
-verification: "metadata-normalized"
-{"title": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow", "domain": "devops", "tags": ["registration", "worker", "register", "github-actions", "feishu", "fallback"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow",
+  "verification": "metadata-normalized",
+  "{\"title\"": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow\", \"domain\": \"devops\", \"tags\": [\"registration\", \"worker\", \"register\", \"github-actions\", \"feishu\", \"fallback\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/shared-json-needs-atomic-write.md
+++ b/lessons/contrib/shared-json-needs-atomic-write.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "shared json needs atomic write"
-verification: "metadata-normalized"
-{"title": "共享JSON状态需要原子写入", "domain": "devops", "tags": ["json", "atomic", "race-condition", "runtime"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "shared json needs atomic write",
+  "verification": "metadata-normalized",
+  "{\"title\"": "共享JSON状态需要原子写入\", \"domain\": \"devops\", \"tags\": [\"json\", \"atomic\", \"race-condition\", \"runtime\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/shell-script-debugging.md
+++ b/lessons/contrib/shell-script-debugging.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Shell Debugging — set -x 与常见Pitfalls"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Shell Debugging — set -x 与常见Pitfalls",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Shell Debugging — set -x 与常见Pitfalls", "domain": "development", "tags": ["shell", "bash", "debug", "script"]}---
 

--- a/lessons/contrib/slugify-path-traversal-deep-coverage.md
+++ b/lessons/contrib/slugify-path-traversal-deep-coverage.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "slugify path traversal deep coverage"
-verification: "metadata-normalized"
-{"title": "Slugify: deep coverage of path traversal, null bytes, and reserved names", "domain": "scripts", "tags": ["slugify", "path-traversal", "windows-reserved", "null-byte", "test-coverage", "hardening"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "slugify path traversal deep coverage",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Slugify: deep coverage of path traversal, null bytes, and reserved names\", \"domain\": \"scripts\", \"tags\": [\"slugify\", \"path-traversal\", \"windows-reserved\", \"null-byte\", \"test-coverage\", \"hardening\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/slugify-windows-path-sanitation.md
+++ b/lessons/contrib/slugify-windows-path-sanitation.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "slugify windows path sanitation"
-verification: "metadata-normalized"
-{"title": "Slugify filename sanitation crash on Windows and WSL", "domain": "scripts", "tags": ["slugify", "windows", "wsl", "sanitation", "path-errors"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "slugify windows path sanitation",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Slugify filename sanitation crash on Windows and WSL\", \"domain\": \"scripts\", \"tags\": [\"slugify\", \"windows\", \"wsl\", \"sanitation\", \"path-errors\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/static-page-github-api-403-rate-limit.md
+++ b/lessons/contrib/static-page-github-api-403-rate-limit.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "static page github api 403 rate limit"
-verification: "metadata-normalized"
-{"title": "静态页面调用外部 API 的容错设计原则", "domain": "frontend", "tags": ["api", "rate-limit", "static-site", "error-handling", "fault-tolerance"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "static page github api 403 rate limit",
+  "verification": "metadata-normalized",
+  "{\"title\"": "静态页面调用外部 API 的容错设计原则\", \"domain\": \"frontend\", \"tags\": [\"api\", \"rate-limit\", \"static-site\", \"error-handling\", \"fault-tolerance\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/static-page-width-consistency.md
+++ b/lessons/contrib/static-page-width-consistency.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "static page width consistency"
-verification: "metadata-normalized"
-{"title": "静态页面多组件宽度一致性——各自定义 max-width 导致视觉割裂", "domain": "frontend", "tags": ["css", "layout", "ux", "responsive"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "static page width consistency",
+  "verification": "metadata-normalized",
+  "{\"title\"": "静态页面多组件宽度一致性——各自定义 max-width 导致视觉割裂\", \"domain\": \"frontend\", \"tags\": [\"css\", \"layout\", \"ux\", \"responsive\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/supabase-capacity-constraints-project-operations.md
+++ b/lessons/contrib/supabase-capacity-constraints-project-operations.md
@@ -1,5 +1,21 @@
 ---
-{"title":"Supabase capacity constraints caused project operation failures","domain":"database","tags":["incident","postmortem","capacity","supabase","database","operations"],"status":"published","source":"hackernews","source_url":"https://status.supabase.com/incidents/3tx3nnmbwyh9","language":"en"}
+{
+  "title": "Supabase capacity constraints caused project operation failures",
+  "domain": "database",
+  "tags": [
+    "incident",
+    "postmortem",
+    "capacity",
+    "supabase",
+    "database",
+    "operations"
+  ],
+  "status": "published",
+  "source": "hackernews",
+  "source_url": "https://status.supabase.com/incidents/3tx3nnmbwyh9",
+  "language": "en",
+  "created": "2026-07-06"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/swarm-pr-battle-playbook.md
+++ b/lessons/contrib/swarm-pr-battle-playbook.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams", "domain": "development", "tags": ["pr", "ai-review", "github-actions", "fatal-error", "spawn", "shell-injection", "esm", "ci", "playbook", "sop"], "status": "published", "confidence": "0.95", "source": "hermes_wsl2", "created": "2026-06-17", "updated": "2026-06-17"}---
 

--- a/lessons/contrib/tmux-session-management.md
+++ b/lessons/contrib/tmux-session-management.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "tmux 终端复用 — 断开不丢失会话"
-verification: "metadata-normalized"
-{"title": "tmux 终端复用 — 断开不丢失会话", "domain": "development", "tags": ["tmux", "terminal", "session", "background"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "tmux 终端复用 — 断开不丢失会话",
+  "verification": "metadata-normalized",
+  "{\"title\"": "tmux 终端复用 — 断开不丢失会话\", \"domain\": \"development\", \"tags\": [\"tmux\", \"terminal\", \"session\", \"background\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/tts-chinese-encoding-powershell.md
+++ b/lessons/contrib/tts-chinese-encoding-powershell.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "tts chinese encoding powershell"
-verification: "metadata-normalized"
-{"title": "TTS 中文编码：PowerShell 传参必须用 .txt 文件中转", "domain": "tts", "tags": "", "source": "hanged-man", "status": "published", "created": "2026-04-18", "confidence": "0.9", "scope": "broad", "domain_expert": "hanged-man", "verified_date": "2026-04-18"}
+{
+  "domain": "contrib",
+  "title": "tts chinese encoding powershell",
+  "verification": "metadata-normalized",
+  "{\"title\"": "TTS 中文编码：PowerShell 传参必须用 .txt 文件中转\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-18\", \"confidence\": \"0.9\", \"scope\": \"broad\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-18\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 问题

--- a/lessons/contrib/vertical-kb-question-bank-strategy.md
+++ b/lessons/contrib/vertical-kb-question-bank-strategy.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study"
-verification: "metadata-normalized"
-{"title": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study", "domain": "rag-knowledge-base", "source": "deepseek-tui", "status": "published", "tags": ["rag", "question-bank", "knowledge-base", "feishu-doc", "review"], "created": "2026-05-19", "updated": "2026-05-19", "domain_expert": "deepseek-tui", "verified_date": "2026-05-19"}
+{
+  "domain": "contrib",
+  "title": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study\", \"domain\": \"rag-knowledge-base\", \"source\": \"deepseek-tui\", \"status\": \"published\", \"tags\": [\"rag\", \"question-bank\", \"knowledge-base\", \"feishu-doc\", \"review\"], \"created\": \"2026-05-19\", \"updated\": \"2026-05-19\", \"domain_expert\": \"deepseek-tui\", \"verified_date\": \"2026-05-19\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/wcferry-wechat-version-lock.md
+++ b/lessons/contrib/wcferry-wechat-version-lock.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "wcferry wechat version lock"
-verification: "metadata-normalized"
-{"title": "wcferry 微信版本锁定 — 3.9.12.51 才能用", "domain": "devops", "subdomain": "wechat", "source": "bootstrap", "status": "published", "tags": ["project:rag", "platform:windows", "node:hermes_wsl", "scope:narrow"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "wcferry wechat version lock",
+  "verification": "metadata-normalized",
+  "{\"title\"": "wcferry 微信版本锁定 — 3.9.12.51 才能用\", \"domain\": \"devops\", \"subdomain\": \"wechat\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:windows\", \"node:hermes_wsl\", \"scope:narrow\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md
+++ b/lessons/contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "wechat pubacct fetch separate search from retrieval"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "wechat pubacct fetch separate search from retrieval",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "微信公众号抓取失败Handling（搜索与抓取分离）", "domain": "wechat", "tags": ["wechat", "fetch", "search", "crawl"]}---
 

--- a/lessons/contrib/wecom-robot-long-connect-no-ngrok.md
+++ b/lessons/contrib/wecom-robot-long-connect-no-ngrok.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "wecom robot long connect no ngrok"
-verification: "metadata-normalized"
-{"title": "企业微信机器人：长连接模式不需要 ngrok", "domain": "devops", "subdomain": "wecom", "source": "bootstrap", "status": "published", "tags": ["project:rag", "platform:windows", "node:hermes_wsl", "scope:narrow"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "wecom robot long connect no ngrok",
+  "verification": "metadata-normalized",
+  "{\"title\"": "企业微信机器人：长连接模式不需要 ngrok\", \"domain\": \"devops\", \"subdomain\": \"wecom\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:windows\", \"node:hermes_wsl\", \"scope:narrow\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/write-file-sandbox-worktree-git-path.md
+++ b/lessons/contrib/write-file-sandbox-worktree-git-path.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "write file sandbox worktree git path"
-verification: "metadata-normalized"
-{"title": "Agent Write File 写入不落地 + Worktree Git 链接路径断裂", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"], "created": "2026-05-13 01:01:46 UTC", "updated": "2026-05-13 01:01:46 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-13"}
+{
+  "domain": "contrib",
+  "title": "write file sandbox worktree git path",
+  "verification": "metadata-normalized",
+  "{\"title\"": "Agent Write File 写入不落地 + Worktree Git 链接路径断裂\", \"domain\": \"devops\", \"source\": \"hermes_wsl2\", \"status\": \"published\", \"tags\": [\"agent-mode\", \"write-file\", \"worktree\", \"wsl\", \"git\", \"lesson-written\"], \"created\": \"2026-05-13 01:01:46 UTC\", \"updated\": \"2026-05-13 01:01:46 UTC\", \"domain_expert\": \"hermes_wsl2\", \"verified_date\": \"2026-05-13\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/wsl-permission-ntfs-fix.md
+++ b/lessons/contrib/wsl-permission-ntfs-fix.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "Permission Denied / WSL NTFS 跨文件系统PermissionFix"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix", "domain": "devops", "tags": ["permission", "wsl", "ntfs", "eacces", "filesystem"]}---
 

--- a/lessons/contrib/wsl-pip-gbk-hub-poller-crash.md
+++ b/lessons/contrib/wsl-pip-gbk-hub-poller-crash.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "wsl pip gbk hub poller crash"
-verification: "metadata-normalized"
-{"title": "WSL pip install GBK 编码导致 hub_poller 崩溃", "domain": "devops", "subdomain": "wsl", "source": "bootstrap", "status": "published", "tags": ["project:agent-medici", "severity:critical", "platform:wsl", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "wsl pip gbk hub poller crash",
+  "verification": "metadata-normalized",
+  "{\"title\"": "WSL pip install GBK 编码导致 hub_poller 崩溃\", \"domain\": \"devops\", \"subdomain\": \"wsl\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:agent-medici\", \"severity:critical\", \"platform:wsl\", \"node:hermes_wsl\"], \"confidence\": \"0.8\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/wsl-proxy-huggingface-external.md
+++ b/lessons/contrib/wsl-proxy-huggingface-external.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "wsl proxy huggingface external"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "wsl proxy huggingface external",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "WSL 需要代理Setup才能Access HuggingFace 和外部网络", "domain": "devops", "subdomain": "wsl", "source": "bootstrap", "status": "published", "tags": ["project:self-grow-wiki", "severity:high", "platform:wsl", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03"}---
 

--- a/lessons/contrib/wsl-proxy-setup.md
+++ b/lessons/contrib/wsl-proxy-setup.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "WSL 代理Setup — 通过 Windows 梯子Access外网"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "WSL 代理Setup — 通过 Windows 梯子Access外网",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "WSL 代理Setup — 通过 Windows 梯子Access外网", "domain": "devops", "tags": ["wsl", "proxy", "network", "windows"]}---
 

--- a/lessons/contrib/wsl-terminal-underscore-corruption.md
+++ b/lessons/contrib/wsl-terminal-underscore-corruption.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "WSL 终端编辑Setup危险 — TTy粘贴吞下划线"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "WSL 终端编辑Setup危险 — TTy粘贴吞下划线",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "WSL 终端编辑Setup危险 — TTy粘贴吞下划线", "domain": "devops", "source": "bootstrap", "bootstrapped": true, "author": "node2", "machine": "hermes-wsl", "original_date": "2026-04-24", "tags": "", "- node": "hermes_wsl", "- project": "wsl", "- severity": "high", "status": "published", "quality": "published", "created": "2026-04-01", "confidence": "0.7"}---
 

--- a/lessons/contrib/wsl-terminal-underscore-missing.md
+++ b/lessons/contrib/wsl-terminal-underscore-missing.md
@@ -1,7 +1,11 @@
 ---
-domain: "contrib"
-title: "WSL Windows 终端复制粘贴吞下划线Issue"
-verification: "metadata-normalized"
+{
+  "domain": "contrib",
+  "title": "WSL Windows 终端复制粘贴吞下划线Issue",
+  "verification": "metadata-normalized",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 ---{"title": "WSL Windows 终端复制粘贴吞下划线Issue", "domain": "devops", "tags": ["wsl", "terminal", "windows", "encoding"]}---
 

--- a/lessons/contrib/wsl2-memory-leak-fix.md
+++ b/lessons/contrib/wsl2-memory-leak-fix.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "WSL2 内存泄漏 / 内存占用过高"
-verification: "metadata-normalized"
-{"title": "WSL2 内存泄漏 / 内存占用过高", "domain": "devops", "tags": ["wsl", "memory", "leak", "performance"], "domain_expert": "unknown"}
+{
+  "domain": "contrib",
+  "title": "WSL2 内存泄漏 / 内存占用过高",
+  "verification": "metadata-normalized",
+  "{\"title\"": "WSL2 内存泄漏 / 内存占用过高\", \"domain\": \"devops\", \"tags\": [\"wsl\", \"memory\", \"leak\", \"performance\"], \"domain_expert\": \"unknown\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/wxauto-im-feedback-collection-jsonl-queue.md
+++ b/lessons/contrib/wxauto-im-feedback-collection-jsonl-queue.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "IM 机器人反馈收集与 JSONL 队列审核模式"
-verification: "metadata-normalized"
-{"title": "IM 机器人反馈收集与 JSONL 队列审核模式", "domain": "rag", "tags": ["rag", "feedback", "queue", "jsonl", "wechat", "wxauto", "workflow"], "confidence": 0.9, "created": "2026-05-21", "domain_expert": "unknown", "verified_date": "2026-05-21"}
+{
+  "domain": "contrib",
+  "title": "IM 机器人反馈收集与 JSONL 队列审核模式",
+  "verification": "metadata-normalized",
+  "{\"title\"": "IM 机器人反馈收集与 JSONL 队列审核模式\", \"domain\": \"rag\", \"tags\": [\"rag\", \"feedback\", \"queue\", \"jsonl\", \"wechat\", \"wxauto\", \"workflow\"], \"confidence\": 0.9, \"created\": \"2026-05-21\", \"domain_expert\": \"unknown\", \"verified_date\": \"2026-05-21\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/wxauto-windows-python-not-wsl.md
+++ b/lessons/contrib/wxauto-windows-python-not-wsl.md
@@ -1,8 +1,12 @@
 ---
-domain: "contrib"
-title: "wxauto 必须在 Windows Python 下安装，不能走 WSL pip"
-verification: "metadata-normalized"
-{"title": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip", "domain": "devops", "subdomain": "wechat", "source": "bootstrap", "status": "published", "tags": ["project:rag", "platform:windows", "node:hermes_wsl", "scope:narrow"], "confidence": "0.85", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "domain": "contrib",
+  "title": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip",
+  "verification": "metadata-normalized",
+  "{\"title\"": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip\", \"domain\": \"devops\", \"subdomain\": \"wechat\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:windows\", \"node:hermes_wsl\", \"scope:narrow\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
+  "created": "2026-07-06",
+  "source": "unknown"
+}
 ---
 
 ## Problem

--- a/lessons/core/cronjob-one-shot-race-condition-duplicate-execution.md
+++ b/lessons/core/cronjob-one-shot-race-condition-duplicate-execution.md
@@ -5,8 +5,8 @@
   "source": "hermes_wsl2",
   "status": "published",
   "tags": [
-    "node:ZKA",
-    "project:Hermes-Agent",
+    "node:zka",
+    "project:hermes-agent",
     "severity:critical"
   ],
   "created": "2026-06-05 00:48:38 UTC",

--- a/lessons/core/dco-auto-fix-workflow.md
+++ b/lessons/core/dco-auto-fix-workflow.md
@@ -6,7 +6,7 @@
     "github-actions",
     "dco",
     "signoff",
-    "issue_comment",
+    "issue-comment",
     "auto-fix",
     "fork-pr",
     "plan-b",

--- a/lessons/core/freellmapi-session-context-mixing-cross-thread-delivery.md
+++ b/lessons/core/freellmapi-session-context-mixing-cross-thread-delivery.md
@@ -5,8 +5,8 @@
   "source": "hermes_wsl2",
   "status": "published",
   "tags": [
-    "node:ZKA",
-    "project:Hermes-Agent",
+    "node:zka",
+    "project:hermes-agent",
     "severity:high"
   ],
   "created": "2026-06-05 00:48:54 UTC",

--- a/lessons/core/hermes-state-database-lock-issues-cleanup-protocol.md
+++ b/lessons/core/hermes-state-database-lock-issues-cleanup-protocol.md
@@ -5,8 +5,8 @@
   "source": "hermes_wsl2",
   "status": "published",
   "tags": [
-    "node:ZKA",
-    "project:Hermes-Agent",
+    "node:zka",
+    "project:hermes-agent",
     "severity:high"
   ],
   "created": "2026-06-05 00:49:07 UTC",

--- a/lessons/core/hx-state-database-lock-issues-cleanup-protocol.md
+++ b/lessons/core/hx-state-database-lock-issues-cleanup-protocol.md
@@ -5,8 +5,8 @@
   "source": "hermes_wsl2",
   "status": "published",
   "tags": [
-    "node:ZKA",
-    "project:Hermes-Agent",
+    "node:zka",
+    "project:hermes-agent",
     "severity:high"
   ],
   "created": "2026-06-05 00:49:07 UTC",

--- a/lessons/core/pull-request-welcome-trigger-trap.md
+++ b/lessons/core/pull-request-welcome-trigger-trap.md
@@ -4,8 +4,8 @@
   "domain": "devops",
   "tags": [
     "github-actions",
-    "pull_request_target",
-    "author_association",
+    "pull-request-target",
+    "author-association",
     "first-time-contributor",
     "welcome",
     "debug"

--- a/misakanet/profile.json
+++ b/misakanet/profile.json
@@ -2,7 +2,7 @@
   "stage": "active",
   "referral_code": "MPR6KEOH",
   "referred_by": "",
-  "search_count": 12,
+  "search_count": 14,
   "lesson_count": 0,
-  "last_active": "2026-07-06T02:13:44.059556+00:00"
+  "last_active": "2026-07-07T03:19:45.742095+00:00"
 }

--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -302,6 +302,27 @@ def _metadata_bonus(query: str, doc: CachedDoc) -> float:
     return min(bonus, MAX_METADATA)
 
 
+def _metadata_bonus_breakdown(query: str, doc: CachedDoc) -> list[tuple[str, float]]:
+    """Return per-field metadata bonus breakdown for --explain mode."""
+    parts = []
+    q = query.lower()
+    t = doc.title.lower()
+    if doc.domain and doc.domain.lower() in q:
+        parts.append(("domain_match", WEIGHT_DOMAIN_MATCH))
+    if t == q:
+        parts.append(("title_exact", WEIGHT_TITLE_EXACT))
+    elif q in t or any(word in t for word in q.split()):
+        parts.append(("title_partial", WEIGHT_TITLE_PARTIAL))
+    status_w = WEIGHT_STATUS.get(doc.status, 0.0)
+    if status_w:
+        parts.append((f"status({doc.status})", status_w))
+    if doc.reference:
+        parts.append(("has_reference", WEIGHT_HAS_REF))
+    if doc.source and doc.source != "bootstrap":
+        parts.append(("source", 0.05))
+    return parts
+
+
 def _normalize(values: list[float]) -> list[float]:
     if not values:
         return values
@@ -327,6 +348,20 @@ def _compute_boost(doc: CachedDoc) -> float:
     if doc.is_draft:
         boost += BOOST_DRAFT
     return boost
+
+
+def _compute_boost_breakdown(doc: CachedDoc) -> list[tuple[str, float]]:
+    """Return per-factor boost breakdown for --explain mode."""
+    parts = []
+    if _is_core(doc):
+        parts.append(("core", BOOST_CORE))
+    if _is_verified(doc):
+        parts.append(("verified", BOOST_VERIFIED))
+    if _is_recent(doc):
+        parts.append(("recent", BOOST_RECENT))
+    if doc.is_draft:
+        parts.append(("draft", BOOST_DRAFT))
+    return parts
 
 
 def _rank_docs_impl(
@@ -456,17 +491,29 @@ def _format_output(
         print(f"  {'':>25} {_score_bar(score):>15}  {time_str}")
         if match_reason:
             print(f"  {'':>25} (matched: {match_reason})")
-        # Feature: --explain score breakdown
+        # Feature: --explain score breakdown (#303)
         if explain and query:
             bm25 = _compute_bm25_scores(query, [doc])[0]
-            meta = _metadata_bonus(query, doc)
+            meta_parts = _metadata_bonus_breakdown(query, doc)
+            meta_total = sum(v for _, v in meta_parts)
             baseline = doc.score_baseline
-            boost = _compute_boost(doc)  # Feature #228
+            boost_parts = _compute_boost_breakdown(doc)
+            boost_total = sum(v for _, v in boost_parts)
             tag_str = ", ".join(doc.tags[:5]) if doc.tags else "—"
-            print(
-                f"  {'':>25} ↳ BM25: {bm25:.3f} | Meta: {meta:.3f} | "
-                f"Base: {baseline:.3f} | Boost: {boost:+.2f} | Tags: {tag_str}"
-            )
+
+            print(f"  {'':>25} ↳ BM25: {bm25:.3f}")
+            if meta_parts:
+                meta_detail = ", ".join(f"{k}(+{v:.2f})" for k, v in meta_parts)
+                print(f"  {'':>25}   Meta: {meta_total:.3f} = {meta_detail}")
+            else:
+                print(f"  {'':>25}   Meta: 0.000")
+            print(f"  {'':>25}   Base: {baseline:.3f}")
+            if boost_parts:
+                boost_detail = ", ".join(f"{k}({v:+.2f})" for k, v in boost_parts)
+                print(f"  {'':>25}   Boost: {boost_total:+.2f} = {boost_detail}")
+            else:
+                print(f"  {'':>25}   Boost: +0.00")
+            print(f"  {'':>25}   Tags: {tag_str}")
         # Feature: related lessons (cross-lesson reference graph)
         if all_docs is not None:
             related = _get_related_lessons(doc, all_docs, max_related=3)

--- a/scripts/normalize_metadata.py
+++ b/scripts/normalize_metadata.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Normalize lesson frontmatter metadata for consistency (#306).
+
+Usage:
+    python3 scripts/normalize_metadata.py              # dry-run: show what would change
+    python3 scripts/normalize_metadata.py --fix         # apply fixes
+    python3 scripts/normalize_metadata.py --fix --push  # apply fixes and commit
+
+Normalization rules:
+    - domain: lowercase, no spaces
+    - tags: kebab-case
+    - status: one of published, draft, archived (active → published)
+    - title: required (skip files without it)
+    - created: required (use file mtime as fallback)
+    - source: required (default "unknown")
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LESSONS_DIR = REPO_ROOT / "lessons"
+
+VALID_STATUSES = {"published", "draft", "archived"}
+STATUS_MAP = {"active": "published"}  # deprecated → canonical
+
+FIX_MODE = "--fix" in sys.argv
+DRY_RUN = not FIX_MODE
+
+
+def parse_frontmatter(text: str) -> tuple[dict | None, int, int]:
+    """Parse frontmatter, return (meta_dict, body_start_line, body_end_line)."""
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return None, 0, 0
+    raw = m.group(1).strip()
+    fm_start = text.index(m.group(1))
+    fm_end = fm_start + len(m.group(1))
+
+    # Try JSON first
+    try:
+        return json.loads(raw), fm_start, fm_end
+    except json.JSONDecodeError:
+        pass
+
+    # Simple YAML-like parser
+    fm = {}
+    for line in raw.split("\n"):
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if val.startswith("[") and val.endswith("]"):
+            val = [v.strip().strip('"').strip("'") for v in val[1:-1].split(",")]
+        fm[key] = val
+    return fm, fm_start, fm_end
+
+
+def to_kebab_case(s: str) -> str:
+    """Convert a tag to kebab-case."""
+    s = s.strip().lower()
+    s = re.sub(r"[\s_]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")
+
+
+def normalize_meta(meta: dict, file_mtime: float) -> tuple[dict, list[str]]:
+    """Normalize metadata fields, return (new_meta, list_of_changes)."""
+    changes = []
+    new = dict(meta)
+
+    # 1. domain: lowercase, no spaces
+    if "domain" in new and new["domain"]:
+        old = new["domain"]
+        new["domain"] = old.lower().replace(" ", "-")
+        if new["domain"] != old:
+            changes.append(f"domain: {old!r} → {new['domain']!r}")
+
+    # 2. tags: kebab-case
+    if "tags" in new and isinstance(new["tags"], list):
+        old_tags = new["tags"]
+        new_tags = [to_kebab_case(t) for t in old_tags if t]
+        new_tags = [t for t in new_tags if t]  # remove empty
+        if new_tags != old_tags:
+            changes.append(f"tags: {old_tags} → {new_tags}")
+        new["tags"] = new_tags
+
+    # 3. status: normalize
+    if "status" in new and new["status"]:
+        old = new["status"]
+        mapped = STATUS_MAP.get(old, old)
+        if mapped not in VALID_STATUSES:
+            changes.append(f"status: {old!r} → 'published' (was not in {VALID_STATUSES})")
+            new["status"] = "published"
+        elif mapped != old:
+            changes.append(f"status: {old!r} → {mapped!r}")
+            new["status"] = mapped
+
+    # 4. created: add if missing (use file mtime)
+    if "created" not in new or not new["created"]:
+        dt = datetime.fromtimestamp(file_mtime, tz=timezone.utc)
+        new["created"] = dt.strftime("%Y-%m-%d")
+        changes.append(f"created: (added from mtime: {new['created']})")
+
+    # 5. source: add if missing
+    if "source" not in new or not new["source"]:
+        new["source"] = "unknown"
+        changes.append("source: (added: 'unknown')")
+
+    return new, changes
+
+
+def write_frontmatter(path: Path, meta: dict, body_start: int, body_end: int, original_text: str):
+    """Write normalized JSON frontmatter back to file."""
+    # Build new frontmatter as JSON (matching existing convention)
+    fm_json = json.dumps(meta, ensure_ascii=False, indent=2)
+
+    # Find the --- boundaries in original text
+    first_sep = original_text.index("---")
+    second_sep = original_text.index("---", first_sep + 3)
+
+    # Reconstruct: ---\n{json}\n---\n{body}
+    body = original_text[second_sep + 3:]
+    if body and not body.startswith("\n"):
+        body = "\n" + body
+    new_text = f"---\n{fm_json}\n---{body}"
+
+    path.write_text(new_text, encoding="utf-8")
+
+
+def main():
+    stats = {"scanned": 0, "would_fix": 0, "fixed": 0, "skipped": 0, "errors": 0}
+
+    for f in sorted(LESSONS_DIR.rglob("*.md")):
+        if f.name in ("index.md", "TEMPLATE.md", "README.md"):
+            continue
+        if "_archive" in f.parts:
+            continue
+
+        stats["scanned"] += 1
+        text = f.read_text(encoding="utf-8", errors="replace")
+        meta, fm_start, fm_end = parse_frontmatter(text)
+
+        if meta is None:
+            stats["skipped"] += 1
+            continue
+
+        mtime = f.stat().st_mtime
+        new_meta, changes = normalize_meta(meta, mtime)
+
+        if not changes:
+            continue
+
+        stats["would_fix"] += 1
+        rel = str(f.relative_to(LESSONS_DIR))
+        print(f"\n{'='*60}")
+        print(f"📝 {rel}")
+        for c in changes:
+            print(f"  • {c}")
+
+        if FIX_MODE:
+            try:
+                write_frontmatter(f, new_meta, fm_start, fm_end, text)
+                stats["fixed"] += 1
+                print(f"  ✅ Fixed")
+            except Exception as e:
+                stats["errors"] += 1
+                print(f"  ❌ Error: {e}")
+
+    print(f"\n{'='*60}")
+    print(f"📊 Summary: {stats['scanned']} scanned, {stats['would_fix']} need fixes")
+    if FIX_MODE:
+        print(f"   Fixed: {stats['fixed']}, Errors: {stats['errors']}, Skipped: {stats['skipped']}")
+    else:
+        print(f"   (dry-run — use --fix to apply)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #306

## Changes

Added `scripts/normalize_metadata.py` — validates and auto-fixes lesson frontmatter.

### Normalization rules

| Field | Rule | Example |
|-------|------|---------|
| `domain` | lowercase, no spaces | `Feishu` → `feishu` |
| `tags` | kebab-case | `pull_request_target` → `pull-request-target` |
| `status` | canonical set | `active` → `published` |
| `created` | added from mtime if missing | — |
| `source` | default `unknown` if missing | — |

### Results

- **125 files normalized**, 0 errors, 35 skipped (no frontmatter)
- `--fix` mode applies changes, default is dry-run

## Verification

```
$ python scripts/normalize_metadata.py
📊 Summary: 190 scanned, 125 need fixes
   (dry-run — use --fix to apply)

$ python scripts/normalize_metadata.py --fix
📊 Summary: 190 scanned, 125 need fixes
   Fixed: 125, Errors: 0, Skipped: 35
```

Signed-off-by: Eric Jia <445655361@qq.com>