### PR TITLE
test: add tombstone redaction regression coverage

### DIFF
--- a/tests/test_tombstone_redaction.py
+++ b/tests/test_tombstone_redaction.py
@@ -1,0 +1,59 @@
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+from tombstone_to_draft import redact_snippet
+
+
+class TestTombstoneRedaction(unittest.TestCase):
+    def test_redacts_sensitive_snippets(self):
+        cases = [
+            (
+                "github token",
+                "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
+                "[REDACTED_GITHUB_TOKEN]",
+            ),
+            (
+                "bearer token",
+                "Bearer abcdefghijklmnopqrstuvwxyz1234567890",
+                "Bearer [REDACTED]",
+            ),
+            (
+                "email address",
+                "developer@example.internal",
+                "[REDACTED_EMAIL]",
+            ),
+            (
+                "windows path",
+                r"C:\Users\alice\project\secret.txt",
+                "[REDACTED_PATH]",
+            ),
+            (
+                "linux path",
+                "/home/alice/project/secret.txt",
+                "[REDACTED_PATH]",
+            ),
+            (
+                "192.168 internal ip",
+                "192.168.10.25",
+                "[REDACTED_IP]",
+            ),
+            (
+                "10.x internal ip",
+                "10.42.0.7",
+                "[REDACTED_IP]",
+            ),
+        ]
+
+        for name, sensitive_value, expected_marker in cases:
+            with self.subTest(name=name):
+                redacted = redact_snippet(f"crash detail: {sensitive_value}")
+                self.assertNotIn(sensitive_value, redacted)
+                self.assertIn(expected_marker, redacted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #394

## Summary
- Add regression coverage for `redact_snippet()` in `tests/test_tombstone_redaction.py`
- Cover GitHub tokens, Bearer tokens, emails, Windows paths, Linux paths, and private IPs (`192.168.x.x` and `10.x.x.x`)
- Assert each original sensitive value is removed and the expected redaction marker is present

## Validation
```text
PYTHONIOENCODING=utf-8 python3 -m pytest tests/test_tombstone_redaction.py -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/lib/hermes-agent/venv/bin/python3
cachedir: .pytest_cache
rootdir: /root/misaka-bounty-394
configfile: pyproject.toml
plugins: anyio-4.12.1, split-0.11.0, cov-7.1.0, xdist-3.8.0, timeout-2.4.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 1 item

tests/test_tombstone_redaction.py::TestTombstoneRedaction::test_redacts_sensitive_snippets PASSED [100%]

===================== 1 passed, 7 subtests passed in 0.02s =====================
```
