### PR TITLE
Add 7 FANUC robot lessons from internal training materials

### DIFF
--- a/lessons/contrib/fanuc-alarm-severity-guide.md
+++ b/lessons/contrib/fanuc-alarm-severity-guide.md
@@ -1,0 +1,103 @@
+---
+title: "FANUC Alarm Severity Levels — Handling and Color Codes"
+domain: "fanuc"
+subdomain: "troubleshooting"
+tags: ["alarm", "severity", "warn", "pause", "stop", "servo", "abort", "system", "troubleshooting"]
+status: "published"
+source: "internal-training"
+confidence: "0.95"
+created: "2026-07-14"
+---
+
+## Problem
+
+FANUC controllers display alarms with different severity levels, but engineers don't always understand the implications of each level — which ones stop the robot, which cut servo power, and which require immediate action vs. can be deferred.
+
+## Solution
+
+### Alarm Severity Table
+
+| Severity | Program | Robot Motion | Servo Power | Scope |
+|----------|---------|--------------|-------------|-------|
+| NONE | No stop | No stop | Not cut | ... |
+| WARN | No stop | No stop | Not cut | ... |
+| PAUSE.L / PAUSE.G | Pause | Decel then stop | Not cut | Local / Global |
+| STOP.L / STOP.G | Pause | Decel then stop | Not cut | Local / Global |
+| SERVO | Force end | Instant stop | **Cut** | Global |
+| ABORT.L / ABORT.G | Force end | Decel then stop | Not cut | Local / Global |
+| SERVO2 / SYSTEM | Force end | Instant stop | **Cut** | Global |
+
+### Severity Descriptions
+
+- **WARN**: Warning for minor/non-critical issues. LED does NOT light up.
+- **PAUSE**: Pauses program execution, robot stops after completing current motion. Servo stays on.
+- **STOP**: Pauses program execution, robot decelerates to stop. Servo stays on.
+- **SERVO**: Interrupts or force-ends program, robot stops INSTANTLY, servo power CUT. Most dangerous motion stop.
+- **ABORT**: Force-ends program, robot decelerates to stop. Servo stays on.
+- **SYSTEM**: System-level critical issue. ALL operations stop.
+
+### Alarm Color Codes
+
+| Color | Severities | Meaning |
+|-------|------------|---------|
+| White | NONE, WARN | Informational, no action needed |
+| Yellow | PAUSE.L/G, STOP.L/G | Caution, check before resuming |
+| Red | SERVO, SERVO2, ABORT.L/G, SYSTEM | Critical, investigate immediately |
+| Blue | Reset, SYST-026 | System normal startup |
+
+### Common Alarm Codes
+
+**Servo alarms:**
+- SRVO-001: Operator panel emergency stop
+- SRVO-002: Teach pendant emergency stop
+- SRVO-007: External emergency stop
+- SRVO-012: Power failure recovery
+- SRVO-048: DCS SSO external emergency stop
+- SRVO-062: DSP not running
+
+**Program alarms:**
+- INTP-127: Power failure detected
+- INTP-224: Cannot branch
+- MEMO-027: Specified line not found
+
+**System alarms:**
+- SYST-026: System normal startup
+- SYST-039: T2 operation mode selected
+- SYST-212: DCS parameters need application
+- SYST-218: DCS function not available for this model
+
+### Alarm Recovery Procedures
+
+1. **Identify**: Read alarm code and severity from TP display
+2. **Investigate**: Check alarm history (MENU → Status → Alarm)
+3. **Resolve**: Fix root cause (not just reset)
+4. **Reset**: Press RESET key after root cause is fixed
+5. **Verify**: Confirm servo power restores and robot operates normally
+
+### DCS Safety Alarms
+
+DCS (Dual Check Safety) uses independent dual CPUs to monitor:
+- Position limits
+- Speed limits
+- Joint speed limits
+
+DCS parameters are stored separately from regular parameters. Changing DCS requires 4-digit password (default: 1111).
+
+Stop distance = (Motion speed × Scan time) + Coast distance at power cutoff
+- Standard scan time: 8ms
+- Safety signal latency: 2ms (DCS I/O), 4ms (PROFINET)
+
+## Verification
+
+1. Trigger a WARN-level alarm — verify robot continues operating
+2. Trigger a PAUSE-level alarm — verify robot decelerates gracefully
+3. Trigger a SERVO-level alarm — verify servo power is cut immediately
+4. Check alarm history after each test — verify correct logging
+
+## Notes
+
+- WARN alarms don't light the LED — easy to miss in production
+- SERVO alarms are the most dangerous — instant stop can damage tooling
+- Always fix root cause before pressing RESET
+- DCS alarms require special handling — DCS parameters are password-protected
+- Alarm history is cleared on power cycle — export before shutdown if needed

--- a/lessons/contrib/fanuc-backup-restore-guide.md
+++ b/lessons/contrib/fanuc-backup-restore-guide.md
@@ -1,0 +1,132 @@
+---
+title: "FANUC Robot Backup and Restore — Full, Mirror, Auto, and File Restore"
+domain: "fanuc"
+subdomain: "maintenance"
+tags: ["backup", "restore", "mirror", "image", "auto-backup", "file-restore", "usb", "maintenance"]
+status: "published"
+source: "internal-training"
+confidence: "0.9"
+created: "2026-07-14"
+---
+
+## Problem
+
+FANUC robot controllers support multiple backup types (full backup, mirror/image backup, auto backup) with different contents, restore procedures, and use cases. Engineers often confuse them or use the wrong type for their situation.
+
+## Solution
+
+### Backup Type Comparison
+
+| Item | Full Backup | Mirror/Image Backup |
+|------|-------------|---------------------|
+| System software | Not included | Included |
+| User data | Included | Included |
+| Restore method | Data restore | Full system restore |
+| File size | Smaller | Larger |
+| Use case | Daily data backup | System-level backup/migration |
+
+### Full Backup (All of Above)
+
+Contains: TP/LS program files, system files, IO config, vision files, KAREL files. Does NOT include system software.
+
+```
+MENU → File → Backup → "All of above" → Select storage (USB/PC) → Execute
+```
+
+### Mirror/Image Backup
+
+Contains: complete system image (system software + all user data + config). Can restore to the exact state at backup time.
+
+```
+MENU → File → Backup → "Image Backup" → Select storage → Execute (takes longer)
+```
+
+### Auto Backup
+
+Scheduled automatic backup without manual intervention.
+
+```
+MENU → File → Auto Backup → Enable
+```
+
+Configuration options:
+- **Period**: Daily / Weekly / Monthly
+- **Time**: Specific backup time
+- **Type**: Full / Incremental
+- **Storage**: USB / CF card / Network
+
+### Restore Procedures
+
+**Full backup restore:**
+```
+MENU → File → Restore → Select backup file → Execute
+```
+
+**Mirror/image restore:**
+```
+1. Power on → Enter BOOT mode
+2. Select "Controlled Start"
+3. Select "Restore Image"
+4. Select image file
+5. Execute (system will restart)
+```
+
+**Partial file restore:**
+```
+MENU → File → Restore → Select source (USB/CF/Network) → Select specific files → Execute
+```
+
+### Remote Image Import
+
+For batch deployment across multiple robots via network:
+
+```
+MENU → File → Image Import → Select network import → Enter image server address
+```
+
+Supports FTP, HTTP, and custom KAREL-based protocols.
+
+### ASCII Program Import/Export
+
+ASCII format (.LS) programs can be edited with text editors and version-controlled:
+
+```
+Export: MENU → File → Export → Select program → ASCII format → Select storage
+Import: MENU → File → Import → Select file → Overwrite/Append → Confirm
+```
+
+Note: ASCII programs must be compiled after import.
+
+### Cross-Version File Transfer
+
+When transferring files between different system versions:
+- High→Low version may be incompatible
+- Specific option files may not transfer
+- System files may need reconfiguration
+- Always backup target system before import
+
+### Investigation Data Collection
+
+Types of data available for diagnostics:
+- **System info**: Software version, hardware config (MENU → Status → System)
+- **Alarm history**: Alarm records, codes (MENU → Status → Alarm)
+- **Runtime data**: Operating hours, cycle counts (MENU → Status → Runtime)
+- **IO status**: Signal states (MENU → Status → IO)
+
+Export methods: USB, FTP to PC, or KAREL automated collection.
+
+## Verification
+
+1. Create a full backup to USB and verify file count
+2. Create a mirror backup and verify file size is significantly larger
+3. Restore a single program file from backup without affecting others
+4. Configure auto backup and verify it runs at scheduled time
+
+## Notes
+
+- Always verify storage device has sufficient space before backup
+- Mirror backup/restore takes significantly longer than full backup
+- Verify backup file integrity before relying on it
+- Keep multiple backup copies in different locations
+- Do not power off during mirror restore operations
+- Auto backup failures usually indicate insufficient storage space

--- a/lessons/contrib/fanuc-dcs-safety-configuration.md
+++ b/lessons/contrib/fanuc-dcs-safety-configuration.md
@@ -1,0 +1,110 @@
+---
+title: "FANUC DCS Safety System — Configuration and Stop Modes"
+domain: "fanuc"
+subdomain: "safety"
+tags: ["dcs", "safety", "dual-check", "emergency-stop", "fence", "stop-mode", "safety-io", "iso13849"]
+status: "published"
+source: "internal-training"
+confidence: "0.95"
+created: "2026-07-14"
+---
+
+## Problem
+
+FANUC DCS (Dual Check Safety) is a critical safety system that uses independent dual CPUs to monitor robot position and speed. Misconfiguration can lead to safety violations or false trips. Engineers need to understand the DCS architecture, stop modes, and safety I/O to configure it correctly.
+
+## Solution
+
+### DCS Overview
+
+- Independent dual-CPU monitoring of motor speed and position
+- Dual-circuit power cutoff on detection of speed/position anomalies
+- Meets ISO 13849-1 and IEC 61508 requirements
+- Default emergency stop password: 1111
+
+### DCS Function Table
+
+| Function | Category | PL/SIL | Description |
+|----------|----------|--------|-------------|
+| Emergency Stop | Cat 4 | PL e / SIL 3 | Cut drive power on E-stop button (default) |
+| Position/Speed Check | Option | Cat 3 / PL d / SIL 2 | Monitor position and speed, cut on exceed |
+| Joint Speed Check | Option | Cat 3 / PL d / SIL 2 | Monitor joint speed, cut on exceed |
+| Basic Position Check | Option | Cat 3 / PL d / SIL 2 | Monitor Cartesian position, cut on exceed |
+| Safety I/O Connection | Option | Cat 4 / PL e / SIL 3 | Operate safety signals |
+| External Mode Switch | Option | Cat 4 / PL e / SIL 3 | Replace panel mode switch |
+| Device Network Security | Option | Cat 4 / PL e / SIL 3 | Network security slave device |
+| Safety PMC | Option | Cat 4 / PL e / SIL 3 | Safety I/O sequence via ladder |
+| Additional Axis Servo Off | Option | Cat 4 / PL e / SIL 3 | Cut additional axis motor power |
+| Safety I/O Consistency | Default | Cat 4 / PL e / SIL 3 | Cut power on I/O group inconsistency |
+
+### Stop Types
+
+| Type | Description |
+|------|-------------|
+| P-Stop (Power Stop) | Cut servo power instantly — robot stops immediately |
+| C-Stop (Control Stop) | Decelerate then cut servo power — controlled stop |
+| Hold | Maintain servo power, decelerate to stop — softest stop |
+
+### Stop Modes
+
+| Mode | E-Stop Button | External E-Stop | Fence Open | SVOFF Input |
+|------|---------------|-----------------|------------|-------------|
+| A | P-Stop | P-Stop | C-Stop | C-Stop |
+| B | P-Stop | P-Stop | P-Stop | P-Stop |
+| C | C-Stop | C-Stop | C-Stop | C-Stop |
+
+### Safety I/O Signals
+
+| Signal | Description |
+|--------|-------------|
+| EES1 / EES2 | External emergency stop input (dual circuit) |
+| EAS1 / EAS2 | Fence input (dual circuit) |
+| FENCE1 / FENCE2 | Fence signal (single circuit) |
+| EMGIN1 / EMGIN2 | External emergency stop (single circuit) |
+| SSO[3] / SSO[4] | DCS safety I/O |
+
+### DCS Parameter Management
+
+DCS parameters are stored in separate memory from regular parameters:
+- DCSPOS.SV — Position check parameters
+- DCSIOC.SV — I/O check parameters
+- SYSCIPS.SV — System safety parameters
+
+**To change DCS parameters:**
+1. Change setting parameters first
+2. Apply to DCS parameters
+3. Enter 4-digit password (default: 1111)
+
+### Stop Distance Calculation
+
+```
+Stop Distance = (Motion Speed × Scan Time) + Coast Distance at Power Cutoff
+```
+
+- Standard scan time: 8ms
+- Safety signal latency: 2ms (DCS I/O), 4ms (PROFINET)
+
+### Common DCS Alarms
+
+- SYST-212: DCS parameters need application
+- SYST-218: DCS function not available for this model
+- SRVO-048: DCS SSO external emergency stop
+- SRVO-049: DCS SSO servo disconnect
+- SRVO-223: DCS SSO error
+
+## Verification
+
+1. Check DCS parameter file exists: DCSPOS.SV, DCSIOC.SV
+2. Verify stop mode matches application requirements (A/B/C)
+3. Test E-stop button — should trigger correct stop type per mode
+4. Test fence signal — should trigger correct stop type per mode
+5. Verify DCS position limits match physical workspace constraints
+
+## Notes
+
+- DCS is a safety-critical system — changes require proper authorization and documentation
+- Always backup DCS parameters before modification
+- Stop mode B (P-Stop on everything) is the safest but most aggressive
+- Stop mode C (C-Stop on everything) is the gentlest but slowest to stop
+- PROFINET safety signals have higher latency (4ms) than DCS I/O (2ms)
+- DCS parameters are NOT included in regular parameter backup — backup separately

--- a/lessons/contrib/fanuc-mi-standard-software-instructions.md
+++ b/lessons/contrib/fanuc-mi-standard-software-instructions.md
@@ -1,0 +1,212 @@
+---
+title: "FANUC MI Standard Software — Complete Instruction Reference (MI01-MI22)"
+domain: "fanuc"
+subdomain: "tp-programming"
+tags: ["mi-standard", "mi01-cmn", "mi02-tch", "mi04-ssw", "mi08-dsp", "mi11-apl", "mi14-spr", "mi22-fds", "automotive", "welding", "gluing", "riveting"]
+status: "published"
+source: "internal-training"
+confidence: "0.9"
+created: "2026-07-14"
+---
+
+## Problem
+
+MI Standard Software is a comprehensive instruction library for automotive FANUC robots, covering PLC communication, tool change, spot welding, gluing, SPR riveting, FDS, stud welding, and more. Engineers need a quick reference for all MI module instructions and their parameters.
+
+## Solution
+
+### Architecture Overview
+
+MI Standard Software uses KAREL + TP hybrid architecture. Instructions are called via `CALL MIxx_MOD(parameters)`.
+
+### MI01_CMN — PLC Communication
+
+Base module for robot-PLC interaction. Background program starts automatically with robot.
+
+**Instructions:**
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Init | Reset collision zones, fixtures, group outputs; check home/pounce; verify MI02 installation | `CALL MI01_CMN(Init, '...')` |
+| CollZone | Collision zone request/release | `CALL MI01_CMN(CollZone, Request/Release, ZoneNo.=1, '...')` |
+| Segment | Send segment number to PLC | `CALL MI01_CMN(Segment, SegNo.=1, '...')` |
+| DecisionCode | Set register or output to PLC | `CALL MI01_CMN(DecisionCode, SetToReg/OutToPLC, '...')` |
+| Fixture | Fixture IN/OUT control | `CALL MI01_CMN(Fixture, IN/OUT, FixNo.=1, '...')` |
+| PressCheck | Pressure detection | `CALL MI01_CMN(PressCheck, '...')` |
+| FestoCheck | RIP detection (Festo) | `CALL MI01_CMN(FestoCheck, '...')` |
+
+**CollZone parameters:**
+- Param 1: `CollZone`
+- Param 2: `Request` or `Release`
+- Param 3: `ZoneNo.` (1-32)
+- Param 4: Comment (max 32 chars)
+
+### MI02_TCH — Tool Change
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| GunChange | Switch tool | `CALL MI02_TCH(GunChange, GunNo.=1, '...')` |
+| GunOpen | Open tool | `CALL MI02_TCH(GunOpen, '...')` |
+| GunClose | Close tool | `CALL MI02_TCH(GunClose, '...')` |
+
+### MI03_GRP — Material Handling
+
+```fanuc
+CALL MI03_GRP(Init, '...')
+CALL MI03_GRP(Step1, '...')
+```
+
+### MI04_SSW — Servo Spot Welding
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Weld | Spot weld | `CALL MI04_SSW(Weld, SpotNum=1, StyleNum=1, '...')` |
+| TipDress | Tip dress | `CALL MI04_SSW(TipDress, TipDressNum=1, '...')` |
+| TIPCHG | Tip change (new) | `CALL MI04_SSW(TIPCHG, TipCHGNum=1, '...')` |
+| FRES-TD | Tip dress (new) | `CALL MI04_SSW(FRES-TD, FRESNum=1, '...')` |
+
+**Tip dress compensation:**
+- System multiplies GI[121] value by `Tip dress scale` coefficient
+- Compensation applied to Tool 1 TCP
+- `Update`: Apply GI[121] × scale to Tool 1
+- `New Tip`: Restore original TCP from saved value
+
+**Config:** MENU → TEST CYCLE → MI GUI → MI04 Setup
+
+### MI08_DSP — Gluing
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Glue_Init | Initialize | `CALL MI08_DSP(Glue_Init, '...')` |
+| Glue_Start | Start gluing | `CALL MI08_DSP(Glue_Start, NozzleNum=1, TypeID=1, '...')` |
+| Glue_Purge | Purge gun | `CALL MI08_DSP(Glue_Purge, NozzleNum=1, '...')` |
+| Glue_Fill | Fill | `CALL MI08_DSP(Glue_Fill, NozzleNum=1, '...')` |
+| Glue_End | End | `CALL MI08_DSP(Glue_End, '...')` |
+
+**Config:** MENU → TEST CYCLE → MI GUI → MI08 Setup
+
+### MI09_DSD — Glue Detection
+
+**BetterWay brand:**
+- `Check`: Detection
+- `Start`: Start nozzle
+- `Reset`: Reset
+- `SendBSNNNum`: Send body serial number
+- `Job Start`: Process start
+
+**Coherix 2D/3D brand:**
+- `Check`, `Camera On/Off`, `Reset`, `SendBSNNNum`, `Job Start`, `Control Run Mode`, `Control Gun`
+
+### MI11_APL — Arplas/Dimple Welding
+
+**Arplas instructions:**
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| ArplasWeld | Weld | `CALL MI11_APL(Arplas, ArplasWeld, SpotNum=1, StrokePos=1000, '...')` |
+| Tipdress Update | Update TCP after dress | `CALL MI11_APL(Arplas, Tipdress, Update, '...')` |
+| Tipdress New Tip | Restore TCP | `CALL MI11_APL(Arplas, Tipdress, New Tip, '...')` |
+
+**Dimple instructions:**
+- `DimplePosCheck`: Pre-process check
+- `CloseGun`: Close gun process (delay then open, check pressure sensor)
+
+### MI13_RVH — SPR Riveting (Old Tucker)
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Init | Initialize | `CALL MI13_RVH(Init, GunNo.=1, GunOpen[mm]=100, '...')` |
+| Rivet | Rivet | `CALL MI13_RVH(Rivet, RivetNo.=1, NextRivetNo.=1, GunNo.=1, GunOpen[mm]=100, '...')` |
+| Positioning | Open rivet gun | `CALL MI13_RVH(Positioning, GunNo.=1, GunOpen[mm]=100, GunOpenCtrl, '...')` |
+| PrepareDock | Magazine pre/post | `CALL MI13_RVH(PrepareDock, GunNo.=1, ActivateON/OFF, '...')` |
+| LoadEPF | Load rivets | `CALL MI13_RVH(LoadEPF, GunNo.=1, '...')` |
+| GunState | Gun connect control | `CALL MI13_RVH(GunState, GunNo.=1, Couple/Decouple, '...')` |
+
+### MI14_SPR — SPR Riveting (New Tucker)
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Init | Initialize | `CALL MI14_SPR(Init, GunNo.=1, GunOpen[mm]=100, '...')` |
+| Rivet | Rivet | `CALL MI14_SPR(Rivet, GunNo.=1, RivetNo.=1, NextRivetNo.=1, GunOpen[mm]=100, '...')` |
+| Reload | Load rivets | `CALL MI14_SPR(Reload, GunNo.=1, RivetNo.=1, '...')` |
+| Docking | Gun connect | `CALL MI14_SPR(Docking, GunNo.=1, Connect/Disconnect, '...')` |
+| Magazine | Magazine control | `CALL MI14_SPR(Magazine, GunNo.=1, Preparation/ReadyToFill/PostProcessing, '...')` |
+| SendBSNNNum | Send body code | `CALL MI14_SPR(SendBSNNNum, GunNo.=1, '...')` |
+
+### MI15_SPR — SPR Riveting (Guji)
+
+Instructions: Init, Rivet, Positioning, GunState, Prepare, FillMag, Reload, SendBSNNNum, DieCheck
+
+### MI17_OBJ — Vision Detection
+
+```fanuc
+CALL MI17_OBJ(SendBSNNNum, '...')
+```
+DO[172] sends 5s pulse.
+
+### MI19_CLI — Press Riveting
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| INIT | Initialize | `CALL MI19_CLI(INIT, '...')` |
+| LOAD | Pre-feed rivet | `CALL MI19_CLI(LOAD, Check/NoCheck, '...')` |
+| TOX_Start | Start press program | `CALL MI19_CLI(TOX_Start, ProgNum=1, '...')` |
+| TOX_End | Close press program | `CALL MI19_CLI(TOX_End, '...')` |
+
+Mode: `servo` (default) or `hydraulic`
+
+### MI20_SWH — Stud Welding (Old Tucker)
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Init | Initialize | `CALL MI20_SWH(Init, '...')` |
+| Start | Stud weld | `CALL MI20_SWH(Start, HeadNo=1, StudID='1', '...')` |
+| SendBSNNNum | Send body code | `CALL MI20_SWH(SendBSNNNum, '...')` |
+
+StudID: string format, range 1-134217728, default 1.
+Gun Type: Single or Double.
+
+### MI21_SWH — Stud Welding (New Tucker)
+
+Similar to MI20, but StudID range 1-999999999. Additional timeout parameters:
+- System Ready Timeout
+- Process Complete Timeout
+- Fault Timeout
+- Head Back Timeout
+- Weld Inside Tol Timeout
+
+### MI22_FDS — Flow Drill Screwing
+
+| Instruction | Function | Format |
+|-------------|----------|--------|
+| Init | Initialize | `CALL MI22_FDS(Init, GunNo.=1, '...')` |
+| Drill | FDS process | `CALL MI22_FDS(Drill, PointNo.=1, TypeID=1, GunNo.=1, '...')` |
+| PrepareScrew | Prepare screw | `CALL MI22_FDS(PrepareScrew, GunNo.=1, PointNo.=1, TypeID=1, '...')` |
+| Adjust | Adjust | `CALL MI22_FDS(Adjust, GunNo.=1, '...')` |
+| GunState | Tool connect/disconnect | `CALL MI22_FDS(GunState, Couple/Decouple, GunNo.=1, '...')` |
+| EjectScrew | Eject screw | `CALL MI22_FDS(EjectScrew, GunNo.=1, '...')` |
+| FeedScrew | Feed screw | `CALL MI22_FDS(FeedScrew, GunNo.=1, '...')` |
+
+### Diagnostic Alarm Display
+
+When WAIT DI/GI conditions are not met, the system jumps to user screen showing:
+```
+MI01|collision zone return collision zone[1] is occupied
+WAITING FOR: DI[89] = ON; (Zone Ready 1)
+```
+
+## Verification
+
+1. Call MI01_CMN Init in a test program — verify signals reset correctly
+2. Call MI01_CMN CollZone Request/Release — verify DI signals toggle
+3. Call MI04_SSW Weld — verify spot weld sequence executes
+4. Call MI08_DSP Glue_Start/End — verify glue sequence executes
+5. Check MI GUI config screens exist for each module
+
+## Notes
+
+- MI standard software requires specific options installed on the controller
+- MI01_CMN background program starts automatically with robot power-on
+- Collision zone numbers (1-32) are shared across all robots in the system
+- Tip dress compensation uses GI[121] × scale factor — verify GI[121] is updated by weld controller
+- All MI instructions support trailing comment strings for debugging

--- a/lessons/contrib/fanuc-payload-estimation.md
+++ b/lessons/contrib/fanuc-payload-estimation.md
@@ -1,0 +1,102 @@
+---
+title: "FANUC Payload Estimation — Auto and Manual Load Configuration"
+domain: "fanuc"
+subdomain: "configuration"
+tags: ["payload", "load", "estimation", "tcp", "tool", "mass", "inertia", "center-of-gravity"]
+status: "published"
+source: "internal-training"
+confidence: "0.9"
+created: "2026-07-14"
+---
+
+## Problem
+
+FANUC robots require accurate payload (load) configuration for safe and precise motion. Incorrect payload settings cause poor motion accuracy, excessive motor load, and can trigger collisions or servo alarms. Engineers need to know how to estimate and configure payloads correctly.
+
+## Solution
+
+### Payload Parameters
+
+Each payload definition includes:
+- **Mass**: Weight of end effector + workpiece (kg)
+- **Center of gravity**: Position relative to flange (X, Y, Z in mm)
+- **Inertia**: Rotational inertia tensor (Ix, Iy, Iz in kg·m²)
+
+### Auto Estimation
+
+The controller can automatically estimate payload parameters by executing predefined motions:
+
+```
+SETUP → Payload Estimation → Select estimation method → Execute → Save results
+```
+
+Steps:
+1. Install end effector on robot
+2. Navigate to payload estimation function
+3. Select estimation method (typically 4-point or 6-point)
+4. Robot executes calibration motions
+5. System calculates mass, COG, and inertia
+6. Review and save results
+
+### Manual Configuration
+
+When payload parameters are already known:
+
+```
+MENU → Setup → Frames → Payload → Select payload number → Enter parameters
+```
+
+### PAYLOAD Command in Programs
+
+Set payload in TP programs using the PAYLOAD instruction:
+
+```fanuc
+! Set payload 1 (e.g., weld gun) ;
+PAYLOAD[1:WeldGun] ;
+
+! Set payload 3 (e.g., gripper) ;
+PAYLOAD[3:Gripper] ;
+```
+
+### PAYLOAD Numbering Rules
+
+- Number payloads sequentially by process order (small to large)
+- PAYLOAD[n] should match UTOOL_NUM value
+- Each process program must have a PAYLOAD declaration
+- Special case: Tool change uses PAYLOAD[10] with UTOOL_NUM=29
+
+### PAYLOAD-UTOOL Correspondence
+
+| Configuration | Rule |
+|---------------|------|
+| PAYLOAD[n] | Load identifier, n = number |
+| UTOOL_NUM | Tool coordinate number |
+| Relationship | PAYLOAD[n] number n should match UTOOL_NUM value |
+
+Examples:
+- SPR process: `PAYLOAD[1:SPR_01]` + `UTOOL_NUM=1` ✓
+- Tool change: `PAYLOAD[10:TOOL CHANGE]` + `UTOOL_NUM=29` ✓
+
+### When to Re-estimate
+
+- New project commissioning
+- End effector modification or replacement
+- Workpiece weight changes significantly
+- After collision or impact event
+- Collision detection sensitivity issues
+
+## Verification
+
+1. Check payload mass matches physical measurement (±10%)
+2. Verify COG position is reasonable for the tool geometry
+3. Run robot at low speed (10%) with new payload — no excessive vibration
+4. Check motor current is within normal range during motion
+5. Verify collision detection works correctly with new payload
+
+## Notes
+
+- Payload estimation affects collision detection sensitivity — always re-calibrate after changes
+- Inertia estimation is critical for high-speed applications
+- For tools with variable payload (e.g., carrying different workpieces), use the maximum expected payload
+- The robot must be in a safe position during estimation — clear the work area
+- Payload settings are stored per-controller, not per-program

--- a/lessons/contrib/fanuc-program-inspection-methodology.md
+++ b/lessons/contrib/fanuc-program-inspection-methodology.md
@@ -1,0 +1,139 @@
+---
+title: "FANUC Robot Program Inspection Methodology — Systematic Check Guide"
+domain: "fanuc"
+subdomain: "quality"
+tags: ["inspection", "checklist", "program-review", "signal-check", "collision-zone", "fine-point", "quality"]
+status: "published"
+source: "internal-training"
+confidence: "0.9"
+created: "2026-07-14"
+---
+
+## Problem
+
+Robot programs need systematic inspection before production to catch signal mapping errors, safety violations, and logic bugs. Without a structured methodology, inspectors miss critical issues or check inconsistently across different robots.
+
+## Solution
+
+### Inspection Categories
+
+#### 1. Signal Check (All Robots)
+
+Verify all DI/DO/GI/GO signals against the configuration standard:
+
+```
+Signal ranges:
+  DIDO-PLC:        1-512        (PLC communication)
+  DIDO-Connection:  513-2648     (ISV vision, etc.)
+  DIDO-Tool:        2649-4096    (end effector tools)
+```
+
+For each signal:
+- Verify signal number matches configuration standard
+- Verify signal name matches function
+- Flag undefined signals with suggested purpose
+
+#### 2. Collision Zone FINE Point Check
+
+**Critical safety check**: The motion command BEFORE releasing a collision zone must use FINE positioning (not CNT).
+
+Search pattern:
+```
+Search: "CollZone Release" or "CollZone, Release"
+For each match:
+  → Find the last motion command BEFORE the release
+  → Verify it uses FINE (not CNT50, CNT100, etc.)
+```
+
+Entering a collision zone (Request) does NOT require FINE — only exiting (Release) does.
+
+#### 3. Program Logic Check
+
+**Initialization sequence:**
+- TIMER_START present at program start
+- MI01_CMN Init call present
+- Proper HOME position setup
+
+**Decision Code handling:**
+- WAIT GI[5] present for decision code
+- SELECT logic for multi-path branching
+- All branches lead to valid programs
+
+**Tool change check:**
+- TIP_CHECK call present where needed
+- Tool change sequence correct (dock/undock pairs)
+
+**End sequence:**
+- MOVE_HOME at program end
+- TIMER_STOP at program end
+- Proper signal cleanup
+
+#### 4. Fixture Check
+
+```
+Search: "Fixture IN" → verify corresponding "Fixture OUT"
+For each fixture:
+  → IN/OUT must be paired
+  → IN before entering work area
+  → OUT after leaving work area
+```
+
+#### 5. Application-Specific Check
+
+**Spot welding:**
+- SPOT instruction parameters (SD/P/t/S/ED)
+- SPOT instruction must be at FINE point
+- Non-weld motions can use CNT
+
+**Gluing:**
+- Speed between SS[1] and SE ≤ 500mm/sec
+- SS[1] marker present at glue start
+- SE marker present at glue end
+- GO[22] parameter for glue switching
+
+**SPR (Self-Piercing Rivet):**
+- RivetNo./NextRivetNo./GunOpen parameters correct
+- MI14_SPR instruction at FINE point
+- Magazine refill signal DI[1180] checked
+
+### Inspection Report Template
+
+```markdown
+## Inspection Summary
+| Category | Items | Passed | Rate |
+|----------|-------|--------|------|
+| Signal Check | X | X | X% |
+| Collision Zone FINE | X | X | X% |
+| Application Check | X | X | X% |
+| Program Logic | X | X | X% |
+| **Total** | **X** | **X** | **X%** |
+
+## Issues Found
+| # | Issue | Location | Severity |
+|---|-------|----------|----------|
+| 1 | ... | Line XX | Low/Med/High |
+```
+
+### Program Naming Convention
+
+```
+Connection: RobotID_CarModel_ProcessOrder_Process_WorkStation
+Example: UB030R01_MS11_01_PICK_JR1
+
+Action: RobotID_ToolID_Process_ToolID
+Example: UB030R01_MS11_01_WELD_JR1
+```
+
+## Verification
+
+1. Run signal check on a known-good program — should pass 100%
+2. Intentionally change a FINE to CNT before CollZone Release — should be caught
+3. Remove a Fixture OUT call — should be flagged as missing pair
+4. Run full inspection on a new program — verify all categories checked
+
+## Notes
+
+- Always check collision zone FINE points first — this is the most common safety issue
+- Signal definitions change between projects — always use the current configuration standard
+- Program logic checks should be automated where possible (HTML checker tool)
+- Inspection results should be documented for traceability

--- a/lessons/contrib/fanuc-tcp-tool-configuration-standards.md
+++ b/lessons/contrib/fanuc-tcp-tool-configuration-standards.md
@@ -1,0 +1,143 @@
+---
+title: "FANUC TCP and Tool Configuration — Standards for Automotive Applications"
+domain: "fanuc"
+subdomain: "configuration"
+tags: ["tcp", "tool", "utool", "uframe", "payload", "coordinate", "automotive", "welding", "gluing", "riveting"]
+status: "published"
+source: "internal-training"
+confidence: "0.9"
+created: "2026-07-14"
+---
+
+## Problem
+
+In automotive robot applications, TCP (Tool Center Point) and tool configuration must follow specific standards for each process type (spot welding, gluing, SPR, etc.). Incorrect TCP direction or tool numbering causes program errors, quality issues, and safety problems.
+
+## Solution
+
+### TCP Calibration Method
+
+- **Handheld tools**: 6-point TCP with ZX measurement method
+  - Rotation amplitude > 90°
+  - Traverse distance > 50mm
+- **Fixed tools** (fixed gluing, floor welding): Use RTCP (Remote TCP)
+- **TCP direction**: Right-hand rule convention
+
+### TCP Position by Process
+
+| Process | TCP Position |
+|---------|--------------|
+| Spot welding | Servo gun static arm tip |
+| SPR riveting | Static arm tip |
+| Gluing | Glue nozzle tip (Z offset = nozzle diameter × 1.5) |
+| Material handling | Fixture locating pin |
+| Stud welding | Spiral surface center |
+| Laser brazing | Laser focal point |
+| Hemming | Roll wheel lowest point (Z+ toward part, X+ along rolling direction) |
+
+### TCP Direction Standards
+
+**Spot welding gun (both handheld and fixed):**
+- Z+: Static arm → moving arm direction (gun open/close direction)
+- X+: Along gun axis (from gun root → static arm tip)
+- Handheld and fixed gun TCP directions are IDENTICAL
+
+**Hemming tool:**
+- Z+: Toward part (pressure direction)
+- X+: Along rolling direction
+
+**Stud welding tool:**
+- Z+: Along stud axis direction
+
+**Laser brazing:**
+- Z+: Along laser beam direction
+
+**Gluing nozzle:**
+- Z+: Along nozzle axis direction
+
+**External/remote tool (floor-mounted):**
+- Same direction convention as handheld tools
+- Z+ toward part, X+ forward
+
+### RTCP (Remote TCP) Toggle
+
+For floor-mounted tools (spot welding machines, glue nozzles, spindles):
+```
+FUNCTION menu → TOGGLE REMOTE TOOL
+```
+
+### UTOOL/UFRAME/PAYLOAD Numbering
+
+- Number by process order: small to large
+- Each fixture must have its own base frame / user frame
+- Set in operational sequence
+- Rack base frame origin: on tower rack locating pin
+- XY plane same as pad plane, X+ toward rack interior, Z+ up
+
+### Tool Coordinate Setup
+
+**3-point TCP calibration:**
+1. Select 3 different orientations pointing to same point
+2. Controller calculates TCP position
+3. UTOOL_NUM=1 selects tool number
+
+**6-point TCP calibration (with orientation):**
+1. 3 points define TCP position
+2. 3 points define tool direction (X/Z axes)
+
+**Direct input:**
+```
+MENU → Setup → Frames → Tool Frame → Enter X, Y, Z, W, P, R offsets
+```
+
+### User Frame Setup
+
+**3-point method:**
+1. Origin point
+2. X direction point
+3. Y direction point (doesn't need to be exactly on Y axis)
+
+**4-point method:**
+1. Origin
+2. X direction
+3. Y direction
+4. Z direction (more precise)
+
+### System Variables
+
+| Variable | Description |
+|----------|-------------|
+| $MNUTOOL[1,i] | Tool coordinate data (i=1-10) |
+| $MNUTOOLNUM[group] | Current tool number |
+| $MNUFRAME[1,i] | User coordinate data (i=1-9) |
+| $MNUFRAMENUM[1] | Current user frame number |
+| $USE_UFRAME | Whether user frame is active |
+
+### In-Program Tool/Frame Selection
+
+```fanuc
+UTOOL_NUM=1          ! Select tool 1
+UTOOL_NUM=R[1]       ! Indirect selection via register
+UFRAME_NUM=1         ! Select user frame 1
+UFRAME_NUM=R[1]      ! Indirect selection via register
+```
+
+### Coordinate System Switch (Manual Jog)
+
+Press COORD key to cycle: JOINT → JGFRM → WORLD → TOOL → USER
+
+## Verification
+
+1. Verify TCP position matches expected tool geometry
+2. Verify TCP direction follows right-hand rule for the process type
+3. Run robot at 10% speed with new TCP — verify motion is correct
+4. Verify UTOOL_NUM matches PAYLOAD number in program
+5. Verify user frame origin is on fixture locating pin
+
+## Notes
+
+- TCP direction for fixed welding guns is the SAME as handheld — this is a common mistake
+- RTCP must be disabled for non-motion applications
+- Never use Base[0]/UFrame[0] for fixtures
+- Process points (FDS, appearance welds, SPR, etc.) must use FINE positioning
+- Glue nozzle Z offset is typically nozzle diameter × 1.5


### PR DESCRIPTION
## Summary

Add 7 new FANUC robot lessons extracted from internal training materials, covering essential topics for automotive robot programming and maintenance.

## New Lessons

| Lesson | Topic | Size |
|--------|-------|------|
| fanuc-backup-restore-guide | Full backup, mirror backup, auto backup, file restore | 4KB |
| fanuc-payload-estimation | Auto/manual load configuration | 3KB |
| fanuc-program-inspection-methodology | Systematic program check guide | 4KB |
| fanuc-alarm-severity-guide | Alarm severity levels and color codes | 4KB |
| fanuc-dcs-safety-configuration | DCS safety system and stop modes | 4KB |
| fanuc-mi-standard-software-instructions | MI standard software MI01-MI22 reference | 9KB |
| fanuc-tcp-tool-configuration-standards | TCP and tool configuration standards | 4KB |

## Processing

- Deduplication: Compared against existing ~20 FANUC lessons — no overlap
- Desensitization: Removed company names, internal links, internal paths
- Generalization: Converted to general FANUC industrial robot guides