### PR TITLE
fix(lessons): convert bare JSON frontmatter to YAML (#380 #379 #378)

### DIFF
--- a/lessons/contrib/agent-manual-update-timeout.md
+++ b/lessons/contrib/agent-manual-update-timeout.md
@@ -1,4 +1,11 @@
-{"title": "Agent 手动Update步骤（update Timeout Handling）", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.8", "created": "2026-05-03"}
+---
+title: Agent 手动Update步骤（update Timeout Handling）
+domain: devops
+source: bootstrap
+status: published
+confidence: 0.8
+created: 2026-05-03
+---
 
 ---{"title": "Agent 手动Update步骤（update Timeout Handling）", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.8", "created": "2026-05-03"}---
 ## Verification

--- a/lessons/contrib/agent-reach-multi-platform-scraper.md
+++ b/lessons/contrib/agent-reach-multi-platform-scraper.md
@@ -1,4 +1,21 @@
-{"title": "Agent-Reach — Multi-Platform Internet Access for AI Agents", "domain": "agent", "subdomain": "tooling", "tags": ["agent-reach", "scraping", "reddit", "twitter", "bilibili", "mcp"], "source": "github.com/Panniantong/Agent-Reach", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+---
+title: Agent-Reach — Multi-Platform Internet Access for AI Agents
+domain: agent
+subdomain: tooling
+tags:
+  - agent-reach
+  - scraping
+  - reddit
+  - twitter
+  - bilibili
+  - mcp
+source: github.com/Panniantong/Agent-Reach
+status: published
+confidence: 0.85
+created: 2026-07-01
+verified_date: ''
+domain_expert: ''
+---
 
 {"title": "Agent-Reach — Multi-Platform Internet Access for AI Agents", "domain": "agent", "subdomain": "tooling", "tags": ["agent-reach", "scraping", "reddit", "twitter", "bilibili", "mcp"], "source": "github.com/Panniantong/Agent-Reach", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
 

--- a/lessons/contrib/agent-state-database-lock-cleanup.md
+++ b/lessons/contrib/agent-state-database-lock-cleanup.md
@@ -1,4 +1,19 @@
-{"title": "Agent State Database Lock Issues — Cleanup Protocol", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["database", "lock", "state", "cleanup", "lesson-written"], "created": "2026-05-16 00:00:00 UTC", "updated": "2026-05-16 00:00:00 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-16"}
+---
+title: Agent State Database Lock Issues — Cleanup Protocol
+domain: devops
+source: hermes_wsl2
+status: published
+tags:
+  - database
+  - lock
+  - state
+  - cleanup
+  - lesson-written
+created: 2026-05-16 00:00:00 UTC
+updated: 2026-05-16 00:00:00 UTC
+domain_expert: hermes_wsl2
+verified_date: 2026-05-16
+---
 
 ## Verification
 


### PR DESCRIPTION
## What

Convert bare JSON frontmatter to standard `---` YAML format in 3 contrib lessons.

## Files

| File | Issue |
|------|-------|
| `lessons/contrib/agent-manual-update-timeout.md` | #380 |
| `lessons/contrib/agent-state-database-lock-cleanup.md` | #379 |
| `lessons/contrib/agent-reach-multi-platform-scraper.md` | #378 |

## Changes

- Wrapped JSON in `---\n...\n---` delimiters
- Converted JSON syntax to YAML
- Preserved all original lesson content unchanged

Relates to #380, #379, #378