### PR TITLE
feat(search): show match reasons

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,6 +20,7 @@ python3 search_knowledge.py <query> [options]
 | `--score` | Mode | Lesson quality scoring from telemetry | `--score --top=5` |
 | `--telemetry=<path>` | Scoring | Custom telemetry DB path | `--telemetry=/tmp/t.db --score` |
 | `--explain` | Search | Show BM25/Meta/Base score breakdown | `--explain` |
+| `--verbose` | Search | Alias for `--explain`; JSON output includes `score_breakdown` | `--verbose --json` |
 | `--env=<env>` | Filter | Filter by environment tag (wsl2, docker, ...) | `--env=wsl2` |
 | `--domain=<d>` | Filter | Filter by domain (devops, rag, ...) | `--domain=devops` |
 | `--lang=<lang>` | Filter | Filter by language | `--lang=zh` |

--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -391,6 +391,16 @@ def _rank_docs_impl(
     return scored
 
 
+def _matching_terms(text: str, query: str) -> list[str]:
+    text_l = text.lower()
+    matches = []
+    for token in _tokenize(query):
+        token_l = token.lower()
+        if token_l and token_l in text_l and token_l not in matches:
+            matches.append(token_l)
+    return matches
+
+
 def _highlight(text: str, query: str) -> str:
     tokens = _tokenize(query)
     if not tokens:
@@ -404,35 +414,69 @@ def _highlight(text: str, query: str) -> str:
     return text
 
 
+def _highlight_plain(text: str, query: str) -> str:
+    """Highlight matching terms without ANSI escapes for JSON consumers."""
+    highlighted = text
+    for token in sorted(set(_tokenize(query)), key=len, reverse=True):
+        highlighted = re.sub(
+            re.escape(token),
+            lambda m: f"[{m.group()}]",
+            highlighted,
+            flags=re.IGNORECASE,
+        )
+    return highlighted
+
+
 def _score_bar(score: float, width: int = 10) -> str:
     pct = max(0.0, min(score, 1.0))
     filled = round(pct * width)
     return "█" * filled + "░" * (width - filled) + f" {pct:.0%}"
 
 
-def _get_match_reason(query: str, doc: CachedDoc, score: float) -> str:
-    """Feature #231: Show why this result was matched."""
-    q = query.lower()
-    t = doc.title.lower()
+def _get_match_reason(query: str, doc: CachedDoc, score: float | None = None) -> str:
+    """Show why this result was matched, including field names and terms."""
     reasons = []
 
-    # Check title match
-    if q in t or any(word in t for word in q.split()):
-        reasons.append("title")
+    for term in _matching_terms(doc.title, query):
+        reasons.append(f"title keyword '{term}'")
 
-    # Check domain match
-    if doc.domain and doc.domain.lower() in q:
-        reasons.append("domain")
+    for term in _matching_terms(doc.domain, query):
+        if term == doc.domain.lower():
+            reasons.append(f"domain '{doc.domain}'")
+        else:
+            reasons.append(f"domain keyword '{term}'")
 
-    # Check content match (BM25 score > 0.3 indicates content match)
-    if score > 0.3 and "title" not in reasons:
-        reasons.append("content")
+    for tag in doc.tags:
+        tag_text = str(tag)
+        for term in _matching_terms(tag_text, query):
+            if term == tag_text.lower():
+                reasons.append(f"tag '{tag_text}'")
+            else:
+                reasons.append(f"tag keyword '{term}'")
 
-    # Check if broad match
+    for term in _matching_terms(doc.content, query):
+        if not any(f"'{term}'" in reason for reason in reasons):
+            reasons.append(f"content keyword '{term}'")
+
     if doc.scope == "broad":
         reasons.append("broad")
 
-    return ", ".join(reasons) if reasons else ""
+    if not reasons and score is not None and score > 0:
+        reasons.append("BM25 content score")
+
+    return " + ".join(dict.fromkeys(reasons))
+
+
+def _score_breakdown(query: str, doc: CachedDoc) -> dict:
+    bm25 = _compute_bm25_scores(query, [doc])[0]
+    meta_parts = _metadata_bonus_breakdown(query, doc)
+    boost_parts = _compute_boost_breakdown(doc)
+    return {
+        "bm25": round(float(bm25), 6),
+        "metadata": {key: round(float(value), 6) for key, value in meta_parts},
+        "baseline": round(float(doc.score_baseline), 6),
+        "boost": {key: round(float(value), 6) for key, value in boost_parts},
+    }
 
 
 def _get_related_lessons(
@@ -580,6 +624,8 @@ __all__ = [
     "_compute_boost",
     "_relative_time",
     "_get_match_reason",
+    "_highlight_plain",
+    "_score_breakdown",
     "_get_related_lessons",
 ]
 

--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -26,22 +26,35 @@ except ImportError as e:
 from misakanet.tools.lesson_scorer import DEFAULT_TELEMETRY, format_lesson_scores, score_lessons
 
 
-def _json_result(score, doc) -> dict:
+def _json_result(score, doc, query: str = "", verbose: bool = False) -> dict:
     """Convert a ranked document to the stable public JSON schema."""
-    from misakanet.search.engine import REPO, _get_preview
+    from misakanet.search.engine import (
+        REPO,
+        _get_match_reason,
+        _get_preview,
+        _highlight_plain,
+        _score_breakdown,
+    )
 
     try:
         path = doc.filepath.relative_to(REPO).as_posix()
     except ValueError:
         path = doc.filepath.as_posix()
-    return {
+    preview = _get_preview(doc.content, max_chars=120)
+    result = {
         "title": doc.title,
         "domain": doc.domain,
         "tags": list(doc.tags),
         "score": round(float(score), 6),
         "path": path,
-        "preview": _get_preview(doc.content, max_chars=120),
+        "preview": preview,
     }
+    if query:
+        result["match_reason"] = _get_match_reason(query, doc, score)
+        result["preview_highlighted"] = _highlight_plain(preview, query)
+    if verbose and query:
+        result["score_breakdown"] = _score_breakdown(query, doc)
+    return result
 
 
 def _print_json_error(message: str) -> None:
@@ -418,6 +431,7 @@ def main():
     use_semantic = False
     suggest = False
     explain = False
+    verbose = False
     env_filter: Optional[str] = None
     lang: Optional[str] = None
     domain: Optional[str] = None
@@ -454,6 +468,9 @@ def main():
         elif arg == "--domain" and i + 1 < len(search_args):
             domain = search_args[i + 1].lower()
         elif arg == "--explain":
+            explain = True
+        elif arg == "--verbose":
+            verbose = True
             explain = True
         elif arg.startswith("--env="):
             env_filter = arg.split("=", 1)[1].lower()
@@ -528,7 +545,7 @@ def main():
         with contextlib.redirect_stdout(io.StringIO()):
             ranked = _rank_docs(query, all_docs, titles_only, broad_only)
         results = [
-            _json_result(score, doc)
+            _json_result(score, doc, query=query, verbose=verbose)
             for score, doc in ranked
             if score >= 0.1
         ][:top_k]

--- a/tests/test_search_knowledge_stdout.py
+++ b/tests/test_search_knowledge_stdout.py
@@ -51,6 +51,43 @@ class TestSearchKnowledgeStdout(unittest.TestCase):
         self.assertEqual(result["path"], "lessons/example.md")
         self.assertEqual(result["score"], 0.123457)
 
+    def test_json_result_includes_match_reason_when_query_is_provided(self):
+        doc = mock.Mock(
+            title="Network timeout",
+            domain="devops",
+            tags=["network", "retry"],
+            filepath=Path(search_knowledge.__file__).parent / "lessons" / "example.md",
+            content="---\ntitle: Example\n---\n\nRetry the network timeout with backoff.",
+        )
+
+        result = search_knowledge._json_result(0.5, doc, query="timeout network")
+
+        self.assertIn("title keyword 'timeout'", result["match_reason"])
+        self.assertIn("tag 'network'", result["match_reason"])
+        self.assertIn("[timeout]", result["preview_highlighted"].lower())
+
+    def test_json_result_includes_score_breakdown_when_verbose(self):
+        doc = mock.Mock(
+            title="Network timeout",
+            domain="devops",
+            status="published",
+            reference="",
+            scope="",
+            source="manual",
+            tags=["network"],
+            filepath=Path(search_knowledge.__file__).parent / "lessons" / "example.md",
+            content="Network timeout retry.",
+            score_baseline=0.1,
+            is_draft=False,
+            mtime=0.0,
+        )
+
+        result = search_knowledge._json_result(0.5, doc, query="timeout", verbose=True)
+
+        self.assertIn("score_breakdown", result)
+        self.assertIn("bm25", result["score_breakdown"])
+        self.assertIn("metadata", result["score_breakdown"])
+
     def test_json_error_is_parseable(self):
         stdout = io.StringIO()
         with mock.patch.object(search_knowledge.sys, "stdout", stdout):


### PR DESCRIPTION
## Summary

- Show field-level match reasons for search results.
- Add highlighted preview text for JSON search results.
- Add `--verbose` as an alias for `--explain`, with JSON `score_breakdown`.
- Cover the new JSON behavior with regression tests.

## Problem

Search results currently expose ranking scores, but users cannot see which field or keyword caused a result to match. That makes results harder to trust and harder to refine.

## Solution

The search engine now builds match reasons from title, domain, tags, and content terms, for example:

- `title keyword 'timeout'`
- `domain 'network'`
- `tag 'timeout'`

Human output shows those reasons inline. JSON output now includes `match_reason` and `preview_highlighted`, and `--verbose --json` includes a structured `score_breakdown`.

## Testing

- `python -m pytest tests/test_search_knowledge_stdout.py tests/test_search_edge_cases.py -q`
  - `32 passed`
- `python -m pytest tests/ -q`
  - `232 passed, 4 skipped, 1 warning, 17 subtests passed`
- `ruff check misakanet/search/engine.py tests/test_search_knowledge_stdout.py`
  - `All checks passed`
- `python search_knowledge.py "timeout network" --top 1`
- `python search_knowledge.py "timeout network" --top 1 --json`
- `python search_knowledge.py "timeout network" --top 1 --json --verbose`
- `git diff --check`

Note: full `ruff check search_knowledge.py ...` still reports unrelated pre-existing lint debt in `search_knowledge.py`, so this PR keeps the lint scope focused on the changed engine/test files instead of doing broad cleanup.

## Files Changed

- `misakanet/search/engine.py`
- `search_knowledge.py`
- `tests/test_search_knowledge_stdout.py`
- `docs/cli-reference.md`

## Risk and Compatibility

Low risk. Ranking logic is unchanged. Existing JSON fields remain present, and the new JSON fields are additive. Existing `--explain` behavior remains available; `--verbose` is a compatibility alias that also enables JSON score breakdown output.

## Checklist

- [x] Code meets the issue acceptance criteria
- [x] Tests added
- [x] Relevant tests pass
- [x] Full pytest suite passes
- [x] No unrelated files included
- [x] Commit includes DCO sign-off

Fixes #302
