### PR TITLE
feat: define trust_tiers config and dynamically load it in registration

### DIFF
--- a/misaka-protocol.json
+++ b/misaka-protocol.json
@@ -57,6 +57,33 @@
     }
   },
 
+  "trust_tiers": {
+    "github-verified": {
+      "method": "github",
+      "trust_level": "verified",
+      "requires_verification": false,
+      "badge_display": "github-verified"
+    },
+    "mail-verified": {
+      "method": "email",
+      "trust_level": "unverified",
+      "requires_verification": true,
+      "badge_display": "mail-verified"
+    },
+    "web-verified": {
+      "method": "web",
+      "trust_level": "unverified",
+      "requires_verification": true,
+      "badge_display": "web-verified"
+    },
+    "anonymous": {
+      "method": "none",
+      "trust_level": "unverified",
+      "requires_verification": false,
+      "badge_display": "anonymous"
+    }
+  },
+
   "dco": {
     "enabled": true,
     "required_for": ["ring-1", "ring-2"],

--- a/workers/email-register/src/index.js
+++ b/workers/email-register/src/index.js
@@ -9,6 +9,9 @@
  *   3. 临时邮箱域名黑名单
  */
 
+// ── 协议配置 ──
+import protocol from '../../../misaka-protocol.json';
+
 // ── 临时邮箱域名黑名单（top 30） ──
 const TEMP_EMAIL_DOMAINS = new Set([
   'mailinator.com', 'guerrillamail.com', '10minutemail.com',
@@ -88,10 +91,13 @@ export default {
       const nextNum = (parseInt(counter) || 10052) + 1;
       const nodeId = `Misaka${String(nextNum).padStart(5, '0')}`;
       await env.MISAKANET_KV.put('node_counter', String(nextNum));
+      const emailTier = Object.keys(protocol.trust_tiers || {}).find(
+        k => protocol.trust_tiers[k].method === 'email'
+      ) || 'mail-verified';
       await env.MISAKANET_KV.put(`node:${nodeId}`, JSON.stringify({
         nodeId, email: sender,
         registeredAt: receivedAt,
-        source: 'email', trustLevel: 'mail-verified',
+        source: 'email', trustLevel: emailTier,
         intakeId,
       }));
       console.log(`Registered via email: ${nodeId} <${sender}>`);
@@ -168,10 +174,13 @@ export default {
       const nextNum = (parseInt(counter) || 10052) + 1;
       const nodeId = `Misaka${String(nextNum).padStart(5, '0')}`;
       await env.MISAKANET_KV.put('node_counter', String(nextNum));
+      const webTier = Object.keys(protocol.trust_tiers || {}).find(
+        k => protocol.trust_tiers[k].method === 'web'
+      ) || 'web-verified';
       await env.MISAKANET_KV.put(`node:${nodeId}`, JSON.stringify({
         nodeId, email, name,
         registeredAt: new Date().toISOString(),
-        source: 'web', trustLevel: 'web-verified'
+        source: 'web', trustLevel: webTier
       }));
 
       return new Response(renderPage('success', { nodeId, email, name }), {


### PR DESCRIPTION
This PR implements dynamic trust tiers for the registration flow:
1. Added a `trust_tiers` section to `misaka-protocol.json` which defines `github-verified`, `mail-verified`, `web-verified`, and `anonymous` tiers.
2. Refactored `workers/email-register/src/index.js` to import the protocol config and dynamically query/resolve the corresponding trust tier based on the registration method (`email` or `web`).

This replaces the previous hardcoded string assignments (`mail-verified` and `web-verified`) with dynamic configurations loaded from the protocol schema.