### PR TITLE
docs: add DCO sign-off quickstart for Windows contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,8 @@ git commit --signoff -m "feat: your message"
 git commit --amend --signoff
 ```
 
+> ℹ️ **Windows Users:** For detailed instructions on fixing DCO issues on Windows (including rebase and force push), see the [Windows DCO Sign-off Guide](docs/dco-windows.md).
+
 The trailer looks like:
 ```
 Signed-off-by: Your Name <your@email.com>

--- a/docs/dco-windows.md
+++ b/docs/dco-windows.md
@@ -1,0 +1,69 @@
+# DCO Commit Sign-off Quickstart for Windows Contributors
+
+This guide helps Windows contributors resolve **Developer Certificate of Origin (DCO)** failures on their pull requests.
+
+## ❓ What is the DCO failure?
+
+MisakaNet enforces the Developer Certificate of Origin (DCO) to ensure all code contributions are legally authorized. Every commit in your Pull Request must contain a `Signed-off-by:` line at the bottom of the commit message matching the git commit author's name and email.
+
+If your PR shows a failed DCO check, it is usually because you didn't commit with the `--signoff` (or `-s`) flag.
+
+---
+
+## 🚀 Copy-Paste Fix Commands for Windows
+
+To fix existing commits that failed the DCO check, open your terminal (Git Bash, Command Prompt, or PowerShell) in your repository directory and run the following commands:
+
+### 1. For the most recent commit
+
+If you only need to sign off your **latest** commit:
+
+```bash
+# Add the sign-off trailer to the last commit
+git commit --amend --signoff --no-edit
+
+# Force-push to update your Pull Request
+git push --force-with-lease
+```
+
+### 2. For multiple commits
+
+If you need to sign off **multiple** commits in your branch, you can perform an interactive rebase:
+
+```bash
+# Start an interactive rebase for the last N commits (replace N with your number of commits)
+git rebase -i HEAD~N
+```
+
+In the editor that opens:
+1. Change `pick` to `edit` (or `e`) for all the commits you need to sign off.
+2. Save and exit the editor.
+3. For each commit, Git will pause. Run the following:
+   ```bash
+   git commit --amend --signoff --no-edit
+   git rebase --continue
+   ```
+4. Once completed, force push:
+   ```bash
+   git push --force-with-lease
+   ```
+
+---
+
+## 🛠️ Configure Git on Windows to Auto-Sign (Optional)
+
+You can configure Git on Windows to automatically sign off or template your commit messages:
+
+### Set up Git Identity
+Ensure your name and email are configured correctly (this email must match the one in your `Signed-off-by:` line):
+
+```bash
+git config --global user.name "Your Real Name"
+git config --global user.email "your.email@example.com"
+```
+
+### Always Use the `-s` Flag
+Remember to append `-s` whenever you make a commit:
+```bash
+git commit -s -m "docs: add Windows DCO quickstart"
+```


### PR DESCRIPTION
### Summary
This PR addresses issue #443 by adding a Windows-specific quickstart guide for resolving Developer Certificate of Origin (DCO) commit sign-off failures.

### Changes
* Created a dedicated guide at [docs/dco-windows.md](file:///C:/Users/Sparsh%20Garg/.gemini/antigravity-ide/scratch/MisakaNet/docs/dco-windows.md) containing:
  - Explanation of DCO checks.
  - Concrete copy-pasteable commands for signing off the latest commit or rebasing multiple commits using Git on Windows.
  - Setup commands for global git name and email configurations.
* Updated [CONTRIBUTING.md](file:///C:/Users/Sparsh%20Garg/.gemini/antigravity-ide/scratch/MisakaNet/CONTRIBUTING.md) to link to the new guide.

Closes #443
/claim #443
Node ID: SparshGarg999