### PR TITLE
docs: add local CI secret-scan troubleshooting on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ The most valuable contribution is sharing what your AI Agent has learned.
 | Crash → draft lesson | `python3 scripts/tombstone_to_draft.py --from-file tombstone.json` |
 | Agent bench run | `python3 scripts/bench_orchestrator.py [--agent openai\|minimax] [--include-drafts]` |
 | Draft lesson wizard | `python3 scripts/contribute.py --wizard` |
-| Quality audit | `python3 scripts/check_worker_secrets.py` |
+| Quality audit | `python3 scripts/check_worker_secrets.py` (Windows users see [troubleshooting](docs/secret-scan-windows.md)) |
 
 ## Reporting Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,8 @@ git commit --signoff -m "feat: your message"
 git commit --amend --signoff
 ```
 
+> ℹ️ **Windows Users:** For detailed instructions on fixing DCO issues on Windows (including rebase and force push), see the [Windows DCO Sign-off Guide](docs/dco-windows.md).
+
 The trailer looks like:
 ```
 Signed-off-by: Your Name <your@email.com>

--- a/docs/dco-windows.md
+++ b/docs/dco-windows.md
@@ -1,0 +1,69 @@
+# DCO Commit Sign-off Quickstart for Windows Contributors
+
+This guide helps Windows contributors resolve **Developer Certificate of Origin (DCO)** failures on their pull requests.
+
+## ❓ What is the DCO failure?
+
+MisakaNet enforces the Developer Certificate of Origin (DCO) to ensure all code contributions are legally authorized. Every commit in your Pull Request must contain a `Signed-off-by:` line at the bottom of the commit message matching the git commit author's name and email.
+
+If your PR shows a failed DCO check, it is usually because you didn't commit with the `--signoff` (or `-s`) flag.
+
+---
+
+## 🚀 Copy-Paste Fix Commands for Windows
+
+To fix existing commits that failed the DCO check, open your terminal (Git Bash, Command Prompt, or PowerShell) in your repository directory and run the following commands:
+
+### 1. For the most recent commit
+
+If you only need to sign off your **latest** commit:
+
+```bash
+# Add the sign-off trailer to the last commit
+git commit --amend --signoff --no-edit
+
+# Force-push to update your Pull Request
+git push --force-with-lease
+```
+
+### 2. For multiple commits
+
+If you need to sign off **multiple** commits in your branch, you can perform an interactive rebase:
+
+```bash
+# Start an interactive rebase for the last N commits (replace N with your number of commits)
+git rebase -i HEAD~N
+```
+
+In the editor that opens:
+1. Change `pick` to `edit` (or `e`) for all the commits you need to sign off.
+2. Save and exit the editor.
+3. For each commit, Git will pause. Run the following:
+   ```bash
+   git commit --amend --signoff --no-edit
+   git rebase --continue
+   ```
+4. Once completed, force push:
+   ```bash
+   git push --force-with-lease
+   ```
+
+---
+
+## 🛠️ Configure Git on Windows to Auto-Sign (Optional)
+
+You can configure Git on Windows to automatically sign off or template your commit messages:
+
+### Set up Git Identity
+Ensure your name and email are configured correctly (this email must match the one in your `Signed-off-by:` line):
+
+```bash
+git config --global user.name "Your Real Name"
+git config --global user.email "your.email@example.com"
+```
+
+### Always Use the `-s` Flag
+Remember to append `-s` whenever you make a commit:
+```bash
+git commit -s -m "docs: add Windows DCO quickstart"
+```

--- a/docs/secret-scan-windows.md
+++ b/docs/secret-scan-windows.md
@@ -1,0 +1,72 @@
+# Local CI Secret-Scan Troubleshooting on Windows
+
+This guide helps Windows contributors resolve crashes and errors when running the local secret-scan audit script (`scripts/check_worker_secrets.py`).
+
+---
+
+## ❓ What is the Secret-Scan failure?
+
+MisakaNet includes a security gate script at `scripts/check_worker_secrets.py` that scans for hardcoded secrets and verifies env var checks. This script is run automatically in the pre-push and PR checks.
+
+On Windows, running the script directly can crash with the following error:
+
+```text
+Traceback (most recent call last):
+  File "scripts\check_worker_secrets.py", line 209, in <module>
+    sys.exit(main())
+  File "scripts\check_worker_secrets.py", line 132, in main
+    print("\U0001f50d Worker Secret & Env Handling Audit")
+UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f50d' in position 0: character maps to <undefined>
+```
+
+### Root Cause
+This occurs because the Windows console (PowerShell or Command Prompt) defaults to a regional encoding (such as `GBK`, `CP936`, or `CP1252`). When the Python script attempts to print emojis (like `🔍` or `✅`), the default encoder fails to map these Unicode characters to the console's character page, throwing a `UnicodeEncodeError`.
+
+---
+
+## 🚀 Copy-Paste Fixes for Windows
+
+Use any of the following methods to run the script successfully on Windows:
+
+### Method 1: Use Python's UTF-8 Mode (Recommended)
+You can force Python to run in UTF-8 mode by passing the `-X utf8` flag:
+
+```bash
+python3 -X utf8 scripts/check_worker_secrets.py
+```
+
+### Method 2: Set the `PYTHONIOENCODING` Environment Variable
+You can explicitly configure Python to output in UTF-8.
+
+#### In PowerShell:
+```powershell
+$env:PYTHONIOENCODING="utf-8"
+python3 scripts/check_worker_secrets.py
+```
+
+#### In Command Prompt (cmd):
+```cmd
+set PYTHONIOENCODING=utf-8
+python3 scripts/check_worker_secrets.py
+```
+
+#### In Git Bash:
+```bash
+export PYTHONIOENCODING=utf-8
+python3 scripts/check_worker_secrets.py
+```
+
+### Method 3: Use the `PYTHONUTF8` Environment Variable
+Enable UTF-8 mode globally in your shell session.
+
+#### In PowerShell:
+```powershell
+$env:PYTHONUTF8=1
+python3 scripts/check_worker_secrets.py
+```
+
+#### In Git Bash:
+```bash
+export PYTHONUTF8=1
+python3 scripts/check_worker_secrets.py
+```


### PR DESCRIPTION
### Summary
This PR addresses issue #444 by adding a Windows-specific troubleshooting guide for resolving `UnicodeEncodeError` crashes when running the local secret-scan audit script (`scripts/check_worker_secrets.py`).

### Root Cause
On Windows systems, Python's default stdout encoding throws a `UnicodeEncodeError` when trying to print emojis or non-ASCII characters to standard Windows consoles (which default to CP1252, GBK, etc.). 

### Changes
* Created a dedicated guide at [docs/secret-scan-windows.md](file:///C:/Users/Sparsh%20Garg/.gemini/antigravity-ide/scratch/MisakaNet/docs/secret-scan-windows.md) containing:
  - Explanation of the crash.
  - Three distinct copy-pasteable solutions to resolve the issue:
    1. Using Python UTF-8 mode (`python -X utf8`)
    2. Setting `PYTHONIOENCODING=utf-8` environment variable
    3. Setting `PYTHONUTF8=1` environment variable
* Linked the troubleshooting guide from the Tools Reference section in [CONTRIBUTING.md](file:///C:/Users/Sparsh%20Garg/.gemini/antigravity-ide/scratch/MisakaNet/CONTRIBUTING.md).

Closes #444
/claim #444
Node ID: SparshGarg999