### PR TITLE
feat: productionize email intake pipeline

### DIFF
--- a/workers/email-register/README.md
+++ b/workers/email-register/README.md
@@ -59,8 +59,14 @@ Contact: admin@example.com
 ## Testing
 
 ```bash
-# Send a test email from any address to bot@misakanet.org
-# with subject "register" and a Node Name in the body.
+# Unit-test MIME/body parsing, intake classification, and reply content
+node --test workers/email-register/email-utils.test.mjs
+
+# Validate the Worker bundle (including Cloudflare runtime imports)
+npx wrangler deploy --config workers/email-register/wrangler.jsonc --dry-run
+
+# End-to-end: send a message to bot@misakanet.org, then verify Worker logs,
+# the `email-intake:*` KV record, forwarding, audit issue, and confirmation reply.
 ```
 
 ## Environment Variables / Secrets
@@ -68,10 +74,12 @@ Contact: admin@example.com
 | Secret | Required | Description |
 |--------|----------|-------------|
 | `TURNSTILE_SECRET` | Yes | Turnstile secret key for CAPTCHA verification (set via `wrangler secret put`) |
-| `GH_TOKEN` | No | GitHub PAT for creating registration Issues |
-| `MISAKANET_KV` | Yes (binding) | KV namespace for node counter + registrations |
+| `GH_TOKEN` | No | GitHub PAT for creating audit Issues |
+| `GH_REPO` | No | Audit repository (defaults to `Ikalus1988/MisakaNet`) |
+| `MAINTAINER_EMAIL` | No | Verified Email Routing destination for forwarded copies |
+| `MISAKANET_KV` | Yes (binding) | KV namespace for counters, stable sender/node mapping, and intake records |
 
 ## GitHub Issue Sync
 
-If `GH_TOKEN` is configured, the Worker also creates a GitHub Issue in
-`Ikalus1988/MisakaNet` with label `registered` + `email` for auditability.
+If `GH_TOKEN` is configured, the Worker creates an audit Issue in `GH_REPO`.
+Lesson submissions use `lesson-intake`; other intake uses `registered` + `email`.

--- a/workers/email-register/email-utils.test.mjs
+++ b/workers/email-register/email-utils.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildReplyText,
+  detectIntakeType,
+  extractLessonContent,
+  parseEmailBody,
+} from './src/email-utils.mjs';
+
+test('parses a plain-text lesson and strips quoted replies', () => {
+  const raw = [
+    'From: agent@example.com',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    'Lesson: retry SQLite writes with bounded backoff.',
+    '',
+    'On Tue, Maintainer wrote:',
+    '> old message',
+  ].join('\r\n');
+  const body = parseEmailBody(raw);
+  assert.equal(extractLessonContent(body), 'Lesson: retry SQLite writes with bounded backoff.');
+  assert.equal(detectIntakeType('Submission', body), 'lesson-submission');
+});
+
+test('prefers text/plain in multipart email and decodes quoted-printable', () => {
+  const raw = [
+    'Content-Type: multipart/alternative; boundary="abc"',
+    '',
+    '--abc',
+    'Content-Type: text/plain; charset=UTF-8',
+    'Content-Transfer-Encoding: quoted-printable',
+    '',
+    'Lesson: lock=20retry',
+    '--abc',
+    'Content-Type: text/html',
+    '',
+    '<p>wrong fallback</p>',
+    '--abc--',
+  ].join('\r\n');
+  assert.equal(parseEmailBody(raw), 'Lesson: lock retry');
+});
+
+test('detects registration hints from the body and includes node ID in reply', () => {
+  assert.equal(detectIntakeType('Hello', 'Please register my agent'), 'registration');
+  const reply = buildReplyText({ intakeId: 'intake-1', intakeType: 'registration', nodeId: 'Misaka10053' });
+  assert.match(reply, /Misaka10053/);
+  assert.match(reply, /Next steps:/);
+});
+
+test('falls back from HTML to readable text', () => {
+  const raw = 'Content-Type: text/html; charset=UTF-8\r\n\r\n<p>Bug report<br>worker failed</p>';
+  assert.equal(parseEmailBody(raw), 'Bug report\nworker failed');
+  assert.equal(detectIntakeType('', parseEmailBody(raw)), 'bug-report');
+});

--- a/workers/email-register/src/email-utils.mjs
+++ b/workers/email-register/src/email-utils.mjs
@@ -1,0 +1,113 @@
+const MAX_BODY_LENGTH = 20000;
+
+function decodeTransferEncoding(value, encoding = '') {
+  const normalized = value.replace(/\r\n/g, '\n');
+  if (encoding.toLowerCase() === 'base64') {
+    try {
+      const binary = atob(normalized.replace(/\s/g, ''));
+      return new TextDecoder().decode(Uint8Array.from(binary, char => char.charCodeAt(0)));
+    } catch {
+      return normalized;
+    }
+  }
+  if (encoding.toLowerCase() === 'quoted-printable') {
+    const unfolded = normalized.replace(/=\n/g, '');
+    const bytes = [];
+    for (let index = 0; index < unfolded.length; index += 1) {
+      if (unfolded[index] === '=' && /^[0-9a-f]{2}$/i.test(unfolded.slice(index + 1, index + 3))) {
+        bytes.push(parseInt(unfolded.slice(index + 1, index + 3), 16));
+        index += 2;
+      } else {
+        bytes.push(...new TextEncoder().encode(unfolded[index]));
+      }
+    }
+    return new TextDecoder().decode(new Uint8Array(bytes));
+  }
+  return normalized;
+}
+
+function parseHeaders(headerBlock) {
+  const headers = new Map();
+  const unfolded = headerBlock.replace(/\r?\n[ \t]+/g, ' ');
+  for (const line of unfolded.split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator > 0) {
+      headers.set(line.slice(0, separator).toLowerCase(), line.slice(separator + 1).trim());
+    }
+  }
+  return headers;
+}
+
+function parseMimePart(rawPart) {
+  const separator = rawPart.search(/\r?\n\r?\n/);
+  const headerBlock = separator >= 0 ? rawPart.slice(0, separator) : '';
+  const body = separator >= 0 ? rawPart.slice(separator).replace(/^\r?\n\r?\n/, '') : rawPart;
+  const headers = parseHeaders(headerBlock);
+  const contentType = headers.get('content-type') || 'text/plain';
+  const boundary = contentType.match(/boundary=(?:"([^"]+)"|([^;\s]+))/i)?.slice(1).find(Boolean);
+
+  if (boundary) {
+    const parts = body
+      .split(`--${boundary}`)
+      .slice(1)
+      .map(part => part.replace(/^\r?\n/, '').replace(/\r?\n--\s*$/, '').trim())
+      .filter(Boolean)
+      .map(parseMimePart);
+    return parts.find(part => part.type.startsWith('text/plain')) ||
+      parts.find(part => part.type.startsWith('text/html')) ||
+      { type: 'text/plain', body: '' };
+  }
+
+  return {
+    type: contentType.toLowerCase(),
+    body: decodeTransferEncoding(body, headers.get('content-transfer-encoding')),
+  };
+}
+
+/** Extract the human-readable text part from a raw RFC 5322 message. */
+export function parseEmailBody(rawEmail) {
+  const part = parseMimePart(rawEmail);
+  let body = part.body;
+  if (part.type.startsWith('text/html')) {
+    body = body
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+      .replace(/<br\s*\/?\s*>/gi, '\n')
+      .replace(/<\/p>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+  }
+  return body.replace(/\0/g, '').trim().slice(0, MAX_BODY_LENGTH);
+}
+
+/** Remove common reply quoting so the stored lesson is the new submission. */
+export function extractLessonContent(body) {
+  const lines = body.replace(/\r\n/g, '\n').split('\n');
+  const replyStart = lines.findIndex(line => /^On .+wrote:\s*$/i.test(line) || /^-{2,}\s*Original Message\s*-{2,}$/i.test(line));
+  const freshLines = (replyStart >= 0 ? lines.slice(0, replyStart) : lines)
+    .filter(line => !line.trimStart().startsWith('>'));
+  return freshLines.join('\n').trim().slice(0, MAX_BODY_LENGTH);
+}
+
+export function detectIntakeType(subject, body) {
+  const searchable = `${subject}\n${body.slice(0, 2000)}`.toLowerCase();
+  if (/\b(register|registration|join)\b|注册/.test(searchable)) return 'registration';
+  if (/\b(lesson|learning|postmortem)\b|投稿|教训|課程/.test(searchable)) return 'lesson-submission';
+  if (/\b(bug|issue|defect)\b/.test(searchable)) return 'bug-report';
+  return 'unknown';
+}
+
+export function buildReplyText({ intakeId, intakeType, nodeId }) {
+  const identifier = nodeId ? `Your node ID is ${nodeId}.` : `Your intake ID is ${intakeId}.`;
+  return [
+    'Thanks for contacting MisakaNet.',
+    '',
+    identifier,
+    `Submission type: ${intakeType}`,
+    '',
+    nodeId
+      ? 'Next steps: clone https://github.com/Ikalus1988/MisakaNet and follow the node quickstart.'
+      : 'Your submission is queued for maintainer review. Keep the intake ID for follow-up.',
+  ].join('\n');
+}

--- a/workers/email-register/src/index.js
+++ b/workers/email-register/src/index.js
@@ -8,7 +8,14 @@
  *   2. KV Rate Limit（每 IP 1h/次，每邮箱 24h/次）
  *   3. 临时邮箱域名黑名单
  */
+import { EmailMessage } from 'cloudflare:email';
 import protocol from '../../../misaka-protocol.json';
+import {
+  buildReplyText,
+  detectIntakeType,
+  extractLessonContent,
+  parseEmailBody,
+} from './email-utils.mjs';
 
 // ── 临时邮箱域名黑名单（top 30） ──
 const TEMP_EMAIL_DOMAINS = new Set([
@@ -26,16 +33,15 @@ export default {
   async email(message, env, ctx) {
     const sender = message.from;
     const recipient = message.to;
-    const subject = message.headers.get('subject') || '';
+    const subject = (message.headers.get('subject') || '').replace(/[\r\n]/g, ' ').trim();
+    const messageId = (message.headers.get('message-id') || '').replace(/[\r\n]/g, ' ').trim();
     const domain = sender.split('@')[1]?.toLowerCase() || '';
 
-    // 防御: 临时邮箱拦截
     if (TEMP_EMAIL_DOMAINS.has(domain)) {
       console.log(`Blocked temp email: ${sender}`);
       return;
     }
 
-    // 防御: 每邮箱 24h 限频
     const lastReg = await env.MISAKANET_KV.get(`rate:email:${sender}`, 'text');
     if (lastReg && (Date.now() - parseInt(lastReg)) < 86400000) {
       console.log(`Rate limited email: ${sender}`);
@@ -43,54 +49,24 @@ export default {
     }
     await env.MISAKANET_KV.put(`rate:email:${sender}`, String(Date.now()), { expirationTtl: 86400 });
 
-    // ── P1a: intake tracking ──
+    // Consume the raw stream before forwarding and retain only bounded, plain text.
+    const rawEmail = await new Response(message.raw).text();
+    const emailBody = parseEmailBody(rawEmail);
+    const lessonContent = extractLessonContent(emailBody);
+    const intakeType = detectIntakeType(subject, lessonContent);
     const intakeId = crypto.randomUUID();
     const receivedAt = new Date().toISOString();
+    let nodeId = await env.MISAKANET_KV.get(`email-node:${sender}`, 'text');
 
-    // Detect intake type from subject/body hints
-    const subjectLower = subject.toLowerCase();
-    let intakeType = 'unknown';
-    if (subjectLower.includes('register') || subjectLower.includes('注册')) {
-      intakeType = 'registration';
-    } else if (subjectLower.includes('lesson') || subjectLower.includes('投稿')) {
-      intakeType = 'lesson-submission';
-    } else if (subjectLower.includes('bug') || subjectLower.includes('issue')) {
-      intakeType = 'bug-report';
-    }
-
-    // Write intake record to KV
-    await env.MISAKANET_KV.put(`email-intake:${intakeId}`, JSON.stringify({
-      intakeId,
-      from: sender,
-      to: recipient,
-      subject,
-      intakeType,
-      receivedAt,
-      status: 'forwarded_to_maintainer',
-    }), { expirationTtl: 2592000 }); // 30 days
-
-    console.log(`Intake ${intakeId}: ${intakeType} from ${sender} — "${subject}"`);
-
-    // Forward to maintainer with tracking header
-    const forwardHeaders = new Headers();
-    forwardHeaders.set('X-MisakaNet-Intake-Id', intakeId);
-    forwardHeaders.set('X-MisakaNet-Intake-Type', intakeType);
-
-    if (env.MAINTAINER_EMAIL) {
-      await message.forward(env.MAINTAINER_EMAIL, forwardHeaders);
-      console.log(`Forwarded ${intakeId} to ${env.MAINTAINER_EMAIL}`);
-    } else {
-      console.warn('MAINTAINER_EMAIL not configured — intake stored in KV only');
-    }
-
-    // ── Registration flow (if intake type is registration) ──
-    if (intakeType === 'registration') {
+    // Every accepted sender receives a stable node ID, including lesson submitters.
+    if (!nodeId) {
       const counter = await env.MISAKANET_KV.get('node_counter', 'text');
       const nextNum = (parseInt(counter) || 10052) + 1;
-      const nodeId = `Misaka${String(nextNum).padStart(5, '0')}`;
+      nodeId = `Misaka${String(nextNum).padStart(5, '0')}`;
       await env.MISAKANET_KV.put('node_counter', String(nextNum));
-      const emailTier = protocol.registration?.email?.trust_tier || 
-        Object.keys(protocol.trust_tiers || {}).find(k => protocol.trust_tiers[k].method === 'email') || 
+      await env.MISAKANET_KV.put(`email-node:${sender}`, nodeId);
+      const emailTier = protocol.registration?.email?.trust_tier ||
+        Object.keys(protocol.trust_tiers || {}).find(k => protocol.trust_tiers[k].method === 'email') ||
         'mail-verified';
       await env.MISAKANET_KV.put(`node:${nodeId}`, JSON.stringify({
         nodeId, email: sender,
@@ -100,6 +76,65 @@ export default {
       }));
       console.log(`Registered via email: ${nodeId} <${sender}>`);
     }
+
+    const intakeRecord = {
+      intakeId,
+      from: sender,
+      to: recipient,
+      subject,
+      intakeType,
+      lessonContent,
+      nodeId,
+      receivedAt,
+      status: 'processed',
+    };
+    await env.MISAKANET_KV.put(
+      `email-intake:${intakeId}`,
+      JSON.stringify(intakeRecord),
+      { expirationTtl: 2592000 },
+    );
+    console.log(`Intake ${intakeId}: ${intakeType} from ${sender} — "${subject}"`);
+
+    if (env.GH_TOKEN) {
+      try {
+        intakeRecord.githubIssueUrl = await createAuditIssue(env, intakeRecord);
+        await env.MISAKANET_KV.put(
+          `email-intake:${intakeId}`,
+          JSON.stringify(intakeRecord),
+          { expirationTtl: 2592000 },
+        );
+        console.log(`Created audit issue: ${intakeRecord.githubIssueUrl}`);
+      } catch (error) {
+        console.error(`GitHub audit issue failed for ${intakeId}: ${error.message}`);
+      }
+    }
+
+    const forwardHeaders = new Headers({
+      'X-MisakaNet-Intake-Id': intakeId,
+      'X-MisakaNet-Intake-Type': intakeType,
+    });
+    if (env.MAINTAINER_EMAIL) {
+      await message.forward(env.MAINTAINER_EMAIL, forwardHeaders);
+      console.log(`Forwarded ${intakeId} to ${env.MAINTAINER_EMAIL}`);
+    } else {
+      console.warn('MAINTAINER_EMAIL not configured — intake stored in KV only');
+    }
+
+    const reply = new EmailMessage(
+      recipient,
+      sender,
+      [
+        `From: MisakaNet <${recipient}>`,
+        `To: ${sender}`,
+        `Subject: Re: ${subject || 'MisakaNet email intake'}`,
+        'Content-Type: text/plain; charset=UTF-8',
+        ...(messageId ? [`In-Reply-To: ${messageId}`] : []),
+        '',
+        buildReplyText({ intakeId, intakeType, nodeId }),
+      ].join('\r\n'),
+    );
+    await message.reply(reply);
+    console.log(`Replied to ${sender} for intake ${intakeId}`);
   },
 
   async fetch(request, env) {
@@ -192,6 +227,44 @@ export default {
     });
   }
 };
+
+async function createAuditIssue(env, intake) {
+  const repo = env.GH_REPO || 'Ikalus1988/MisakaNet';
+  const labels = intake.intakeType === 'lesson-submission'
+    ? ['lesson-intake']
+    : ['registered', 'email'];
+  const content = intake.lessonContent || '_No plain-text body was found._';
+  const response = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${env.GH_TOKEN}`,
+      'Accept': 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'MisakaNet-email-intake',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      title: `[email/${intake.intakeType}] ${intake.subject || intake.intakeId}`.slice(0, 240),
+      labels,
+      body: [
+        '<!-- Created automatically by the MisakaNet email intake Worker. -->',
+        `- **Intake ID:** \`${intake.intakeId}\``,
+        `- **Type:** \`${intake.intakeType}\``,
+        `- **From:** \`${intake.from.replace(/`/g, '')}\``,
+        `- **Received:** ${intake.receivedAt}`,
+        intake.nodeId ? `- **Node ID:** \`${intake.nodeId}\`` : '',
+        '',
+        '## Parsed content',
+        '',
+        content.replace(/<!--/g, '&lt;!--').slice(0, 12000),
+      ].filter(Boolean).join('\n'),
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}: ${(await response.text()).slice(0, 300)}`);
+  }
+  return (await response.json()).html_url;
+}
 
 function renderPage(view, data) {
   const style = `


### PR DESCRIPTION
## Summary
- parse bounded plain-text lesson content from plain, HTML, and multipart email
- persist stable sender/node mappings and complete `email-intake:*` records in KV
- create optional GitHub audit issues, forward tracked copies, and auto-reply with node IDs
- document deployment verification and add focused parser/classification tests

## Verification
- `node --test workers/email-register/email-utils.test.mjs` (4/4 passed)
- `npx --yes wrangler@4.107.0 deploy --config workers/email-register/wrangler.jsonc --dry-run`
- `git diff --check`

Closes #470

/claim #470