### PR TITLE
feat(lesson): PEP 668 externally-managed-environment on macOS Homebrew Python

### DIFF
--- a/lessons/contrib/lesson-pep668-homebrew-externally-managed.md
+++ b/lessons/contrib/lesson-pep668-homebrew-externally-managed.md
@@ -1,0 +1,99 @@
+---
+{
+  "domain": "devops",
+  "title": "macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment",
+  "tags": ["python", "pip", "homebrew", "macos", "pep-668", "venv", "pyyaml"],
+  "status": "draft",
+  "confidence": "0.95",
+  "created": "2026-07-09",
+  "source": "Real incident, running validate.py on macOS Homebrew Python 3.14 (2026-07-09)"
+}
+---
+
+# macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment
+
+> Author: zsxh1990  
+> Created: 2026-07-09  
+> Status: draft  
+> Domain: devops  
+> Source: Real incident, running `python3 validate.py --strict` on macOS with Homebrew Python 3.14
+
+## Problem
+
+On macOS with Homebrew-installed Python (3.12+), `pip install` is blocked by PEP 668:
+
+```
+$ pip3 install pyyaml
+error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try brew install
+    xyz, where xyz the Homebrew formulae.
+
+    If you wish to install a Python library that's not in Homebrew,
+    use a virtual environment:
+    python3 -m venv path/to/venv
+    source path/to/venv/bin/activate
+    python3 -m pip install xyz
+```
+
+**Root cause**: Homebrew Python includes an `EXTERNALLY-MANAGED` marker file (PEP 668) that prevents system-wide pip installs to protect the Homebrew-managed Python environment from corruption.
+
+## Diagnostic
+
+```bash
+# Check if your Python has the marker
+python3 -c "import sysconfig; print(sysconfig.get_paths()['stdlib'])"
+# Look for EXTERNALLY-MANAGED file in that directory
+
+# Confirm it's Homebrew Python
+which python3
+# Expected: /opt/homebrew/bin/python3 (Apple Silicon) or /usr/local/bin/python3 (Intel)
+```
+
+## Solutions (ranked)
+
+### 1. Virtual environment (recommended)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install pyyaml
+```
+
+### 2. pipx (for CLI tools)
+
+```bash
+brew install pipx
+pipx install some-tool
+```
+
+### 3. User install with override (quick fix, not ideal)
+
+```bash
+pip3 install --user --break-system-packages pyyaml
+```
+
+**Warning**: `--break-system-packages` bypasses the safety check. Use only for quick debugging, not in production.
+
+### 4. uv (fastest, modern)
+
+```bash
+brew install uv
+uv pip install pyyaml  # respects venvs, no PEP 668 issue
+```
+
+## Prevention
+
+- Always use a virtual environment for project dependencies
+- Add `.venv/` to `.gitignore`
+- For CI: ensure the CI environment uses a venv or container
+
+## Key Insight
+
+PEP 668 is **not a bug** — it's a protection mechanism. The correct fix is always to use a venv. The `--break-system-packages` flag is an escape hatch, not a solution.
+
+## Related
+
+- lesson-07: Ubuntu WSL Python venv Missing pip (similar PEP 668 context, different OS)
+- [PEP 668 spec](https://peps.python.org/pep-0668/)

--- a/lessons/index.md
+++ b/lessons/index.md
@@ -1,106 +1,86 @@
----
-domain: "general"
-title: "MisakaNet Shared Lessons"
-verification: "metadata-normalized"
----
 # MisakaNet Shared Lessons
 
-> 最后更新: 2026-06-19 | 来源: hermes_wsl2
+> 最后更新: 2026-07-09 17:29:45 UTC | 来源: Real incident, running validate.py on macOS Homebrew Python 3.14 (2026-07-09)
 
 每条 lesson 包含踩坑记录、修复方法和验证方式，跨节点自动同步。
-
-## 分级说明
-
-| 目录 | 等级 | 说明 |
-|------|------|------|
-| `core/` | ⭐ 核心 | 经策划审查、安全扫描、CI 验证的标准答案 |
-| `verified/` | ✅ 已验证 | 经维护者人工审核确认正确 |
-| `contrib/` | 📦 贡献 | Agent/开发者提交，通过基础 CI (过渡目录) |
-| `draft/` | ✏️ 草稿 | 新提交，待审核 |
-| `_archive/` | 🗄️ 归档 | 已过时/原始转储，保留做历史参考 |
 
 ## 目录
 
 | Lesson | Domain | Tags | Source |
 |--------|--------|------|--------|
 - [AI Agent 项目宣发引流指南](contrib/ai-agent-project-outreach-guide.md) | marketing | "outreach", "github", "awesome-list", "pr", "promotion", "agent", "marketing" | Misaka10004
-- [Agent 手动更新步骤（update 超时处理）](contrib/agent-manual-update-timeout.md) | devops | | bootstrap
+- [API 分页设计](contrib/lesson-14-api-pagination-design.md) | ops | "api", "pagination", "cursor", "keyset" | solovyov.net
+- [API 设计原则](contrib/lesson-20-api-design-principles.md) | ops | "api", "design", "principles", "rest" | increase.com
+- [AWS ECS 高分辨率指标](contrib/lesson-16-aws-ecs-high-resolution-metrics.md) | ops | "aws", "ecs", "metrics", "auto-scaling" | aws.amazon.com
+- [AWS Lambda MicroVMs](contrib/lesson-13-aws-lambda-microvms.md) | ops | "aws", "lambda", "microvm", "sandbox" | aws.amazon.com
+- [Agent Infrastructure — Unified Postgres (Ghost)](contrib/agent-infrastructure-unified-postgres.md) | agent | "postgres", "agent-infra", "memory", "sandbox" | dev.to
+- [Agent Memory Extractor Timing — Eager vs Lazy](contrib/agent-memory-extractor-timing.md) | agent | "agent-memory", "extractor", "timing", "token-efficiency" | brgsk.xyz
+- [Agent Memory Three-Index Architecture on Elasticsearch](contrib/agent-memory-three-index-architecture.md) | agent | "agent-memory", "elasticsearch", "episodic", "semantic", "procedural" | elastic.co
 - [Agent State Database Lock Issues — Cleanup Protocol](contrib/agent-state-database-lock-cleanup.md) | devops | "database", "lock", "state", "cleanup" | hermes_wsl2
 - [Agent Write File 写入不落地 + Worktree Git 链接路径断裂](contrib/agent-write-file-sandbox-worktree-path-breakage.md) | devops | "agent-mode", "write-file", "worktree", "wsl", "git" | hermes_wsl2
+- [Agent 手动更新步骤（update 超时处理）](contrib/agent-manual-update-timeout.md) | devops | | bootstrap
+- [Agent-Reach — Multi-Platform Internet Access](contrib/agent-reach-multi-platform-scraper.md) | agent | "agent-reach", "scraping", "reddit", "twitter" | github.com/Panniantong/Agent-Reach
 - [BGE embedding 模型需要降级 fallback 避免启动崩溃](contrib/bge-embedding-fallback-crash.md) | rag | | bootstrap
-- [Chroma 建库无 Checkpoint — 进程一死全部丢失](contrib/chroma-rebuild-no-checkpoint.md) | rag | | bootstrap
 - [Chroma 建库无 Checkpoint — 进程一死全部丢失](contrib/chroma-rebuild-no-checkpoint-cn.md) | rag | | bootstrap
+- [Chroma 建库无 Checkpoint — 进程一死全部丢失](contrib/chroma-rebuild-no-checkpoint.md) | rag | | bootstrap
+- [Cloudflare Workflows 持久化](contrib/lesson-15-cloudflare-workflows-durable.md) | ops | "cloudflare", "workflows", "durable" | blog.cloudflare.com
+- [Cloudflare x402 Monetization Gateway](contrib/lesson-review-6-cloudflare-x402-monetization.md) | ops | "cloudflare", "x402", "api", "monetization" | blog.cloudflare.com
+- [Content Quality Scoring System](contrib/session-lesson-1-content-quality-scoring.md) | ops | "quality", "scoring", "automation", "evaluation" | practical-experience
 - [Cronjob One-Shot Race Condition - Duplicate Execution](core/cronjob-one-shot-race-condition-duplicate-execution.md) | agent-network | | hermes_wsl2
 - [DCO 自动修复工作流 — /fix-dco 命令设计与实现](core/dco-auto-fix-workflow.md) | devops | "github-actions", "dco", "signoff", "issue_comment", "auto-fix", "fork-pr" | 2026-06-13
-- [FANUC KL: ERR_ABORT vs ERR_PAUSE 行为差异](contrib/fanuc-kl-err-abort-vs-err-pause.md) | fanuc | | bootstrap
-- [FANUC KL: mm_module_h.kl 禁止 ROUTINE 声明](contrib/fanuc-kl-mm-module-h-no-routine.md) | fanuc | | bootstrap
-- [FANUC R-2000iC 检索混淆修复 — 关键词强制召回](contrib/fanuc-r-2000ic-retrieval-fix.md) | rag | | hermes_wsl
-- [FANUC Profinet 32-bit Real Value Transfer Without KAREL](contrib/fanuc-profinet-32bit-real-value-transfer.md) | fanuc | "profinet", "real-value", "32-bit", "gi-go", "plc-communication" | robot-forum.com
+- [DevOps Platform Engineering Golden Paths](contrib/lesson-review-3-devops-platform-engineering.md) | ops | "devops", "platform-engineering", "golden-paths" | dev.to
+- [EKS Kubernetes Version Rollback](contrib/lesson-review-5-eks-version-rollback.md) | ops | "kubernetes", "eks", "aws", "upgrade", "rollback" | aws.amazon.com
+- [FANUC Auto Abort on Fault — Restart $SHELL_WRK Program](contrib/fanuc-auto-abort-on-fault-restart.md) | fanuc | "abort", "fault", "restart", "shell-wrk", "error-severity" | robot-forum.com
+- [FANUC DO Not Found in Program — Check Reference Position](contrib/fanuc-do-not-found-in-program-reference-position.md) | fanuc | "do", "reference-position", "background-logic" | robot-forum.com
 - [FANUC INTP-102 DETECT JOINT — OLP Whitespace Bug](contrib/fanuc-intp-102-detect-joint-olp-whitespace.md) | fanuc | "intp-102", "detect-joint", "olp", "robodk", "whitespace" | robot-forum.com
 - [FANUC IO Marker M[] — Background Logic Alternative](contrib/fanuc-io-marker-m-instruction.md) | fanuc | "marker", "m-register", "handling-tool", "vass" | robot-forum.com
-- [FANUC DO Not Found in Program — Check Reference Position](contrib/fanuc-do-not-found-in-program-reference-position.md) | fanuc | "do", "reference-position", "background-logic" | robot-forum.com
-- [FANUC Auto Abort on Fault — Restart $SHELL_WRK Program](contrib/fanuc-auto-abort-on-fault-restart.md) | fanuc | "abort", "fault", "restart", "shell-wrk", "error-severity" | robot-forum.com
-- [Agent Memory Three-Index Architecture on Elasticsearch](contrib/agent-memory-three-index-architecture.md) | agent | "agent-memory", "elasticsearch", "episodic", "semantic", "procedural" | elastic.co
-- [Agent Memory Extractor Timing — Eager vs Lazy](contrib/agent-memory-extractor-timing.md) | agent | "agent-memory", "extractor", "timing", "token-efficiency" | brgsk.xyz
-- [Universal Memory Protocol (UMP)](contrib/ump-universal-memory-protocol.md) | agent | "ump", "memory-protocol", "interoperability", "mcp" | universalmemoryprotocol.io
-- [Agent Infrastructure — Unified Postgres (Ghost)](contrib/agent-infrastructure-unified-postgres.md) | agent | "postgres", "agent-infra", "memory", "sandbox" | dev.to
-- [The Private Agent Memory Fallacy](contrib/private-agent-memory-fallacy.md) | agent | "memory-wallet", "portable-memory", "privacy" | blog.getzep.com
-- [GFW TLS SNI Block Pattern](contrib/gfw-tls-sni-block-pattern.md) | ops | "gfw", "tls", "sni", "scraping", "proxy" | practical-experience
-- [Multi-Forum Scraping Architecture](contrib/multi-forum-scraping-architecture.md) | ops | "scraping", "playwright", "api", "forum" | practical-experience
-- [Scrapling — Web Scraping with Anti-Detection](contrib/scrapling-installation-and-usage.md) | ops | "scrapling", "curl-cffi", "anti-detection" | github.com/D4Vinci/Scrapling
-- [Agent-Reach — Multi-Platform Internet Access](contrib/agent-reach-multi-platform-scraper.md) | agent | "agent-reach", "scraping", "reddit", "twitter" | github.com/Panniantong/Agent-Reach
-- [rdt-cli — Reddit in Your Terminal](contrib/rdt-cli-reddit-terminal.md) | ops | "rdt-cli", "reddit", "scraping", "cli" | github.com/public-clis/rdt-cli
-- [MCP Context Mode — 98% Context Reduction](contrib/mcp-context-mode-98-reduction.md) | mcp | "mcp", "claude-code", "context-window", "optimization" | mksg.lu
-- [Ghidra MCP Server — AI Reverse Engineering](contrib/ghidra-mcp-server-reverse-engineering.md) | mcp | "mcp", "ghidra", "reverse-engineering", "security" | github.com/LaurieWired/GhidraMCP
-- [webMCP — Chrome AI Agent Protocol](contrib/webmcp-chrome-ai-agent-protocol.md) | mcp | "webmcp", "chrome", "ai-agents", "protocol" | dev.to
-- [MCP + Bedrock Integration](contrib/lesson-review-4-mcp-bedrock-integration.md) | mcp | "mcp", "bedrock", "aws", "tool-calling" | segmentfault.com
-- [EKS Kubernetes Version Rollback](contrib/lesson-review-5-eks-version-rollback.md) | ops | "kubernetes", "eks", "aws", "upgrade", "rollback" | aws.amazon.com
-- [Cloudflare x402 Monetization Gateway](contrib/lesson-review-6-cloudflare-x402-monetization.md) | ops | "cloudflare", "x402", "api", "monetization" | blog.cloudflare.com
-- [Redis → PostgreSQL 替换](contrib/lesson-9-redis-postgresql-replacement.md) | ops | "redis", "postgresql", "caching", "pubsub" | dev.to
-- [微服务延迟成本分析](contrib/lesson-10-microservices-latency-math.md) | ops | "microservices", "latency", "architecture" | dev.to
-- [GitHub Commit GPG 签名](contrib/lesson-11-github-commit-signing.md) | ops | "git", "github", "gpg", "security" | dev.to
-- [AWS Lambda MicroVMs](contrib/lesson-13-aws-lambda-microvms.md) | ops | "aws", "lambda", "microvm", "sandbox" | aws.amazon.com
-- [API 分页设计](contrib/lesson-14-api-pagination-design.md) | ops | "api", "pagination", "cursor", "keyset" | solovyov.net
-- [Cloudflare Workflows 持久化](contrib/lesson-15-cloudflare-workflows-durable.md) | ops | "cloudflare", "workflows", "durable" | blog.cloudflare.com
-- [AWS ECS 高分辨率指标](contrib/lesson-16-aws-ecs-high-resolution-metrics.md) | ops | "aws", "ecs", "metrics", "auto-scaling" | aws.amazon.com
-- [MCP 标准化协议](contrib/lesson-17-segmentfault-mcp-standardization.md) | mcp | "mcp", "agent", "tool-calling" | segmentfault.com
-- [数据库索引优化](contrib/lesson-18-database-performance-indexing.md) | ops | "database", "postgresql", "indexing", "performance" | practical-experience
-- [gRPC vs OpenAPI vs REST](contrib/lesson-19-grpc-openapi-rest-comparison.md) | ops | "grpc", "openapi", "rest", "api" | cloud.google.com
-- [API 设计原则](contrib/lesson-20-api-design-principles.md) | ops | "api", "design", "principles", "rest" | increase.com
-- [Content Quality Scoring System](contrib/session-lesson-1-content-quality-scoring.md) | ops | "quality", "scoring", "automation", "evaluation" | practical-experience
-- [Forum Accessibility Testing](contrib/session-lesson-2-forum-accessibility-testing.md) | ops | "scraping", "accessibility", "forum", "testing" | practical-experience
-- [Lobsters JSON API](contrib/session-lesson-3-lobsters-json-api.md) | ops | "lobsters", "api", "scraping", "json" | practical-experience
-- [Playwright Forum Selectors](contrib/session-lesson-4-playwright-forum-selectors.md) | ops | "playwright", "scraping", "selectors", "forum" | practical-experience
-- [DevOps Platform Engineering Golden Paths](contrib/lesson-review-3-devops-platform-engineering.md) | ops | "devops", "platform-engineering", "golden-paths" | dev.to
+- [FANUC KL: ERR_ABORT vs ERR_PAUSE 行为差异](contrib/fanuc-kl-err-abort-vs-err-pause.md) | fanuc | | bootstrap
+- [FANUC KL: mm_module_h.kl 禁止 ROUTINE 声明](contrib/fanuc-kl-mm-module-h-no-routine.md) | fanuc | | bootstrap
+- [FANUC Profinet 32-bit Real Value Transfer Without KAREL](contrib/fanuc-profinet-32bit-real-value-transfer.md) | fanuc | "profinet", "real-value", "32-bit", "gi-go", "plc-communication" | robot-forum.com
+- [FANUC R-2000iC 检索混淆修复 — 关键词强制召回](contrib/fanuc-r-2000ic-retrieval-fix.md) | rag | | hermes_wsl
 - [FFmpeg 音频转码：必须用 libopus 而非 -format ogg](contrib/ffmpeg-audio-libopus-not-ogg.md) | audio | | hanged-man
 - [FReeLLMAPI Session Context Mixing - Cross-Thread Delivery](core/freellmapi-session-context-mixing-cross-thread-delivery.md) | agent-network | | hermes_wsl2
 - [Feishu 文件上传：file_type 必须用 opus](contrib/feishu-upload-file-type-opus.md) | feishu | | hanged-man
 - [Feishu 文档 URL：必须用 API 返回值，不要拼接](contrib/feishu-doc-url-use-api-return.md) | feishu | | hanged-man
+- [Forum Accessibility Testing](contrib/session-lesson-2-forum-accessibility-testing.md) | ops | "scraping", "accessibility", "forum", "testing" | practical-experience
+- [GFW TLS SNI Block Pattern](contrib/gfw-tls-sni-block-pattern.md) | ops | "gfw", "tls", "sni", "scraping", "proxy" | practical-experience
 - [GPT-SoVITS 训练：2-name2text 格式必须用 ARPABET 音素而非中文原文](contrib/gpt-sovits-name2text-arpabet.md) | tts | | hanged-man
 - [GPT-SoVITS：HuBERT 必须 16kHz 且 get_model() 返回单体](contrib/gpt-sovits-hubert-16khz.md) | tts | | hanged-man
 - [GPT-SoVITS：ref_free bug——prompt_text 为空时参数被覆盖](contrib/gpt-sovits-ref-free-bug.md) | tts | | hanged-man
-- [Gateway 进程挂死未崩溃 — watchdog 自动恢复](contrib/gateway-hang-watchdog-recovery.md) | devops | | bootstrap
-- [Git 凭证和 Node ID 配置](contrib/git-credentials-and-node-id-setup.md) | devops | "git", "credentials", "node-id", "setup" | hermes_wsl2
-- [Git Push 的正确方式 — 在受限 Agent 环境中推送代码](contrib/git-push-without-shell-agent.md) | devops | "git", "push", "agent", "gh-cli" | 2026-06-04
 - [Game MCP: End Turn Returns 409 Conflict](contrib/game-mcp-end-turn-conflict-409.md) | mcp | | hanged-man
 - [Game MCP: GAME OVER Restart Flow](contrib/game-mcp-game-over-restart-flow.md) | mcp | | hanged-man
 - [Game MCP: Rare Relic Selection Freeze](contrib/game-mcp-rare-relic-freeze.md) | mcp | | hanged-man
+- [Gateway 进程挂死未崩溃 — watchdog 自动恢复](contrib/gateway-hang-watchdog-recovery.md) | devops | | bootstrap
+- [Ghidra MCP Server — AI Reverse Engineering](contrib/ghidra-mcp-server-reverse-engineering.md) | mcp | "mcp", "ghidra", "reverse-engineering", "security" | github.com/LaurieWired/GhidraMCP
+- [Git Push 的正确方式 — 在受限 Agent 环境中推送代码](contrib/git-push-without-shell-agent.md) | devops | "git", "push", "agent", "gh-cli" | 2026-06-04
+- [Git 凭证和 Node ID 配置](contrib/git-credentials-and-node-id-setup.md) | devops | "git", "credentials", "node-id", "setup" | hermes_wsl2
+- [GitHub Commit GPG 签名](contrib/lesson-11-github-commit-signing.md) | ops | "git", "github", "gpg", "security" | dev.to
 - [Hub FeishuWSClient.start() 从未调用 — WebSocket 接收死代码](contrib/hub-feishu-wsclient-start-never-called.md) | feishu | | bootstrap
 - [Hub 凭证体系 — Gateway vs Hub 各自读哪里](contrib/hub-credential-gateway-vs-hub.md) | devops | | bootstrap
 - [InternalGateway API 网关不兼容 Anthropic 原生格式](contrib/api-gateway-anthropic-incompatibility.md) | devops | | bootstrap
+- [Lobsters JSON API](contrib/session-lesson-3-lobsters-json-api.md) | ops | "lobsters", "api", "scraping", "json" | practical-experience
+- [MCP + Bedrock Integration](contrib/lesson-review-4-mcp-bedrock-integration.md) | mcp | "mcp", "bedrock", "aws", "tool-calling" | segmentfault.com
+- [MCP Context Mode — 98% Context Reduction](contrib/mcp-context-mode-98-reduction.md) | mcp | "mcp", "claude-code", "context-window", "optimization" | mksg.lu
+- [MCP 标准化协议](contrib/lesson-17-segmentfault-mcp-standardization.md) | mcp | "mcp", "agent", "tool-calling" | segmentfault.com
 - [Model Switch Script Pattern — 多 Agent 模型管理](contrib/model-switch-script-pattern.md) | devops | "model-switching", "proxy", "config-management" | bootstrap
+- [Multi-Forum Scraping Architecture](contrib/multi-forum-scraping-architecture.md) | ops | "scraping", "playwright", "api", "forum" | practical-experience
 - [OpenClaw Gateway 动态模块缺失 — 飞书消息分发失败](contrib/openclaw-gateway-dynamic-module-missing.md) | feishu | "platform:wsl" | bootstrap
 - [OpenClaw 重装教训 — 删除前先停服务清残留](contrib/openclaw-reinstall-lesson.md) | devops | | bootstrap
-- [PR 仓库清理 SOP — 过时/重复/已解决 PR 的处置策略](core/pr-cleanup-sop.md) | devops | "github-actions", "pr-management", "cleanup", "maintenance", "sop" | 2026-06-13
 - [PR Welcome 未触发排查 — author_association NONE vs FIRST_TIMER 陷阱](core/pull-request-welcome-trigger-trap.md) | devops | "github-actions", "pull_request_target", "author_association", "first-time-contributor", "welcome", "debug" | 2026-06-13
+- [PR 仓库清理 SOP — 过时/重复/已解决 PR 的处置策略](core/pr-cleanup-sop.md) | devops | "github-actions", "pr-management", "cleanup", "maintenance", "sop" | 2026-06-13
 - [Permission Denied / WSL NTFS 跨文件系统权限修复](contrib/permission-denied-fix.md) | devops | | hermes_wsl
+- [Playwright Forum Selectors](contrib/session-lesson-4-playwright-forum-selectors.md) | ops | "playwright", "scraping", "selectors", "forum" | practical-experience
 - [RAG Cross-Encoder Reranker CPU 瓶颈与 LLM 确定性调优](contrib/rag-cross-encoder-cpu-bottleneck.md) | rag | "scope:broad" | bootstrap
 - [RAG 三通道 LLM 容灾方案](contrib/rag-three-channel-llm-disaster-recovery.md) | rag | "scope:broad" | bootstrap
 - [RAG 分块参数：800 字符 + 100 重叠 + 每文件最多 100 分块](contrib/rag-chunk-params-800-100.md) | rag | | bootstrap
 - [RAG 建库策略：不可一次性加载全部数据到显存/内存](contrib/rag-build-strategy-batch.md) | rag | | hanged-man
 - [RAG 报警代码检索需要关键词强制召回](contrib/rag-alarm-code-mandatory-recall.md) | rag | | bootstrap
 - [RAG 检索中文乱码 — pymupdf4llm 默认编码问题](contrib/rag-chinese-encoding-pymupdf.md) | rag | | bootstrap
+- [Redis → PostgreSQL 替换](contrib/lesson-9-redis-postgresql-replacement.md) | ops | "redis", "postgresql", "caching", "pubsub" | dev.to
+- [Scrapling — Web Scraping with Anti-Detection](contrib/scrapling-installation-and-usage.md) | ops | "scrapling", "curl-cffi", "anti-detection" | github.com/D4Vinci/Scrapling
 - [TTS 中文编码：PowerShell 传参必须用 .txt 文件中转](contrib/tts-chinese-encoding-powershell.md) | tts | | hanged-man
+- [The Private Agent Memory Fallacy](contrib/private-agent-memory-fallacy.md) | agent | "memory-wallet", "portable-memory", "privacy" | blog.getzep.com
+- [Universal Memory Protocol (UMP)](contrib/ump-universal-memory-protocol.md) | agent | "ump", "memory-protocol", "interoperability", "mcp" | universalmemoryprotocol.io
 - [WSL pip install GBK 编码导致 hub_poller 崩溃](contrib/wsl-pip-gbk-hub-poller-crash.md) | devops | "platform:wsl" | bootstrap
 - [WSL 终端编辑配置危险 — TTy粘贴吞下划线](contrib/wsl-terminal-underscore-corruption.md) | devops | | bootstrap
 - [WSL 需要代理配置才能访问 HuggingFace 和外部网络](contrib/wsl-proxy-huggingface-external.md) | devops | "platform:wsl" | bootstrap
@@ -124,6 +104,7 @@ verification: "metadata-normalized"
 - [feishu-wiki批量下载-文件类型处理策略](contrib/feishu-wiki-batch-download.md) | feishu | | bootstrap
 - [feishu文件上传-file-type-必须用opus](contrib/feishu-upload-file-type-opus.md) | feishu | | 
 - [ffmpeg音频转码-必须用libopus而非format-ogg](contrib/ffmpeg-audio-libopus-not-ogg.md) | feishu | | 
+- [gRPC vs OpenAPI vs REST](contrib/lesson-19-grpc-openapi-rest-comparison.md) | ops | "grpc", "openapi", "rest", "api" | cloud.google.com
 - [git-credential-helper-gh-path-mismatch](contrib/git-credential-helper-gh-path-mismatch.md) | uncategorized | | 
 - [git-credentials-automation](contrib/git-credentials-automation.md) | uncategorized | | 
 - [git-merge-conflict-resolution](contrib/git-merge-conflict-resolution.md) | uncategorized | | 
@@ -138,6 +119,7 @@ verification: "metadata-normalized"
 - [json-parse-failure-handling](contrib/json-parse-failure-handling.md) | uncategorized | | 
 - [knowledge-graph-ux-patterns-from-high-star-projects](contrib/knowledge-graph-ux-patterns-from-high-star-projects.md) | uncategorized | | 
 - [lessons-md-修正-4-处-项目-旧结论-修正后-heading-block-type-4](contrib/lessons-md-fix-heading-block-type.md) | uncategorized | | 
+- [macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment](macos-homebrew-python-pip-install-blocked-by-pep-668-externa.md) | devops | python, pip, homebrew, macos, pep-668, venv, pyyaml | Real incident, running validate.py on macOS Homebrew Python 3.14 (2026-07-09)
 - [misakanet-refactor-v2-review](contrib/misakanet-refactor-v2-review.md) | uncategorized | | 
 - [model-output-fix](contrib/model-output-fix.md) | uncategorized | | 
 - [openai-compatible-api-call](contrib/openai-compatible-api-call.md) | uncategorized | | 
@@ -158,6 +140,7 @@ verification: "metadata-normalized"
 - [rag-brand-contamination-detection-and-fix](contrib/rag-brand-contamination-detection-and-fix.md) | uncategorized | | 
 - [rag-brand-filter-three-pitfalls](contrib/rag-brand-filter-three-pitfalls.md) | uncategorized | | 
 - [rag-kb-quality-flywheel-self-loop](contrib/rag-kb-quality-flywheel-self-loop.md) | uncategorized | | 
+- [rdt-cli — Reddit in Your Terminal](contrib/rdt-cli-reddit-terminal.md) | ops | "rdt-cli", "reddit", "scraping", "cli" | github.com/public-clis/rdt-cli
 - [readme-seven-traps-fix-checklist](contrib/readme-seven-traps-fix-checklist.md) | uncategorized | | 
 - [regex-greedy-matching](contrib/regex-greedy-matching.md) | uncategorized | | 
 - [registration-chain-worker-fallback](contrib/registration-chain-worker-fallback.md) | devops | "registration", "worker", "register", "github-actions", "feishu", "fallback" | 2026-06-04
@@ -180,6 +163,7 @@ verification: "metadata-normalized"
 - [tmux-session-management](contrib/tmux-session-management.md) | uncategorized | | 
 - [vertical-kb-question-bank-strategy](contrib/vertical-kb-question-bank-strategy.md) | uncategorized | | 
 - [wcferry 微信版本锁定 — 3.9.12.51 才能用](contrib/wcferry-wechat-version-lock.md) | devops | "platform:windows", "scope:narrow" | bootstrap
+- [webMCP — Chrome AI Agent Protocol](contrib/webmcp-chrome-ai-agent-protocol.md) | mcp | "webmcp", "chrome", "ai-agents", "protocol" | dev.to
 - [wechat-pubacct-fetch-separate-search-from-retrieval](contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md) | uncategorized | | 
 - [wsl-permission-ntfs-fix](contrib/wsl-permission-ntfs-fix.md) | uncategorized | | 
 - [wsl-proxy-setup](contrib/wsl-proxy-setup.md) | uncategorized | | 
@@ -188,6 +172,8 @@ verification: "metadata-normalized"
 - [wxauto 必须在 Windows Python 下安装，不能走 WSL pip](contrib/wxauto-windows-python-not-wsl.md) | devops | "platform:windows", "scope:narrow" | bootstrap
 - [企业微信机器人：长连接模式不需要 ngrok](contrib/wecom-robot-long-connect-no-ngrok.md) | devops | "platform:windows", "scope:narrow" | bootstrap
 - [引流文案用真实案例不要编造](contrib/promo-use-real-examples-not-hypotheticals.md) | marketing | "outreach", "content-strategy", "awesome-list", "reddit", "hacker-news" | Misaka10004
+- [微服务延迟成本分析](contrib/lesson-10-microservices-latency-math.md) | ops | "microservices", "latency", "architecture" | dev.to
+- [数据库索引优化](contrib/lesson-18-database-performance-indexing.md) | ops | "database", "postgresql", "indexing", "performance" | practical-experience
 - [模型输出截断 / JSON 解析失败处理](contrib/model-output-fix.md) | claude | | hermes_wsl
 - [注册链路设计 — Worker 只创建 Issue，其余交给 Workflow](contrib/registration-chain-worker-fallback.md) | devops | "registration", "worker", "register", "github-actions", "feishu", "fallback" | 2026-06-04
 - [知识库 4σ 质量审计流水线](contrib/kb-4sigma-quality-audit-pipeline.md) | rag | | bootstrap

--- a/lessons/macos-homebrew-python-pip-install-blocked-by-pep-668-externa.md
+++ b/lessons/macos-homebrew-python-pip-install-blocked-by-pep-668-externa.md
@@ -1,0 +1,91 @@
+---
+{"domain": "devops", "title": "macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment", "tags": ["python", "pip", "homebrew", "macos", "pep-668", "venv", "pyyaml"], "status": "published", "confidence": "0.95", "created": "2026-07-09", "source": "Real incident, running validate.py on macOS Homebrew Python 3.14 (2026-07-09)", "updated": "2026-07-09 17:29:45 UTC"}
+---
+
+# macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment
+
+> Author: zsxh1990  
+> Created: 2026-07-09  
+> Status: draft  
+> Domain: devops  
+> Source: Real incident, running `python3 validate.py --strict` on macOS with Homebrew Python 3.14
+
+## Problem
+
+On macOS with Homebrew-installed Python (3.12+), `pip install` is blocked by PEP 668:
+
+```
+$ pip3 install pyyaml
+error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try brew install
+    xyz, where xyz the Homebrew formulae.
+
+    If you wish to install a Python library that's not in Homebrew,
+    use a virtual environment:
+    python3 -m venv path/to/venv
+    source path/to/venv/bin/activate
+    python3 -m pip install xyz
+```
+
+**Root cause**: Homebrew Python includes an `EXTERNALLY-MANAGED` marker file (PEP 668) that prevents system-wide pip installs to protect the Homebrew-managed Python environment from corruption.
+
+## Diagnostic
+
+```bash
+# Check if your Python has the marker
+python3 -c "import sysconfig; print(sysconfig.get_paths()['stdlib'])"
+# Look for EXTERNALLY-MANAGED file in that directory
+
+# Confirm it's Homebrew Python
+which python3
+# Expected: /opt/homebrew/bin/python3 (Apple Silicon) or /usr/local/bin/python3 (Intel)
+```
+
+## Solutions (ranked)
+
+### 1. Virtual environment (recommended)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install pyyaml
+```
+
+### 2. pipx (for CLI tools)
+
+```bash
+brew install pipx
+pipx install some-tool
+```
+
+### 3. User install with override (quick fix, not ideal)
+
+```bash
+pip3 install --user --break-system-packages pyyaml
+```
+
+**Warning**: `--break-system-packages` bypasses the safety check. Use only for quick debugging, not in production.
+
+### 4. uv (fastest, modern)
+
+```bash
+brew install uv
+uv pip install pyyaml  # respects venvs, no PEP 668 issue
+```
+
+## Prevention
+
+- Always use a virtual environment for project dependencies
+- Add `.venv/` to `.gitignore`
+- For CI: ensure the CI environment uses a venv or container
+
+## Key Insight
+
+PEP 668 is **not a bug** — it's a protection mechanism. The correct fix is always to use a venv. The `--break-system-packages` flag is an escape hatch, not a solution.
+
+## Related
+
+- lesson-07: Ubuntu WSL Python venv Missing pip (similar PEP 668 context, different OS)
+- [PEP 668 spec](https://peps.python.org/pep-0668/)


### PR DESCRIPTION
## Summary

Add lesson for PEP 668 `externally-managed-environment` error on macOS Homebrew Python 3.12+.

**Real error**: `pip install pyyaml` blocked by Homebrew's EXTERNALLY-MANAGED marker file.

### Changes
- `lessons/contrib/lesson-pep668-homebrew-externally-managed.md` — root cause, diagnostic, 4 ranked solutions, prevention

### Why this lesson
No existing lesson covers PEP 668 on macOS Homebrew. Closest match is lesson-07 (Ubuntu WSL venv) at 74% relevance.

### Verification
- `python3 search_knowledge.py "externally-managed-environment"` — new lesson should rank #1
- Content is desensitized (no internal project details)

Closes #254

/claim #254