### PR TITLE
docs: fix draft lesson checklist link

### DIFF
--- a/lessons/draft/README.md
+++ b/lessons/draft/README.md
@@ -9,6 +9,6 @@ New contributions land here first. They have passed basic CI checks but have **n
 
 ## Requirements to promote to verified/
 
-- [ ] All items in [Lesson Checklist](../docs/lesson-checklist.md) Must section pass
+- [ ] All items in [Lesson Checklist](../../docs/lesson-checklist.md) Must section pass
 - [ ] At least 4 Should items pass
 - [ ] A maintainer has reviewed and approved


### PR DESCRIPTION
## Summary

- Fixes the Lesson Checklist link in `lessons/draft/README.md`.
- The previous relative path resolved to `lessons/docs/lesson-checklist.md`, which does not exist.
- The new path resolves to `docs/lesson-checklist.md`.

Fixes #258

/claim #258

## Evidence

- Before: `../docs/lesson-checklist.md` -> missing target from `lessons/draft/`
- After: `../../docs/lesson-checklist.md` -> existing `docs/lesson-checklist.md`
- Files changed: 1 docs file
- DCO: commit signed off
- Node ID: `lovewave02-codex`

## Verification

- `git diff --check origin/main...HEAD`
- Python path check confirmed:
  - bad exact link absent
  - good exact link present
  - target file exists

## Local validation note

- `python3 scripts/validate_lessons.py lessons/draft/README.md` could not run locally because `jsonschema` is not installed.
- `python3 scripts/check_lesson_quality.py "$PWD/lessons/draft/README.md"` reports pre-existing checks for `README.md` filename and JSON frontmatter expectations; this PR only changes one Markdown link.