### PR TITLE
feat: add trust_tiers to protocol, registration reads from protocol

### DIFF
--- a/misaka-protocol.json
+++ b/misaka-protocol.json
@@ -2,12 +2,15 @@
   "protocol": "Swarm Knowledge Protocol",
   "version": "1.0",
   "description": "Machine-readable ecosystem configuration for MisakaNet-compatible nodes",
-
   "rings": {
     "1": {
       "name": "Core Architecture",
       "audience": "Expert Agents & Maintainers",
-      "labels": ["status:competition", "Bounty $0", "core"],
+      "labels": [
+        "status:competition",
+        "Bounty $0",
+        "core"
+      ],
       "require_dco": true,
       "require_coverage": 70,
       "reward": "Hall of Fame · Architecture influence"
@@ -15,7 +18,10 @@
     "2": {
       "name": "Feature Works",
       "audience": "Competent Agents",
-      "labels": ["enhancement", "feature"],
+      "labels": [
+        "enhancement",
+        "feature"
+      ],
       "require_dco": true,
       "require_coverage": 40,
       "reward": "Contribution graph · Merge credit"
@@ -23,7 +29,11 @@
     "3": {
       "name": "Open Ground",
       "audience": "All Agents & Beginners",
-      "labels": ["good-first-issue", "docs", "bug"],
+      "labels": [
+        "good-first-issue",
+        "docs",
+        "bug"
+      ],
       "require_dco": false,
       "require_coverage": 20,
       "reward": "Contribution graph · GitHub reputation"
@@ -31,40 +41,87 @@
     "4": {
       "name": "Human & Docs",
       "audience": "Human Contributors",
-      "labels": ["docs", "i18n", "test-coverage", "good-first-issue"],
+      "labels": [
+        "docs",
+        "i18n",
+        "test-coverage",
+        "good-first-issue"
+      ],
       "require_dco": false,
       "require_coverage": 0,
       "reward": "Contribution credit · Docs maintainer role"
     }
   },
-
   "registration": {
     "github": {
       "method": "issue",
-      "trigger_labels": ["join", "register", "注册", "加入", "Registration"],
-      "trust_level": "verified",
+      "trigger_labels": [
+        "join",
+        "register",
+        "注册",
+        "加入",
+        "Registration"
+      ],
       "node_prefix": "Misaka",
       "counter_path": "data/counter.json",
-      "avatar_generator": "scripts/misakanet-avatar.py"
+      "avatar_generator": "scripts/misakanet-avatar.py",
+      "trust_tier": "github-verified",
+      "trust_level_reference": "trust_tiers.github-verified.trust_level"
     },
     "email": {
       "method": "email",
       "address": "bot@misakanet.org",
-      "trust_level": "unverified",
       "requires_verification": true,
       "node_prefix": "Misaka",
-      "counter_kv": "MISAKANET_KV"
+      "counter_kv": "MISAKANET_KV",
+      "trust_tier": "mail-verified",
+      "trust_level_reference": "trust_tiers.mail-verified.trust_level"
     }
   },
-
   "dco": {
     "enabled": true,
-    "required_for": ["ring-1", "ring-2"],
+    "required_for": [
+      "ring-1",
+      "ring-2"
+    ],
     "signoff_format": "Signed-off-by: Name <email>",
     "auto_fix_command": "/fix-dco",
     "audit_action": "Ikalus1988/dco-audit@v1"
   },
-
+  "trust_tiers": {
+    "github-verified": {
+      "description": "Verified via GitHub OAuth / issue trigger",
+      "trust_level": 3,
+      "method": "github",
+      "requires_verification": false,
+      "badge_display": "Verified",
+      "badge_icon": "octicon-check-circle-fill"
+    },
+    "mail-verified": {
+      "description": "Verified via email confirmation code",
+      "trust_level": 2,
+      "method": "email",
+      "requires_verification": true,
+      "badge_display": "Mail Verified",
+      "badge_icon": "octicon-mail"
+    },
+    "web-verified": {
+      "description": "Verified via web domain ownership",
+      "trust_level": 1,
+      "method": "web",
+      "requires_verification": true,
+      "badge_display": "Web Verified",
+      "badge_icon": "octicon-globe"
+    },
+    "anonymous": {
+      "description": "No verification performed",
+      "trust_level": 0,
+      "method": "none",
+      "requires_verification": false,
+      "badge_display": "Anonymous",
+      "badge_icon": "octicon-person"
+    }
+  },
   "competition": {
     "claim_timeout_hours": 4,
     "wip_pr_deadline_hours": 4,
@@ -73,7 +130,6 @@
     "first_past_the_post": true,
     "runner_up_must_review": true
   },
-
   "scoring": {
     "quality_threshold": 40,
     "pr_size_warning_files": 10,
@@ -81,9 +137,13 @@
     "coverage_minimum": 20,
     "benchmark_regression_max_pct": 15
   },
-
   "ci": {
-    "required_checks": ["lint", "pytest", "dco-audit", "quality-score"],
+    "required_checks": [
+      "lint",
+      "pytest",
+      "dco-audit",
+      "quality-score"
+    ],
     "audit_report": true,
     "auto_merge": {
       "enabled": true,
@@ -91,13 +151,11 @@
       "merge_method": "merge"
     }
   },
-
   "nodes": {
     "current_count": 52,
     "prefix": "Misaka",
     "counter_start": 10000
   },
-
   "ecosystem": {
     "tools": {
       "harvester": {
@@ -105,9 +163,21 @@
         "command": "misaka harvest",
         "description": "Scan terminal history or log files for error→fix patterns and auto-generate SKP-compliant lessons.",
         "input_sources": [
-          {"flag": "--bash-history", "source": "$HISTFILE (bash history)", "status": "planned"},
-          {"flag": "--from-file", "source": "Arbitrary log file path", "status": "planned"},
-          {"flag": "--pipe", "source": "stdin (piped from other tools)", "status": "planned"}
+          {
+            "flag": "--bash-history",
+            "source": "$HISTFILE (bash history)",
+            "status": "planned"
+          },
+          {
+            "flag": "--from-file",
+            "source": "Arbitrary log file path",
+            "status": "planned"
+          },
+          {
+            "flag": "--pipe",
+            "source": "stdin (piped from other tools)",
+            "status": "planned"
+          }
         ],
         "output": "Markdown lesson file matching lessons/schema/lesson.json",
         "integration_points": [


### PR DESCRIPTION
## Summary

Adds a machine-readable \	rust_tiers\ section to \misaka-protocol.json\ as described in issue #354.

## Changes

### \misaka-protocol.json\
- **Added \	rust_tiers\ section** with 4 tiers:
  - \github-verified\ (level 3) — GitHub OAuth verified
  - \mail-verified\ (level 2) — Email confirmation
  - \web-verified\ (level 1) — Web domain ownership
  - \nonymous\ (level 0) — No verification
- Each tier defines: \description\, \	rust_level\, \method\, \equires_verification\, \adge_display\, \adge_icon\
- **Updated \egistration\ section** to reference \	rust_tiers\ instead of hardcoded \	rust_level\

## Verification
- \python -m json.tool misaka-protocol.json\ — passes
- Existing \erify_protocol_config.py\ — compatible

Closes #354