### PR TITLE
fix(lessons): fix template frontmatter and YAML parser (#417)

### DIFF
--- a/lessons/templates/database.md
+++ b/lessons/templates/database.md
@@ -1,4 +1,26 @@
-{"title": "<Database Domain Lesson Title>", "domain": "database", "subdomain": "<subdomain>", "tags": ["database", "postgresql", "mysql", "indexing", "query", "migration", "backup", "performance", "replication", "connection-pool"], "status": "draft", "confidence": "0.8", "created": "<YYYY-MM-DD>", "updated": "<YYYY-MM-DD>", "source": "<your-source>", "verified_date": "", "domain_expert": ""}
+---
+title: <Database Domain Lesson Title>
+domain: database
+subdomain: <subdomain>
+tags:
+  - database
+  - postgresql
+  - mysql
+  - indexing
+  - query
+  - migration
+  - backup
+  - performance
+  - replication
+  - connection-pool
+status: draft
+confidence: 0.8
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+source: <your-source>
+verified_date: ''
+domain_expert: ''
+---
 
 # <Database Domain Lesson Title>
 

--- a/lessons/templates/network.md
+++ b/lessons/templates/network.md
@@ -1,4 +1,26 @@
-{"title": "<Network Domain Lesson Title>", "domain": "network", "subdomain": "<subdomain>", "tags": ["network", "dns", "tls", "proxy", "firewall", "load-balancer", "tcp", "http", "ssl", "vpn", "cdn"], "status": "draft", "confidence": "0.8", "created": "<YYYY-MM-DD>", "updated": "<YYYY-MM-DD>", "source": "<your-source>", "verified_date": "", "domain_expert": ""}
+---
+title: <Network Domain Lesson Title>
+domain: network
+subdomain: <subdomain>
+tags:
+  - network
+  - dns
+  - tls
+  - proxy
+  - firewall
+  - load-balancer
+  - tcp
+  - http
+  - ssl
+  - vpn
+status: draft
+confidence: 0.8
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+source: <your-source>
+verified_date: ''
+domain_expert: ''
+---
 
 # <Network Domain Lesson Title>
 

--- a/scripts/validate_lessons.py
+++ b/scripts/validate_lessons.py
@@ -43,25 +43,59 @@ def extract_frontmatter(path: Path) -> tuple[dict | None, str | None]:
     # Simple YAML-like parser for common patterns
     try:
         fm = {}
+        current_key = None
+        current_list = None
+
         for line in raw.split("\n"):
+            # Check if this is a list item
+            if line.strip().startswith("- "):
+                if current_key and current_list is not None:
+                    item = line.strip()[2:].strip().strip('"').strip("'")
+                    current_list.append(item)
+                continue
+
             line = line.strip()
             if not line:
                 continue
+
             if ":" in line:
                 key, _, val = line.partition(":")
                 key = key.strip()
                 val = val.strip()
-                if val.startswith("[") and val.endswith("]"):
+
+                # Save previous list if exists
+                if current_key and current_list is not None:
+                    fm[current_key] = current_list
+                    current_list = None
+
+                if val == "":
+                    # Start a new list
+                    current_key = key
+                    current_list = []
+                elif val.startswith("[") and val.endswith("]"):
                     val = [v.strip().strip('"').strip("'") for v in val[1:-1].split(",")]
+                    fm[key] = val
+                    current_key = None
                 elif val.lower() == "true":
-                    val = True
+                    fm[key] = True
+                    current_key = None
                 elif val.lower() == "false":
-                    val = False
+                    fm[key] = False
+                    current_key = None
                 elif val.startswith('"') and val.endswith('"'):
-                    val = val[1:-1]
+                    fm[key] = val[1:-1]
+                    current_key = None
                 elif val.startswith("'") and val.endswith("'"):
-                    val = val[1:-1]
-                fm[key] = val
+                    fm[key] = val[1:-1]
+                    current_key = None
+                else:
+                    fm[key] = val
+                    current_key = None
+
+        # Save last list if exists
+        if current_key and current_list is not None:
+            fm[current_key] = current_list
+
         if fm:
             return fm, None
     except Exception:


### PR DESCRIPTION
## What

- Fix template files with bare JSON frontmatter
- Fix YAML parser to handle multi-line lists
- Reduce network template tags to 10 (schema limit)

## Files

| File | Change |
|------|--------|
| `lessons/templates/database.md` | Convert bare JSON to YAML frontmatter |
| `lessons/templates/network.md` | Convert bare JSON to YAML, reduce tags to 10 |
| `scripts/validate_lessons.py` | Fix YAML parser to handle multi-line lists |

## Validation

```
$ PYTHONIOENCODING=utf-8 python3 scripts/validate_lessons.py
Total: 195  Passed: 53  Failed: 142
```

All template files now pass validation. Remaining failures are legacy contrib files missing 'status' property (not blocking).

Closes #417