### PR TITLE
Add smoke test for queue_lesson.py --dry-run

### DIFF
--- a/tests/test_queue_lesson_dry_run.py
+++ b/tests/test_queue_lesson_dry_run.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestQueueLessonDryRun(unittest.TestCase):
+    def test_dry_run_renders_lesson_without_writing_files(self):
+        with TemporaryDirectory() as tmp:
+            lessons_dir = Path(tmp) / "lessons"
+            env = os.environ.copy()
+            env["LESSONS_DIR"] = str(lessons_dir)
+            command = [
+                sys.executable,
+                "scripts/queue_lesson.py",
+                "--dry-run",
+                "--title",
+                "Dry run smoke test",
+                "--domain",
+                "contrib",
+                "--tags",
+                "smoke,dry-run",
+                "This lesson is only rendered during a smoke test.",
+            ]
+            result = subprocess.run(
+                command,
+                cwd=PROJECT_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn('"title": "Dry run smoke test"', result.stdout)
+        self.assertIn('"domain": "contrib"', result.stdout)
+        self.assertIn("This lesson is only rendered during a smoke test.", result.stdout)
+        self.assertFalse(lessons_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add smoke test for queue_lesson.py --dry-run

## Summary

- Adds a subprocess smoke test for `scripts/queue_lesson.py --dry-run`.
- Verifies that dry-run mode renders the lesson frontmatter and body successfully.
- Uses a temporary `LESSONS_DIR` and asserts that dry-run mode does not create lesson files.

## Tests

- `python3 -m unittest tests.test_queue_lesson_dry_run`
- Manual `scripts/queue_lesson.py --dry-run` verification

## Linked Issue

https://github.com/Ikalus1988/MisakaNet/issues/416

## Notes

This PR only adds test coverage and does not change production behavior.
