### PR TITLE
feat(search): add machine-readable JSON output

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,6 +13,7 @@ python3 search_knowledge.py <query> [options]
 | `--ref` | Mode | Switch to reference search mode (not a path/id filter) | `--ref` |
 | `--top=<N>` | Pagination | Show top N results (default: 10) | `--top=3` |
 | `--titles` | Display | Show titles only | `--titles` |
+| `--json` | Display | Emit a JSON array with `title`, `domain`, `tags`, `score`, `path`, and `preview`; errors are JSON objects | `"pip timeout" --json \| jq '.[0]'` |
 | `--broad` | Matching | Broader keyword matching | `--broad` |
 | `--suggest` | Mode | List matching titles (≥2 chars) | `--suggest` |
 | `--semantic` | Mode | Use sentence-transformers _(optional dep)_ | `--semantic` |
@@ -26,6 +27,13 @@ python3 search_knowledge.py <query> [options]
 | `--harvest --from-file=<f>` | Mode | Parse log for errors → draft lesson | `--harvest --from-file=crash.log` |
 
 **Exit codes:** `0` = results found, `1` = no results or error.
+
+`--json` keeps standard output machine-readable, so it can be piped directly to
+tools such as `jq`:
+
+```bash
+python3 search_knowledge.py "database locked" --json --top=3 | jq '.[].path'
+```
 
 ## Other CLI Tools
 

--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -4,9 +4,13 @@
 Ecosystem links:
     from misakanet_core import BM25, tokenize, rrf
 """
+import contextlib
+import io
+import json
 import sys
 import time
 import re
+from pathlib import Path
 from typing import Optional
 
 # ── 生态核心声明 ──
@@ -20,6 +24,29 @@ except ImportError as e:
         sys.exit(1)
     raise
 from misakanet.tools.lesson_scorer import DEFAULT_TELEMETRY, format_lesson_scores, score_lessons
+
+
+def _json_result(score, doc) -> dict:
+    """Convert a ranked document to the stable public JSON schema."""
+    from misakanet.search.engine import REPO, _get_preview
+
+    try:
+        path = doc.filepath.relative_to(REPO).as_posix()
+    except ValueError:
+        path = doc.filepath.as_posix()
+    return {
+        "title": doc.title,
+        "domain": doc.domain,
+        "tags": list(doc.tags),
+        "score": round(float(score), 6),
+        "path": path,
+        "preview": _get_preview(doc.content, max_chars=120),
+    }
+
+
+def _print_json_error(message: str) -> None:
+    """Emit a machine-readable error without contaminating it with CLI prose."""
+    print(json.dumps({"error": message}, ensure_ascii=False))
 
 
 def _ensure_utf8_stdout():
@@ -375,7 +402,15 @@ def main():
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(1)
-    query = sys.argv[1]
+    json_output = "--json" in args
+    positional_args = [arg for arg in args if arg != "--json"]
+    if not positional_args or positional_args[0].startswith("--"):
+        if json_output:
+            _print_json_error("a search query is required")
+        else:
+            print(__doc__)
+        sys.exit(1)
+    query = positional_args[0]
     mode = "all"
     titles_only = False
     broad_only = False
@@ -386,7 +421,7 @@ def main():
     env_filter: Optional[str] = None
     lang: Optional[str] = None
     domain: Optional[str] = None
-    search_args = sys.argv[2:]
+    search_args = positional_args[1:]
     for i, arg in enumerate(search_args):
         if arg == "--ref":
             mode = "ref"
@@ -428,9 +463,12 @@ def main():
     from misakanet.profile import check_quota as _check_quota
     allowed, quota_msg = _check_quota()
     if not allowed:
-        print(quota_msg, file=sys.stderr)
+        if json_output:
+            _print_json_error(quota_msg)
+        else:
+            print(quota_msg, file=sys.stderr)
         sys.exit(1)
-    if quota_msg:
+    if quota_msg and not json_output:
         print(quota_msg, file=sys.stderr)
         print("", file=sys.stderr)
 
@@ -438,7 +476,7 @@ def main():
     found_any = False
 
     # --suggest mode: list matching titles when query >= 2 chars
-    if suggest and len(query) >= 2:
+    if suggest and len(query) >= 2 and not json_output:
         q = query.lower()
         lessons_docs = _load_docs(LESSONS, is_lesson=True) if mode in ("all", "lessons") else []
         ref_docs = _load_docs(REFERENCES, is_lesson=False) if mode in ("all", "ref") else []
@@ -457,26 +495,49 @@ def main():
         _show_timing(time.time() - t0, len(all_docs))
         return
 
-    lessons_docs = _load_docs(LESSONS, is_lesson=True) if mode in ("all", "lessons") else []
-    ref_docs = _load_docs(REFERENCES, is_lesson=False) if mode in ("all", "ref") else []
+    # Cache migrations can report status to stdout. Capture those messages in
+    # JSON mode so stdout remains directly pipeable to jq.
+    output_context = contextlib.redirect_stdout(io.StringIO()) if json_output else contextlib.nullcontext()
+    with output_context:
+        lessons_docs = _load_docs(LESSONS, is_lesson=True) if mode in ("all", "lessons") else []
+        ref_docs = _load_docs(REFERENCES, is_lesson=False) if mode in ("all", "ref") else []
 
     # Language filter
     if lang:
         lessons_docs = [d for d in lessons_docs if d.language == lang]
         ref_docs = [d for d in ref_docs if d.language == lang]
-        print(f"  🌐 Filtering by language: {lang}")
+        if not json_output:
+            print(f"  🌐 Filtering by language: {lang}")
 
     # Domain filter (fix #229)
     if domain:
         lessons_docs = [d for d in lessons_docs if d.domain and d.domain.lower() == domain]
         ref_docs = [d for d in ref_docs if d.domain and d.domain.lower() == domain]
-        print(f"  🏷️  Filtering by domain: {domain}")
+        if not json_output:
+            print(f"  🏷️  Filtering by domain: {domain}")
 
     # Environment filter (--env)
     if env_filter:
         lessons_docs = [d for d in lessons_docs if any(env_filter in t.lower() for t in d.tags)]
         ref_docs = [d for d in ref_docs if any(env_filter in t.lower() for t in d.tags)]
-        print(f"  💻 Filtering by environment: {env_filter}")
+        if not json_output:
+            print(f"  💻 Filtering by environment: {env_filter}")
+
+    if json_output:
+        all_docs = lessons_docs + ref_docs
+        with contextlib.redirect_stdout(io.StringIO()):
+            ranked = _rank_docs(query, all_docs, titles_only, broad_only)
+        results = [
+            _json_result(score, doc)
+            for score, doc in ranked
+            if score >= 0.1
+        ][:top_k]
+        if results:
+            from misakanet.profile import increment_search, consume_quota
+            increment_search()
+            consume_quota()
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+        return
 
     if use_semantic:
         try:
@@ -620,4 +681,12 @@ Error encountered during `{query[:60]}`.
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if "--json" in sys.argv:
+            _print_json_error(str(exc))
+            raise SystemExit(1)
+        raise

--- a/tests/test_search_knowledge_stdout.py
+++ b/tests/test_search_knowledge_stdout.py
@@ -1,5 +1,7 @@
 import io
+import json
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import search_knowledge
@@ -31,6 +33,30 @@ class TestSearchKnowledgeStdout(unittest.TestCase):
 
         with mock.patch.object(search_knowledge.sys, "stdout", stdout):
             search_knowledge._ensure_utf8_stdout()
+
+    def test_json_result_uses_required_schema(self):
+        doc = mock.Mock(
+            title="Database locked",
+            domain="database",
+            tags=["sqlite", "locking"],
+            filepath=Path(search_knowledge.__file__).parent / "lessons" / "example.md",
+            content="---\ntitle: Example\n---\n\nA useful preview.",
+        )
+
+        result = search_knowledge._json_result(0.12345678, doc)
+
+        self.assertEqual(
+            set(result), {"title", "domain", "tags", "score", "path", "preview"}
+        )
+        self.assertEqual(result["path"], "lessons/example.md")
+        self.assertEqual(result["score"], 0.123457)
+
+    def test_json_error_is_parseable(self):
+        stdout = io.StringIO()
+        with mock.patch.object(search_knowledge.sys, "stdout", stdout):
+            search_knowledge._print_json_error("query failed")
+
+        self.assertEqual(json.loads(stdout.getvalue()), {"error": "query failed"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--json` output to `search_knowledge.py` with the stable `{title, domain, tags, score, path, preview}` schema
- keep stdout clean for direct `jq` piping and emit machine-readable JSON errors
- document JSON usage in the CLI reference and add focused schema/error tests

## Verification
- `python3 -m pytest -q tests/test_search_knowledge_stdout.py tests/test_search_edge_cases.py tests/test_misaka_search_json.py` (33 passed)
- `python3 search_knowledge.py "database locked" --json --top=2 | jq -e ...` (valid array and exact schema)
- missing-query output parses with `python3 -m json.tool` and exits 1
- `git diff --check`

Closes #304

/claim #304