### PR TITLE
feat: resolve email intake forwarding headers gap and fix doc references

### DIFF
--- a/docs/agents/node-injection.md
+++ b/docs/agents/node-injection.md
@@ -40,7 +40,7 @@ python3 search_knowledge.py "错误关键词" --lessons
 每次会话开始时执行：
 
 ```bash
-cd ~/Agent-Medici && git pull --ff-only
+cd ~/MisakaNet && git pull --ff-only
 python3 search_knowledge.py "当前话题" --lessons
 ```
 
@@ -50,15 +50,15 @@ python3 search_knowledge.py "当前话题" --lessons
 
 ```bash
 # cron 配置
-*/10 * * * * cd ~/Agent-Medici && git pull --ff-only
+*/10 * * * * cd ~/MisakaNet && git pull --ff-only
 ```
 
 ## 保持同步
 
 ```bash
 # 每次会话开始时
-cd ~/Agent-Medici && git pull --ff-only
+cd ~/MisakaNet && git pull --ff-only
 
 # 或设 cron（Hermes/cc-haha 等常驻节点）
-*/10 * * * * cd ~/Agent-Medici && git pull --ff-only
+*/10 * * * * cd ~/MisakaNet && git pull --ff-only
 ```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -85,7 +85,7 @@ A method for combining multiple search result lists into a single ranking. Used 
 
 ### Quality Score
 A numerical rating (0-100) assigned to lessons based on completeness, verification status, and community feedback. Higher scores get better search ranking.
-→ [Quality scoring](../scripts/score_lesson.py)
+→ [Quality scoring](../scripts/quality_scorer.py)
 
 ---
 

--- a/docs/journey-reports/2026-07-18-ivegotahunnitonit.md
+++ b/docs/journey-reports/2026-07-18-ivegotahunnitonit.md
@@ -1,0 +1,58 @@
+# MisakaNet Journey Report
+
+## Environment
+- Date: 2026-07-18
+- Browser / OS: Chrome / Windows 10 (GCP VM: Debian Linux 11)
+- GitHub username: ivegotahunnitonit
+- Optional: MCP client / agent used: Antigravity AI Coding Assistant (pair programming)
+
+## Steps Completed
+- [x] README understanding
+- [x] Website / node registration
+- [x] Lesson search and use
+- [x] Guard / test bug investigation
+- [ ] Bot email feedback path
+- [ ] Optional human feedback
+
+## Findings
+
+### What worked
+- **Documentation & Onboarding clarity**: The `README.md` does a fantastic job of separating the concept of a **Lesson** (failure-memory) from a **Skill** (executable capability), preventing the common pitfall of treating MisakaNet as another tool directory.
+- **CLI Search speed**: Running `python3 search_knowledge.py` on the VM with zero dependencies works instantly and outputs readable TAP-compatible results.
+- **Node registration UI**: The website at `https://misakanet.org/` loaded quickly and provided a seamless form for node onboarding.
+
+### What was confusing
+- **Obsolete repository references**: Some guides (specifically `docs/agents/node-injection.md`) were referencing a home folder named `~/Agent-Medici` instead of `~/MisakaNet` for synchronization command blocks, which could lead to copy-paste errors for new operators.
+- **Glossary broken links**: The `docs/glossary.md` file linked to `../scripts/score_lesson.py` for quality scoring, but this script is no longer present in the root `scripts/` folder (the feature appears to be unified into `search_knowledge.py --score`).
+
+### Bugs or edge cases found
+- **Gmail-style forwarding gap**: The email registration worker had a marked "known gap" in its tests where Gmail-style forwarded message headers (`---------- Forwarded message ----------`) were not stripped from incoming text, leaving redundant headers in the extracted lesson body.
+
+### Suggested improvements
+- We have addressed the `~/Agent-Medici` obsolete path references by replacing them with `~/MisakaNet` in `docs/agents/node-injection.md`.
+- We resolved the "known gap" in the email intake pipeline by adding forwarding header patterns to the parser in `workers/email-register/src/email-utils.mjs` and updated the test assertions to ensure these headers are cleanly stripped.
+
+## Evidence
+
+### Test Run Verification
+After applying the email forwarding header parser changes, all 20 tests pass successfully:
+```
+# Subtest: strips Gmail-style forwarded message headers
+ok 15 - strips Gmail-style forwarded message headers
+  ---
+  duration_ms: 0.280527
+  type: 'test'
+  ...
+1..20
+# tests 20
+# suites 0
+# pass 20
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 149.434383
+```
+
+## Privacy
+- [x] I confirm that this report does not contain private secrets, personal API tokens, or sensitive environment configurations.

--- a/workers/email-register/email-utils.test.mjs
+++ b/workers/email-register/email-utils.test.mjs
@@ -176,7 +176,7 @@ test('strips multiple levels of > quoting', () => {
   assert.equal(extractLessonContent(body), 'Lesson: original lesson text');
 });
 
-test('Gmail-style forwarded message headers are not yet stripped (known gap)', () => {
+test('strips Gmail-style forwarded message headers', () => {
   const raw = [
     'From: agent@example.com',
     'Content-Type: text/plain; charset=UTF-8',
@@ -189,8 +189,7 @@ test('Gmail-style forwarded message headers are not yet stripped (known gap)', (
   ].join('\r\n');
   const body = parseEmailBody(raw);
   const extracted = extractLessonContent(body);
-  assert.ok(extracted.includes('Lesson: forwarded lesson content'), 'preserves new lesson text');
-  assert.ok(extracted.includes('Forwarded message'), 'does not yet strip Gmail forwarding headers');
+  assert.equal(extracted, 'Lesson: forwarded lesson content');
 });
 
 // --- Intake type detection edge cases ---

--- a/workers/email-register/src/email-utils.mjs
+++ b/workers/email-register/src/email-utils.mjs
@@ -196,7 +196,7 @@ export function parseEmailBody(rawEmail) {
 /** Remove common reply quoting so the stored lesson is the new submission. */
 export function extractLessonContent(body) {
   const lines = body.replace(/\r\n/g, '\n').split('\n');
-  const replyStart = lines.findIndex(line => /^On .+wrote:\s*$/i.test(line) || /^-{2,}\s*Original Message\s*-{2,}$/i.test(line));
+  const replyStart = lines.findIndex(line => /^On .+wrote:\s*$/i.test(line) || /^-{2,}\s*Original Message\s*-{2,}$/i.test(line) || /^[-]+\s*Forwarded message\s*[-]+/i.test(line));
   const freshLines = (replyStart >= 0 ? lines.slice(0, replyStart) : lines)
     .filter(line => !line.trimStart().startsWith('>'));
   return freshLines.join('\n').trim().slice(0, MAX_BODY_LENGTH);


### PR DESCRIPTION
Resolves the Gmail forwarded message headers parsing gap in the email intake worker, adds unit test coverage, and corrects the outdated Agent-Medici directory references in the node injection guide.

/claim #510
