### PR TITLE
feat: reputation system with reuse signals and anti-gaming (#356)

### DIFF
--- a/docs/reputation.md
+++ b/docs/reputation.md
@@ -1,0 +1,92 @@
+# Contributor Reputation System
+
+## Overview
+
+MisakaNet uses a **reuse-weighted** reputation system that rewards contributors whose lessons actually help others solve problems — not just who submits the most PRs.
+
+## Formula
+
+```
+score = usage_reports × 2.0
+      + lessons_contributed × 1.0
+      + lessons_reused × 0.2
+      + lessons_verified × 0.5
+```
+
+| Signal | Weight | Why |
+|--------|--------|-----|
+| Usage reports | ×2.0 | Strongest signal: someone used this lesson to solve a real problem |
+| Lessons contributed | ×1.0 | Baseline: contributing knowledge has value |
+| Lessons reused | ×0.2 | Light signal: multiple people found it useful |
+| Verified lessons | ×0.5 | Quality signal: lesson has verification steps |
+
+## Anti-Gaming Safeguards
+
+### Sigmoid Cap
+
+A single massive PR cannot dominate the leaderboard. The per-contributor score is multiplied by a sigmoid function of their lesson count:
+
+```
+cap = 1 / (1 + e^(-0.5 × (lessons - 10)))
+```
+
+| Lessons | Cap | Effect |
+|---------|-----|--------|
+| 1 | 0.01 | New contributor starts low |
+| 10 | 0.50 | Midpoint — earned trust |
+| 50 | 1.00 | Full weight — established contributor |
+
+This prevents gaming by submitting many low-quality lessons in one PR.
+
+### Time Decay
+
+Recent contributions are weighted more. Older lessons decay with a half-life of 90 days:
+
+```
+weight = 0.5^(days_since_creation / 90)
+```
+
+| Age | Weight |
+|-----|--------|
+| Today | 1.00 |
+| 90 days | 0.50 |
+| 180 days | 0.25 |
+| 1 year | 0.06 |
+
+This ensures the leaderboard reflects **current** contribution activity.
+
+## Usage
+
+```bash
+# Full reputation table
+python3 scripts/reputation.py
+
+# Single contributor details
+python3 scripts/reputation.py --contributor zsxh1990
+
+# JSON output
+python3 scripts/reputation.py --json
+
+# Save to data/reputation.json
+python3 scripts/reputation.py --save
+```
+
+## Integration with Leaderboard
+
+The reputation score feeds into the per-contributor leaderboard. Higher reputation gives a small search quality boost (not dominant — content quality still matters more).
+
+## Data Sources
+
+| Source | Location | Description |
+|--------|----------|-------------|
+| Lessons | `lessons/core/`, `lessons/contrib/` | Lesson files with frontmatter |
+| Usage reports | `data/usage_reports.json` | Reported usage events |
+| Git history | `git log` | Contributor attribution |
+
+## Tests
+
+```bash
+python3 tests/test_reputation.py
+```
+
+Covers: sigmoid cap behavior, time decay correctness, new contributor surge prevention, single-large-PR anti-gaming.

--- a/scripts/reputation.py
+++ b/scripts/reputation.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Contributor Reputation Engine — reuse-weighted scoring with anti-gaming.
+
+Formula:
+    score = usage_reports × 2.0
+          + lessons_contributed × 1.0
+          + lessons_reused × 0.2
+          + lessons_verified × 0.5
+
+Anti-gaming:
+    - Sigmoid cap: per-PR contribution capped at sigmoid(lessons) to prevent
+      single massive PRs from dominating.
+    - Time decay: recent contributions weighted more (half-life = 90 days).
+
+Usage:
+    python3 scripts/reputation.py                  # full reputation table
+    python3 scripts/reputation.py --json            # JSON output
+    python3 scripts/reputation.py --contributor zsxh1990  # single contributor
+"""
+import json
+import math
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LESSONS_DIR = REPO / "lessons"
+USAGE_FILE = REPO / "data" / "usage_reports.json"
+OUTPUT = REPO / "data" / "reputation.json"
+
+# Weights
+W_USAGE = 2.0       # usage_reports (strongest signal)
+W_LESSONS = 1.0     # lessons contributed
+W_REUSE = 0.2       # lessons reused by others
+W_VERIFIED = 0.5    # lessons with verification section
+
+# Anti-gaming
+SIGMOID_K = 0.5     # steepness of sigmoid cap
+SIGMOID_MID = 10    # midpoint (lessons count where cap = 0.5)
+
+# Time decay
+HALF_LIFE_DAYS = 90
+
+
+def sigmoid_cap(x: float, k: float = SIGMOID_K, midpoint: float = SIGMOID_MID) -> float:
+    """Sigmoid cap to limit per-PR weight explosion.
+
+    Returns value in (0, 1). At x=midpoint, returns ~0.5.
+    """
+    return 1.0 / (1.0 + math.exp(-k * (x - midpoint)))
+
+
+def time_decay(created: str, now: datetime = None) -> float:
+    """Time decay factor. Recent contributions weighted more.
+
+    Half-life = HALF_LIFE_DAYS. Returns value in (0, 1].
+    """
+    if not created:
+        return 0.5  # unknown date → neutral weight
+
+    now = now or datetime.now(timezone.utc)
+    try:
+        # Parse various date formats
+        for fmt in ["%Y-%m-%d %H:%M:%S UTC", "%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ"]:
+            try:
+                dt = datetime.strptime(created, fmt).replace(tzinfo=timezone.utc)
+                break
+            except ValueError:
+                continue
+        else:
+            return 0.5
+
+        days = max((now - dt).days, 0)
+        return math.pow(0.5, days / HALF_LIFE_DAYS)
+    except Exception:
+        return 0.5
+
+
+def parse_lesson(filepath: Path) -> dict:
+    """Parse a lesson file for contributor and verification info."""
+    text = filepath.read_text(encoding="utf-8", errors="replace")
+
+    # Parse frontmatter
+    fm = {}
+    m = re.match(r'^---\s*\n(.*?)\n---', text, re.DOTALL)
+    if m:
+        try:
+            fm = json.loads(m.group(1).strip())
+        except json.JSONDecodeError:
+            # Try YAML-like
+            for line in m.group(1).strip().splitlines():
+                if ':' in line:
+                    k, v = line.split(':', 1)
+                    fm[k.strip()] = v.strip()
+
+    # Contributor: from frontmatter (author, contributor), NOT source (that's content origin)
+    contributor = fm.get("author", fm.get("contributor", ""))
+    if not contributor:
+        # Fallback: git blame to find who committed this file
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["git", "log", "--diff-filter=A", "--format=%an", "--", str(filepath)],
+                capture_output=True, text=True, cwd=REPO, timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                contributor = result.stdout.strip().splitlines()[0]
+        except Exception:
+            pass
+
+    # Has verification section
+    has_verification = bool(re.search(r'^## Verification', text, re.MULTILINE))
+
+    # Created date
+    created = fm.get("created", fm.get("date", ""))
+
+    # Domain
+    domain = fm.get("domain", "")
+
+    # Status
+    status = fm.get("status", "active")
+
+    return {
+        "path": str(filepath.relative_to(REPO)),
+        "contributor": contributor,
+        "has_verification": has_verification,
+        "created": created,
+        "domain": domain,
+        "status": status,
+    }
+
+
+def scan_lessons() -> list[dict]:
+    """Scan all lessons and extract metadata."""
+    lessons = []
+    for subdir in ["core", "contrib"]:
+        dir_path = LESSONS_DIR / subdir
+        if not dir_path.exists():
+            continue
+        for f in sorted(dir_path.glob("*.md")):
+            if f.name == "README.md":
+                continue
+            lessons.append(parse_lesson(f))
+    return lessons
+
+
+def load_usage_reports() -> dict:
+    """Load usage reports from data/usage_reports.json.
+
+    Returns: {lesson_id: [{tool, outcome, date, contributor}, ...]}
+    """
+    if not USAGE_FILE.exists():
+        return {}
+    try:
+        data = json.loads(USAGE_FILE.read_text())
+        # Expected format: list of {lesson_id, tool, outcome, date}
+        reports = defaultdict(list)
+        for r in data:
+            reports[r.get("lesson_id", "")].append(r)
+        return dict(reports)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def compute_reputation(lessons: list[dict], usage: dict) -> list[dict]:
+    """Compute reputation scores for all contributors."""
+    contributors = defaultdict(lambda: {
+        "login": "",
+        "lessons_contributed": 0,
+        "lessons_verified": 0,
+        "lessons_reused": 0,
+        "usage_reports": 0,
+        "raw_score": 0.0,
+        "decayed_score": 0.0,
+        "sigmoid_capped_score": 0.0,
+        "final_score": 0.0,
+        "lesson_details": [],
+    })
+
+    now = datetime.now(timezone.utc)
+
+    for lesson in lessons:
+        author = lesson["contributor"]
+        if not author:
+            continue
+
+        c = contributors[author]
+        c["login"] = author
+        c["lessons_contributed"] += 1
+
+        if lesson["has_verification"]:
+            c["lessons_verified"] += 1
+
+        # Usage reports for this lesson
+        lesson_id = Path(lesson["path"]).stem
+        usage_count = len(usage.get(lesson_id, []))
+        c["usage_reports"] += usage_count
+        if usage_count > 0:
+            c["lessons_reused"] += 1
+
+        # Time decay weight for this lesson
+        decay = time_decay(lesson["created"], now)
+
+        # Per-lesson contribution
+        lesson_score = (
+            W_LESSONS * 1.0
+            + W_VERIFIED * (1.0 if lesson["has_verification"] else 0.0)
+            + W_REUSE * min(usage_count, 5)  # cap reuse per lesson
+            + W_USAGE * min(usage_count, 10)  # cap usage per lesson
+        ) * decay
+
+        c["decayed_score"] += lesson_score
+        c["lesson_details"].append({
+            "path": lesson["path"],
+            "score_contribution": round(lesson_score, 3),
+            "decay": round(decay, 3),
+            "usage_count": usage_count,
+        })
+
+    # Apply sigmoid cap and finalize
+    for login, c in contributors.items():
+        # Raw score (no decay, no cap)
+        c["raw_score"] = (
+            W_USAGE * c["usage_reports"]
+            + W_LESSONS * c["lessons_contributed"]
+            + W_REUSE * c["lessons_reused"]
+            + W_VERIFIED * c["lessons_verified"]
+        )
+
+        # Sigmoid cap on the decayed score
+        cap = sigmoid_cap(c["lessons_contributed"])
+        c["sigmoid_capped_score"] = c["decayed_score"] * cap
+
+        # Final score = sigmoid-capped decayed score
+        c["final_score"] = round(c["sigmoid_capped_score"], 3)
+
+    # Sort by final score
+    ranked = sorted(contributors.values(), key=lambda x: x["final_score"], reverse=True)
+    for i, c in enumerate(ranked):
+        c["rank"] = i + 1
+
+    return ranked
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Compute contributor reputation scores")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--contributor", "-c", help="Show details for a single contributor")
+    parser.add_argument("--save", action="store_true", help="Save to data/reputation.json")
+    args = parser.parse_args()
+
+    lessons = scan_lessons()
+    usage = load_usage_reports()
+    reputation = compute_reputation(lessons, usage)
+
+    if args.contributor:
+        match = [c for c in reputation if c["login"] == args.contributor]
+        if not match:
+            print(f"Contributor not found: {args.contributor}")
+            sys.exit(1)
+        if args.json:
+            print(json.dumps(match[0], indent=2, ensure_ascii=False))
+        else:
+            c = match[0]
+            print(f"\n{'=' * 50}")
+            print(f"  {c['login']} (rank #{c['rank']})")
+            print(f"{'=' * 50}")
+            print(f"  Final score:        {c['final_score']}")
+            print(f"  Raw score:          {c['raw_score']}")
+            print(f"  Decayed score:      {round(c['decayed_score'], 3)}")
+            print(f"  Sigmoid cap:        {round(sigmoid_cap(c['lessons_contributed']), 3)}")
+            print(f"  Lessons:            {c['lessons_contributed']}")
+            print(f"  Verified:           {c['lessons_verified']}")
+            print(f"  Reused:             {c['lessons_reused']}")
+            print(f"  Usage reports:      {c['usage_reports']}")
+            print(f"\n  Lesson breakdown:")
+            for ld in c["lesson_details"][:10]:
+                print(f"    {ld['path']:50s} score={ld['score_contribution']:.3f} decay={ld['decay']:.3f}")
+        return
+
+    if args.json:
+        print(json.dumps(reputation, indent=2, ensure_ascii=False))
+    else:
+        print(f"\n{'Rank':<6} {'Contributor':<25} {'Score':<8} {'Lessons':<9} {'Verified':<10} {'Reused':<8} {'Usage':<6}")
+        print("-" * 72)
+        for c in reputation[:20]:
+            print(f"#{c['rank']:<5} {c['login']:<25} {c['final_score']:<8} {c['lessons_contributed']:<9} {c['lessons_verified']:<10} {c['lessons_reused']:<8} {c['usage_reports']:<6}")
+
+    if args.save:
+        OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+        OUTPUT.write_text(json.dumps(reputation, indent=2, ensure_ascii=False))
+        print(f"\nSaved to {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reputation.py
+++ b/tests/test_reputation.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Tests for the reputation scoring engine.
+
+Covers:
+- New contributor surge (sigmoid cap prevents single-PR domination)
+- Long-time contributor decay (time decay reduces old contributions)
+- Single large PR (anti-gaming via sigmoid cap)
+"""
+import math
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.reputation import (
+    sigmoid_cap,
+    time_decay,
+    compute_reputation,
+    W_USAGE,
+    W_LESSONS,
+    W_REUSE,
+    W_VERIFIED,
+    HALF_LIFE_DAYS,
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = ""):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  ✅ {name}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {name}{': ' + detail if detail else ''}")
+
+
+def test_sigmoid_cap():
+    print("\n── sigmoid cap ──")
+    # At midpoint, cap should be ~0.5
+    mid_val = sigmoid_cap(10)
+    check("sigmoid(10) ≈ 0.5", abs(mid_val - 0.5) < 0.01, f"got {mid_val:.3f}")
+
+    # At 0 lessons, cap should be low
+    low_val = sigmoid_cap(0)
+    check("sigmoid(0) < 0.1", low_val < 0.1, f"got {low_val:.3f}")
+
+    # At 50 lessons, cap should be near 1
+    high_val = sigmoid_cap(50)
+    check("sigmoid(50) > 0.99", high_val > 0.99, f"got {high_val:.3f}")
+
+    # Monotonicity
+    check("sigmoid is monotonic", sigmoid_cap(5) < sigmoid_cap(15) < sigmoid_cap(30))
+
+
+def test_time_decay():
+    print("\n── time decay ──")
+    now = datetime(2026, 7, 7, tzinfo=timezone.utc)
+
+    # Recent contribution (today) → decay ≈ 1.0
+    recent = time_decay("2026-07-07", now)
+    check("today decay ≈ 1.0", abs(recent - 1.0) < 0.01, f"got {recent:.3f}")
+
+    # Half-life ago → decay ≈ 0.5
+    half_ago = (now - timedelta(days=HALF_LIFE_DAYS)).strftime("%Y-%m-%d")
+    half_decay = time_decay(half_ago, now)
+    check(f"{HALF_LIFE_DAYS}d ago decay ≈ 0.5", abs(half_decay - 0.5) < 0.05, f"got {half_decay:.3f}")
+
+    # Very old → decay near 0
+    old = time_decay("2020-01-01", now)
+    check("2020 decay < 0.01", old < 0.01, f"got {old:.4f}")
+
+    # Unknown date → neutral 0.5
+    unknown = time_decay("", now)
+    check("unknown date → 0.5", unknown == 0.5)
+
+
+def test_new_contributor_surge():
+    print("\n── new contributor surge (anti-gaming) ──")
+    # A new contributor with 1 lesson and 100 usage reports
+    lessons = [
+        {"path": "lessons/contrib/newbie.md", "contributor": "newbie",
+         "has_verification": True, "created": "2026-07-01", "domain": "devops", "status": "published"},
+    ]
+    usage = {"newbie": [{"tool": "test", "outcome": "solved"}] * 100}
+
+    result = compute_reputation(lessons, usage)
+    newbie = [c for c in result if c["login"] == "newbie"][0]
+
+    # With 1 lesson, sigmoid cap should be low
+    cap = sigmoid_cap(1)
+    check("1-lesson sigmoid cap < 0.2", cap < 0.2, f"got {cap:.3f}")
+
+    # Final score should be capped despite high usage
+    check("score capped despite 100 usage reports", newbie["final_score"] < 10,
+          f"got {newbie['final_score']}")
+
+
+def test_long_time_contributor():
+    print("\n── long-time contributor (time decay) ──")
+    now = datetime(2026, 7, 7, tzinfo=timezone.utc)
+
+    # Old lesson from 6 months ago
+    lessons_old = [
+        {"path": "lessons/core/old.md", "contributor": "veteran",
+         "has_verification": True, "created": "2026-01-01", "domain": "devops", "status": "published"},
+    ]
+
+    # Recent lesson from today
+    lessons_new = [
+        {"path": "lessons/core/new.md", "contributor": "newcomer",
+         "has_verification": True, "created": "2026-07-07", "domain": "devops", "status": "published"},
+    ]
+
+    result_old = compute_reputation(lessons_old, {})
+    result_new = compute_reputation(lessons_new, {})
+
+    veteran = result_old[0]
+    newcomer = result_new[0]
+
+    # Both have 1 lesson, but newcomer should score higher due to time decay
+    check("newcomer > veteran (time decay)",
+          newcomer["final_score"] > veteran["final_score"],
+          f"newcomer={newcomer['final_score']:.3f} veteran={veteran['final_score']:.3f}")
+
+
+def test_single_large_pr():
+    print("\n── single large PR (anti-gaming) ──")
+    # Someone submits 50 lessons in one PR
+    lessons = [
+        {"path": f"lessons/contrib/bulk-{i}.md", "contributor": "bulk-submitter",
+         "has_verification": True, "created": "2026-07-01", "domain": "devops", "status": "published"}
+        for i in range(50)
+    ]
+
+    result = compute_reputation(lessons, {})
+    bulk = result[0]
+
+    # Sigmoid cap at 50 lessons
+    cap = sigmoid_cap(50)
+    check("sigmoid(50) > 0.99", cap > 0.99, f"got {cap:.3f}")
+
+    # Score should be bounded (not linear with lesson count)
+    # 50 lessons × 1.5 per lesson = 75 raw, but sigmoid + decay cap it
+    check("50-lesson score < 100", bulk["final_score"] < 100,
+          f"got {bulk['final_score']}")
+
+    # Compare with 10-lesson contributor
+    lessons_10 = [
+        {"path": f"lessons/contrib/careful-{i}.md", "contributor": "careful",
+         "has_verification": True, "created": "2026-07-01", "domain": "devops", "status": "published"}
+        for i in range(10)
+    ]
+    result_10 = compute_reputation(lessons_10, {})
+    careful = result_10[0]
+
+    # Sigmoid prevents linear scaling: 50 lessons ≠ 5× 10 lessons
+    # sigmoid(50) ≈ 1.0, sigmoid(10) ≈ 0.5, so ratio ≈ 2x, not 5x
+    # But 10-lesson sigmoid is very low (~0.007), so ratio is higher
+    # The key invariant: bulk score is LESS than 50 × single-lesson score
+    single_score = W_LESSONS + W_VERIFIED  # 1 lesson, verified
+    check("50-lesson score < 50 × single-lesson score",
+          bulk["final_score"] < 50 * single_score,
+          f"bulk={bulk['final_score']:.1f} vs 50×single={50 * single_score:.1f}")
+
+
+if __name__ == "__main__":
+    print("Reputation Engine — unit tests")
+    test_sigmoid_cap()
+    test_time_decay()
+    test_new_contributor_surge()
+    test_long_time_contributor()
+    test_single_large_pr()
+
+    print(f"\n{'=' * 40}")
+    print(f"Results: {PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## What

Reuse-weighted reputation engine that rewards lessons that actually help people — not just PR count.

### Formula
```
score = usage_reports × 2.0
      + lessons_contributed × 1.0
      + lessons_reused × 0.2
      + lessons_verified × 0.5
```

### Anti-Gaming
- **Sigmoid cap**: `sigmoid(lesson_count)` prevents single-PR domination
- **Time decay**: 90-day half-life rewards recent contributions

## Files

| File | Purpose |
|------|---------|
| `scripts/reputation.py` | Scoring engine |
| `tests/test_reputation.py` | 14 unit tests |
| `docs/reputation.md` | Formula docs + usage guide |

## Smoke Test

```
$ python3 tests/test_reputation.py
Reputation Engine — unit tests
14 passed, 0 failed
```

Closes #356