### PR TITLE
fix: sync lesson count across STATUS.md, README, and frontend (#298)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 <p align="center">
   <a href="https://github.com/Ikalus1988/MisakaNet/stargazers"><img src="https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social" alt="Stars"/></a>
   <a href="https://img.shields.io/badge/nodes-52+-green"><img src="https://img.shields.io/badge/nodes-52+-green?label=Nodes" alt="Nodes"/></a>
-  <a href="https://img.shields.io/badge/lessons-205+-blue"><img src="https://img.shields.io/badge/lessons-205+-blue?label=Lessons" alt="Lessons"/></a>
+  <a href="https://img.shields.io/badge/lessons-207+-blue"><img src="https://img.shields.io/badge/lessons-207+-blue?label=Lessons" alt="Lessons"/></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Ikalus1988/MisakaNet?style=flat&color=blueviolet" alt="License"/></a>
 </p>
 
 ---
 
-> **Give Cursor / Claude access to 205+ verified failure lessons.**
+> **Give Cursor / Claude access to 207+ verified failure lessons.**
 > Clone → paste MCP config → ask "Search MisakaNet for DCO sign-off failure".
 > [3-step MCP quickstart →](docs/mcp-quickstart.md)
 
@@ -34,7 +34,7 @@
 | **Best for** | DCO failures, GitHub token errors, pip timeout, Feishu API, WSL, FANUC |
 | **Not for** | Private memory storage, hosted vector database, general chatbot memory |
 | **License** | Apache 2.0 |
-| **Data** | 205 lessons, 52+ nodes, 18 domains |
+| **Data** | 207 lessons, 52+ nodes, 18 domains |
 
 ---
 
@@ -84,7 +84,7 @@ The MisakaNet ecosystem is built as a **layered defense & knowledge stack**:
 │  (npm, zero-config)          │  → feeds draft lesson pipeline     │
 ├──────────────────────────────────────────────────────────────────┤
 │  🧠 MisakaNet (this repo)    │  Swarm Knowledge Protocol (SKP)    │
-│  $ python3 search_know-      │  205+ lessons, BM25 + RRF          │
+│  $ python3 search_know-      │  207+ lessons, BM25 + RRF          │
 │     ledge.py "<error>"       │  git clone → search → contribute   │
 │  (zero-dep core engine)      │  Zero server, zero database        │
 ├──────────────────────────────────────────────────────────────────┤
@@ -212,7 +212,7 @@ python3 search_knowledge.py "pip install timeout"
 
 ### Use in Cursor / Claude Desktop / Claude Code
 
-Give your AI assistant access to 205+ verified failure lessons via MCP:
+Give your AI assistant access to 207+ verified failure lessons via MCP:
 
 ```json
 {
@@ -271,7 +271,7 @@ python3 scripts/lesson_reuse_bench.py --compare         # with vs without lesson
 
 | Metric | Value |
 |--------|-------|
-| Shared Lessons | 200+ |
+| Shared Lessons | 207+ |
 | Registered Nodes | 35+ |
 | Agent Types | CodeWhale, Claude, Codex, OpenClaw, OpenCode |
 | npm packages | [`@misaka-net/fatal-guard`](https://www.npmjs.com/package/@misaka-net/fatal-guard) |

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,7 +6,7 @@
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 205 篇 |
+| 📚 Lessons | 207 篇 |
 | 📖 References | 6 篇 |
 | 🏛️ 领域覆盖 | 18 个 |
 | 🎤 Network Voices | 5 条 |

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="MisakaNet — Git-backed, zero-dependency failure lesson network for AI agents. 205+ curated lessons, GitHub-audited, searchable.">
+<meta name="description" content="MisakaNet — Git-backed, zero-dependency failure lesson network for AI agents. 207+ curated lessons, GitHub-audited, searchable.">
 <meta name="keywords" content="AI Agent, MisakaNet, failure lessons, debugging, knowledge base, zero-dependency, GitHub-audited">
 <link rel="canonical" href="https://misakanet.org/">
 <meta property="og:title" content="MisakaNet — Failure Lesson Network for AI Agents">
-<meta property="og:description" content="Git-backed, zero-dependency failure lesson network. 205+ curated lessons from real AI agent debugging sessions.">
+<meta property="og:description" content="Git-backed, zero-dependency failure lesson network. 207+ curated lessons from real AI agent debugging sessions.">
 <meta property="og:image" content="https://raw.githubusercontent.com/Ikalus1988/MisakaNet/main/promotional/og-card.png">
 <meta property="og:url" content="https://misakanet.org/">
 <meta name="twitter:card" content="summary_large_image">
@@ -1695,7 +1695,7 @@
     <div style="text-align:center;margin-bottom:12px;">
       <div style="font-size:17px;font-weight:700;color:var(--text-main);margin-bottom:4px;" data-i18n="searchPanelTitle">Search verified failure lessons</div>
       <div style="font-size:12px;color:var(--text-dim);" data-i18n="searchPanelSubtitle">Find fixes from real AI agent debugging sessions.</div>
-      <div id="lesson-count-search" style="font-size:11px;color:var(--text-dim);margin-top:4px;">198 curated lessons · GitHub-audited · no database</div>
+      <div id="lesson-count-search" style="font-size:11px;color:var(--text-dim);margin-top:4px;">207 curated lessons · GitHub-audited · no database</div>
     </div>
     <div style="position:relative;max-width:680px;margin:0 auto;">
       <div class="home-search-box" style="position:relative;background:rgba(4,10,24,0.86);border:1px solid rgba(0,229,255,0.30);border-radius:14px;transition:border-color 0.25s ease,box-shadow 0.25s ease;">
@@ -1804,7 +1804,7 @@
         <span style="background:var(--cyan);color:var(--bg-deep);font-size:11px;font-weight:700;padding:3px 10px;border-radius:12px;letter-spacing:0.5px;">v2.8.0</span>
         <span style="color:var(--text-dim);font-size:13px;">2026-07-02</span>
       </div>
-      <h3 style="font-size:18px;font-weight:700;margin-bottom:12px;color:var(--text-primary);">Zero-Bounty Open Source: 60 Days, <span id="lesson-count-hero">200+</span> Lessons, $0 Spent</h3>
+      <h3 style="font-size:18px;font-weight:700;margin-bottom:12px;color:var(--text-primary);">Zero-Bounty Open Source: 60 Days, <span id="lesson-count-hero">207+</span> Lessons, $0 Spent</h3>
       <p style="color:var(--text-dim);font-size:14px;line-height:1.7;margin-bottom:16px;">
         MisakaNet is a <strong style="color:var(--cyan);">Swarm Knowledge Protocol</strong> — when one AI agent hits a bug, it documents the workaround, and all agents skip that failure path.
         No server. No database. Just <code style="background:rgba(0,229,255,0.1);padding:2px 6px;border-radius:4px;font-size:13px;">git clone</code> + <code style="background:rgba(0,229,255,0.1);padding:2px 6px;border-radius:4px;font-size:13px;">python3 search_knowledge.py</code>.
@@ -1849,7 +1849,7 @@
         <div style="background:rgba(0,229,255,0.03);border:1px solid var(--border-glow);border-radius:8px;padding:14px;">
           <div style="font-size:13px;font-weight:700;color:var(--cyan);margin-bottom:4px;">MisakaNet</div>
           <div style="font-size:11px;color:var(--text-dim);margin-bottom:8px;">Python · git-native</div>
-          <div style="font-size:12px;color:var(--text-primary);line-height:1.5;">SKP reference impl. BM25 + RRF search across <span id="lesson-count-product">200+</span> lessons.</div>
+          <div style="font-size:12px;color:var(--text-primary);line-height:1.5;">SKP reference impl. BM25 + RRF search across <span id="lesson-count-product">207+</span> lessons.</div>
           <code style="font-size:11px;color:var(--cyan);background:rgba(0,229,255,0.08);padding:2px 6px;border-radius:3px;">pip install misakanet-core</code>
         </div>
         <div style="background:rgba(0,229,255,0.03);border:1px solid var(--border-glow);border-radius:8px;padding:14px;">

--- a/scripts/sync_lesson_count.py
+++ b/scripts/sync_lesson_count.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Sync lesson count across all project files using data/lessons.json as the single source of truth.
+
+Usage:
+    python3 scripts/sync_lesson_count.py              # sync all files
+    python3 scripts/sync_lesson_count.py --check      # check only, exit 1 if mismatch
+    python3 scripts/sync_lesson_count.py --quiet      # sync silently
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LESSONS_JSON = REPO / "data" / "lessons.json"
+STATUS_MD = REPO / "STATUS.md"
+README_MD = REPO / "README.md"
+FRONTEND_HTML = REPO / "docs" / "index.html"
+
+
+def get_lesson_count() -> int:
+    """Read lesson count from the single source of truth: data/lessons.json."""
+    with open(LESSONS_JSON, "r", encoding="utf-8") as f:
+        lessons = json.load(f)
+    return len(lessons)
+
+
+def sync_status_md(count: int, dry_run: bool = False) -> list[str]:
+    """Sync lesson count in STATUS.md."""
+    changes = []
+    text = STATUS_MD.read_text(encoding="utf-8")
+    # Pattern: | 📚 Lessons | XXX 篇 |
+    pattern = r"(\| 📚 Lessons \|\s*)\d+(\s*篇\s*\|)"
+    replacement = rf"\g<1>{count}\2"
+    if re.search(pattern, text):
+        new_text = re.sub(pattern, replacement, text)
+        if new_text != text:
+            changes.append(f"STATUS.md: lesson count updated to {count}")
+            if not dry_run:
+                STATUS_MD.write_text(new_text, encoding="utf-8")
+    return changes
+
+
+def sync_readme_md(count: int, dry_run: bool = False) -> list[str]:
+    """Sync lesson count in README.md (badges, descriptions, tables)."""
+    changes = []
+    text = README_MD.read_text(encoding="utf-8")
+    old_text = text
+
+    # Replace standalone digit counts followed by + or space or end-of-word
+    # Match patterns like "205+", "205 ", "205 lessons"
+    replacements = [
+        (r"\b\d{2,3}\+", f"{count}+"),
+        (r"(\|\s*\*\*Data\*\*\s*\|\s*)\d{2,3}\s+lessons", rf"\g<1>{count} lessons"),
+        (r"(Give Cursor / Claude access to )\d{2,3}\+ verified", rf"\g<1>{count}+ verified"),
+    ]
+
+    for pattern, replacement in replacements:
+        new_text = re.sub(pattern, replacement, text)
+        if new_text != text:
+            changes.append(f"README.md: matched pattern '{pattern}'")
+            text = new_text
+
+    if text != old_text:
+        if not dry_run:
+            README_MD.write_text(text, encoding="utf-8")
+    return changes
+
+
+def sync_frontend_html(count: int, dry_run: bool = False) -> list[str]:
+    """Sync hardcoded lesson count fallbacks in docs/index.html.
+
+    Note: The JS dynamically fetches from /data/lessons.json at runtime,
+    so runtime values are always correct. This syncs the static HTML fallbacks
+    for when JS is disabled or hasn't loaded yet.
+    """
+    changes = []
+    text = FRONTEND_HTML.read_text(encoding="utf-8")
+    old_text = text
+
+    # Search panel fallback: "198 curated lessons"
+    text = re.sub(
+        r'(\b\d{2,3}\s+curated lessons)',
+        f'{count} curated lessons',
+        text,
+    )
+
+    # Hero section span: "<span id="lesson-count-hero">200+</span>"
+    text = re.sub(
+        r'(<span id="lesson-count-hero">)\d{2,3}\+(</span>)',
+        rf'\g<1>{count}+\g<2>',
+        text,
+    )
+
+    # Product section span: "<span id="lesson-count-product">200+</span>"
+    text = re.sub(
+        r'(<span id="lesson-count-product">)\d{2,3}\+(</span>)',
+        rf'\g<1>{count}+\g<2>',
+        text,
+    )
+
+    # Meta description: "205+ curated lessons"
+    text = re.sub(
+        r'(\b\d{2,3}\+\s+curated lessons)',
+        f'{count}+ curated lessons',
+        text,
+    )
+
+    if text != old_text:
+        changes.append(f"docs/index.html: hardcoded fallbacks updated to {count}")
+        if not dry_run:
+            FRONTEND_HTML.write_text(text, encoding="utf-8")
+    return changes
+
+
+def check_count_in_files(count: int) -> tuple[list[str], bool]:
+    """Check all files for stale lesson counts. Returns (issues, is_clean)."""
+    issues = []
+
+    # STATUS.md
+    text = STATUS_MD.read_text(encoding="utf-8")
+    if re.search(r'\|\s*📚\s*Lessons\s*\|\s*\d+\s*篇\s*\|', text):
+        m = re.search(r'\|\s*📚\s*Lessons\s*\|\s*(\d+)\s*篇\s*\|', text)
+        if m and int(m.group(1)) != count:
+            issues.append(f"STATUS.md has lesson count {m.group(1)}, expected {count}")
+
+    # README.md — look for lesson-count-specific patterns, not PR numbers
+    text = README_MD.read_text(encoding="utf-8")
+    # Match patterns like "205+", "200+", "205 lessons" — but ignore "#NNN" (PR refs)
+    lesson_ref_patterns = [
+        r"\b\d{2,3}\+\s*(?:verified)?\s*lessons?",
+        r"\b\d{2,3}\+\s*curated",
+        r"\|\s*\*\*Data\*\*\s*\|\s*\d{2,3}\s+lessons",
+        r"\|\s*Shared Lessons\s*\|\s*\d{2,3}\+",
+    ]
+    for pattern in lesson_ref_patterns:
+        m = re.search(pattern, text, re.IGNORECASE)
+        if m:
+            digits = re.findall(r"\d+", m.group())
+            for d in digits:
+                if int(d) < count:
+                    issues.append(f"README.md has stale lesson count reference: '{m.group()}'")
+
+    # Frontend HTML
+    text = FRONTEND_HTML.read_text(encoding="utf-8")
+    m = re.search(r'(\d{2,3})\s+curated lessons', text)
+    if m and int(m.group(1)) != count:
+        issues.append(f"docs/index.html search panel has {m.group(1)}, expected {count}")
+
+    return issues, len(issues) == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sync lesson count across project files")
+    parser.add_argument("--check", action="store_true", help="Check only, exit 1 if mismatch")
+    parser.add_argument("--quiet", action="store_true", help="Silent mode (no output on success)")
+    args = parser.parse_args()
+
+    count = get_lesson_count()
+    all_changes = []
+
+    if args.check:
+        issues, is_clean = check_count_in_files(count)
+        if is_clean:
+            if not args.quiet:
+                print(f"✅ All files consistent: lesson count = {count}")
+            sys.exit(0)
+        else:
+            print(f"❌ Mismatch detected (expected {count}):", file=sys.stderr)
+            for issue in issues:
+                print(f"  - {issue}", file=sys.stderr)
+            sys.exit(1)
+
+    all_changes += sync_status_md(count)
+    all_changes += sync_readme_md(count)
+    all_changes += sync_frontend_html(count)
+
+    if all_changes:
+        print(f"✅ Synced lesson count to {count}:")
+        for change in all_changes:
+            print(f"  - {change}")
+    elif not args.quiet:
+        print(f"✅ Already consistent: lesson count = {count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fix inconsistent lesson count across the project. Single source of truth is `data/lessons.json` (length = **207**).

## Changes

| File | Before | After |
|------|--------|-------|
| `STATUS.md` | 205 篇 | 207 篇 |
| `README.md` badge | lessons-205+ | lessons-207+ |
| `README.md` descriptions | "205+ verified failure lessons" (×3) | "207+" |
| `README.md` stats table | "Shared Lessons: 200+" | "207+" |
| `README.md` product matrix | "205+ lessons" | "207+" |
| `docs/index.html` meta | "205+ curated lessons" | "207+" |
| `docs/index.html` search panel | "198 curated lessons" | "207 curated lessons" |
| `docs/index.html` hero | "200+" | "207+" |
| `docs/index.html` product | "200+" | "207+" |

## New script

Added `scripts/sync_lesson_count.py`:
- Reads lesson count from `data/lessons.json` (single source of truth)
- Syncs `STATUS.md`, `README.md`, `docs/index.html` in one command
- `--check` mode for CI: exits 1 if any file has stale count
- Python stdlib only (json, re, pathlib)

## Verification

```bash
python3 scripts/sync_lesson_count.py --check
# ✅ All files consistent: lesson count = 207
```

## Acceptance Criteria

- [x] Single source of truth for lesson count (`data/lessons.json` length)
- [x] STATUS.md updated
- [x] README badges updated
- [x] Frontend count matches
- [x] Script to auto-update counts (`scripts/sync_lesson_count.py`)

/claim #298