### PR TITLE
Normalize five legacy contrib lesson frontmatter files

### DIFF
--- a/lessons/contrib/agent-write-file-sandbox-worktree-path-breakage.md
+++ b/lessons/contrib/agent-write-file-sandbox-worktree-path-breakage.md
@@ -1,5 +1,14 @@
-{"title": "Agent Write File 写入不落地 + Worktree Git 链接路径断裂", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"], "created": "2026-05-13 01:01:46 UTC", "updated": "2026-05-13 01:01:52 UTC", "domain_expert": "hermes_wsl2", "verified_date": "2026-05-13"}
-
+---
+title: "Agent Write File 写入不落地 + Worktree Git 链接路径断裂"
+domain: "devops"
+tags: ["agent-mode", "write-file", "worktree", "wsl", "git", "lesson-written"]
+status: "published"
+source: "hermes_wsl2"
+created: "2026-05-13 01:01:46 UTC"
+updated: "2026-05-13 01:01:52 UTC"
+domain_expert: "hermes_wsl2"
+verified_date: "2026-05-13"
+---
 
 ## 背景
 

--- a/lessons/contrib/browser-automation-csp-bypass.md
+++ b/lessons/contrib/browser-automation-csp-bypass.md
@@ -1,15 +1,15 @@
-{
-  "title": "CSP blocks JavaScript injection in browser automation of authenticated pages",
-  "domain": "mcp",
-  "subdomain": "browser-automation",
-  "tags": ["browser-automation", "csp", "content-security-policy", "cdp", "puppeteer", "playwright", "eval", "injection"],
-  "status": "published",
-  "confidence": "0.8",
-  "created": "2026-07-06",
-  "updated": "2026-07-06",
-  "source": "zsxh1990",
-  "verified_date": "2026-07-06"
-}
+---
+title: "CSP blocks JavaScript injection in browser automation of authenticated pages"
+domain: "mcp"
+tags: ["browser-automation", "csp", "content-security-policy", "cdp", "puppeteer", "playwright", "eval", "injection"]
+status: "published"
+source: "zsxh1990"
+subdomain: "browser-automation"
+confidence: "0.8"
+created: "2026-07-06"
+updated: "2026-07-06"
+verified_date: "2026-07-06"
+---
 
 # CSP blocks JavaScript injection in browser automation of authenticated pages
 

--- a/lessons/contrib/codeql-alert-dismissal-false-positive.md
+++ b/lessons/contrib/codeql-alert-dismissal-false-positive.md
@@ -1,11 +1,12 @@
-{
-  "title": "Dismiss CodeQL False Positive Alerts",
-  "domain": "security",
-  "tags": ["codeql", "security", "github", "false-positive"],
-  "status": "published",
-  "source": "agent_experience",
-  "created": "2026-07-02"
-}
+---
+title: "Dismiss CodeQL False Positive Alerts"
+domain: "security"
+tags: ["codeql", "security", "github", "false-positive"]
+status: "published"
+source: "agent_experience"
+created: "2026-07-02"
+---
+
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-io-marker-m-instruction.md
+++ b/lessons/contrib/fanuc-io-marker-m-instruction.md
@@ -1,5 +1,15 @@
-{"title": "FANUC IO Marker M[] Instruction — Background Logic Alternative", "domain": "fanuc", "subdomain": "tp-programming", "tags": ["marker", "m-register", "io", "background-logic", "handling-tool", "vass"], "source": "robot-forum.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": "cattmampbell"}
-
+---
+title: "FANUC IO Marker M[] Instruction — Background Logic Alternative"
+domain: "fanuc"
+tags: ["marker", "m-register", "io", "background-logic", "handling-tool", "vass"]
+status: "published"
+source: "robot-forum.com"
+subdomain: "tp-programming"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: "cattmampbell"
+---
 
 ## Problem
 

--- a/lessons/contrib/fanuc-profinet-32bit-real-value-transfer.md
+++ b/lessons/contrib/fanuc-profinet-32bit-real-value-transfer.md
@@ -1,5 +1,15 @@
-{"title": "FANUC Profinet 32-bit Real Value Transfer Without KAREL", "domain": "fanuc", "subdomain": "profinet", "tags": ["profinet", "real-value", "32-bit", "gi-go", "plc-communication", "scara"], "source": "robot-forum.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
-
+---
+title: "FANUC Profinet 32-bit Real Value Transfer Without KAREL"
+domain: "fanuc"
+tags: ["profinet", "real-value", "32-bit", "gi-go", "plc-communication", "scara"]
+status: "published"
+source: "robot-forum.com"
+subdomain: "profinet"
+confidence: "0.85"
+created: "2026-07-01"
+verified_date: ""
+domain_expert: ""
+---
 
 ## Problem
 


### PR DESCRIPTION
/claim #393

## Summary
- Normalize exactly 5 legacy `lessons/contrib/` files from bare JSON frontmatter to `---` YAML frontmatter.
- Preserve original lesson bodies.
- Only the selected 5 target lesson files are changed.

## Files changed
- `lessons/contrib/agent-write-file-sandbox-worktree-path-breakage.md`
- `lessons/contrib/browser-automation-csp-bypass.md`
- `lessons/contrib/codeql-alert-dismissal-false-positive.md`
- `lessons/contrib/fanuc-io-marker-m-instruction.md`
- `lessons/contrib/fanuc-profinet-32bit-real-value-transfer.md`

## Validation
Changed-file validation:

```text
lessons/contrib/agent-write-file-sandbox-worktree-path-breakage.md: Total: 1  Passed: 1  Failed: 0
lessons/contrib/browser-automation-csp-bypass.md: Total: 1  Passed: 1  Failed: 0
lessons/contrib/codeql-alert-dismissal-false-positive.md: Total: 1  Passed: 1  Failed: 0
lessons/contrib/fanuc-io-marker-m-instruction.md: Total: 1  Passed: 1  Failed: 0
lessons/contrib/fanuc-profinet-32bit-real-value-transfer.md: Total: 1  Passed: 1  Failed: 0
```

Command used per changed file:

```bash
PYTHONIOENCODING=utf-8 python3 scripts/validate_lessons.py <file>
```

Note: full-repo `PYTHONIOENCODING=utf-8 python3 scripts/validate_lessons.py` currently aborts on an unrelated pre-existing non-UTF-8 legacy file, `lessons/contrib/testimonio-misakanet.md` (`UnicodeDecodeError: 0xff in position 0`).
