### PR TITLE
test: harden email intake parser with edge-case coverage (#498)

### DIFF
--- a/workers/email-register/email-utils.test.mjs
+++ b/workers/email-register/email-utils.test.mjs
@@ -64,3 +64,172 @@ test('converts HTML without regex tag filtering or recursive entity decoding', (
   ].join('\r\n');
   assert.equal(parseEmailBody(raw), 'Lesson & notes\n&lt;not-a-tag&gt;');
 });
+
+// --- MIME edge cases ---
+
+test('handles deeply nested multipart (mixed containing alternative)', () => {
+  const raw = [
+    'Content-Type: multipart/mixed; boundary="outer"',
+    '',
+    '--outer',
+    'Content-Type: multipart/alternative; boundary="inner"',
+    '',
+    '--inner',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    'Nested plain text lesson',
+    '--inner',
+    'Content-Type: text/html',
+    '',
+    '<p>HTML fallback</p>',
+    '--inner--',
+    '--outer--',
+  ].join('\r\n');
+  assert.equal(parseEmailBody(raw), 'Nested plain text lesson');
+});
+
+test('decodes base64 Content-Transfer-Encoding in text/plain part', () => {
+  const plainText = 'Lesson: base64 encoded content';
+  const encoded = btoa(plainText);
+  const raw = [
+    'Content-Type: text/plain; charset=UTF-8',
+    'Content-Transfer-Encoding: base64',
+    '',
+    encoded,
+  ].join('\r\n');
+  assert.equal(parseEmailBody(raw), 'Lesson: base64 encoded content');
+});
+
+test('defaults to text/plain when Content-Type header is missing', () => {
+  const raw = [
+    'From: agent@example.com',
+    '',
+    'Lesson: no content type header present',
+  ].join('\r\n');
+  assert.equal(parseEmailBody(raw), 'Lesson: no content type header present');
+});
+
+test('handles broken boundary without throwing', () => {
+  const raw = [
+    'Content-Type: multipart/alternative; boundary="broken"',
+    '',
+    '--broken',
+    'Content-Type: text/plain',
+    '',
+    'Lesson: broken boundary test',
+  ].join('\r\n');
+  assert.doesNotThrow(() => parseEmailBody(raw));
+});
+
+// --- Non-ASCII content ---
+
+test('handles CJK characters in subject line (RFC 2047 encoded)', () => {
+  const subject = '=?UTF-8?B?5q2j56eN?= Lesson';
+  const body = 'Lesson: CJK subject test';
+  assert.equal(detectIntakeType(subject, body), 'lesson-submission');
+});
+
+test('handles mixed Chinese and English body content', () => {
+  const body = 'Lesson: 提交一个bug报告 about SQLite locking';
+  assert.equal(detectIntakeType('', body), 'lesson-submission');
+});
+
+test('handles sender name with non-ASCII characters', () => {
+  const raw = [
+    'From: =?UTF-8?B?5peg5a2d5LiA?= <agent@example.com>',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    'Lesson: non-ASCII sender name',
+  ].join('\r\n');
+  assert.equal(parseEmailBody(raw), 'Lesson: non-ASCII sender name');
+});
+
+// --- Quoting and forwarding chains ---
+
+test('strips Outlook-style Original Message separator', () => {
+  const raw = [
+    'From: agent@example.com',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    'Lesson: new content after outlook separator',
+    '',
+    '-----Original Message-----',
+    'From: old@example.com',
+    'old quoted text',
+  ].join('\r\n');
+  const body = parseEmailBody(raw);
+  assert.equal(extractLessonContent(body), 'Lesson: new content after outlook separator');
+});
+
+test('strips multiple levels of > quoting', () => {
+  const raw = [
+    'From: agent@example.com',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    'Lesson: original lesson text',
+    '',
+    '> On Mon, someone wrote:',
+    '>> older message',
+    '>>> oldest message',
+  ].join('\r\n');
+  const body = parseEmailBody(raw);
+  assert.equal(extractLessonContent(body), 'Lesson: original lesson text');
+});
+
+test('Gmail-style forwarded message headers are not yet stripped (known gap)', () => {
+  const raw = [
+    'From: agent@example.com',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    'Lesson: forwarded lesson content',
+    '',
+    '---------- Forwarded message ----------',
+    'From: previous-sender@example.com',
+    'old forwarded content',
+  ].join('\r\n');
+  const body = parseEmailBody(raw);
+  const extracted = extractLessonContent(body);
+  assert.ok(extracted.includes('Lesson: forwarded lesson content'), 'preserves new lesson text');
+  assert.ok(extracted.includes('Forwarded message'), 'does not yet strip Gmail forwarding headers');
+});
+
+// --- Intake type detection edge cases ---
+
+test('classifies based on combined subject+body signal when conflicting', () => {
+  const subject = 'register';
+  const body = 'I want to submit a lesson about networking';
+  assert.equal(detectIntakeType(subject, body), 'registration');
+});
+
+test('returns unknown for empty subject and empty body', () => {
+  assert.equal(detectIntakeType('', ''), 'unknown');
+});
+
+test('truncates very long body to MAX_BODY_LENGTH without crashing', () => {
+  const longBody = 'Lesson: ' + 'x'.repeat(25000);
+  const raw = [
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    longBody,
+  ].join('\r\n');
+  const body = parseEmailBody(raw);
+  assert.ok(body.length <= 20000);
+  assert.ok(body.startsWith('Lesson: '));
+});
+
+// --- Reply text generation ---
+
+test('buildReplyText with null nodeId returns intake ID instead of node ID', () => {
+  const reply = buildReplyText({ intakeId: 'intake-99', intakeType: 'bug-report', nodeId: null });
+  assert.match(reply, /intake-99/);
+  assert.match(reply, /Your intake ID is intake-99/);
+  assert.doesNotMatch(reply, /Your node ID/);
+  assert.match(reply, /queued for maintainer review/);
+});
+
+test('buildReplyText with registered nodeId includes node ID and quickstart link', () => {
+  const reply = buildReplyText({ intakeId: 'intake-42', intakeType: 'lesson-submission', nodeId: 'Misaka00001' });
+  assert.match(reply, /Your node ID is Misaka00001/);
+  assert.match(reply, /Next steps:/);
+  assert.match(reply, /quickstart/);
+});


### PR DESCRIPTION
## Summary

Adds 15 new test cases to `email-utils.test.mjs` covering edge cases from the bounty issue #498.

### Tests Added

**MIME edge cases:**
- Deeply nested multipart (mixed containing alternative)
- Base64 Content-Transfer-Encoding in text/plain part
- Missing Content-Type header (defaults to text/plain)
- Broken/missing boundary without throwing

**Non-ASCII content:**
- CJK characters in subject line (RFC 2047 encoded)
- Mixed Chinese + English body content
- Sender name with non-ASCII characters

**Quoting and forwarding chains:**
- Outlook-style `-----Original Message-----` separator
- Multiple levels of `>` quoting
- Gmail-style forwarded message headers (documents known gap)

**Intake type detection:**
- Conflicting signals (register in subject, lesson in body → registration wins)
- Empty subject + empty body → unknown
- Very long body (>20KB) → truncated to MAX_BODY_LENGTH

**Reply text generation:**
- `nodeId: null` → returns intake ID, not node ID
- `nodeId: 'Misaka00001'` → includes quickstart link

### Known Gap Identified

Gmail-style forwarding headers (`---------- Forwarded message ----------`) are not yet recognized by `extractLessonContent`. The test documents this as a known gap for future improvement.

### Test Results

```
# tests 20
# pass 20
# fail 0
```

Closes #498