### PR TITLE
feat: add Dockerfile for Glama MCP server detection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.cache
+__pycache__
+*.pyc
+*.egg-info
+dist
+build
+node_modules
+.web
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY pyproject.toml .
+COPY search_knowledge.py .
+COPY misakanet/ misakanet/
+COPY scripts/mcp_server.py scripts/mcp_server.py
+COPY lessons/ lessons/
+COPY reference/ reference/
+
+RUN pip install --no-cache-dir .
+
+# MCP server runs on stdio
+CMD ["python3", "scripts/mcp_server.py"]


### PR DESCRIPTION
## Summary

Adds a minimal Dockerfile so Glama can build and run the MCP server for introspection checks. This enables the Glama badge required by awesome-mcp-servers PR listing.

## Changes

- `Dockerfile` — Python 3.12-slim, installs misakanet-core, runs `scripts/mcp_server.py` on stdio
- `.dockerignore` — keeps image small (excludes .git, __pycache__, node_modules, etc.)

## Why

awesome-mcp-servers requires Glama badge for all entries. Glama needs to build and run the server to verify it responds to MCP introspection. Without a Dockerfile, Glama cannot auto-detect and validate the Python stdio server.

## Test

```bash
docker build -t misakanet-mcp .
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | docker run -i misakanet-mcp
```

Signed-off-by: zsxh1990 <445655361@qq.com>