### PR TITLE
ci: stop fatal-guard false failure when paths do not match

### DIFF
--- a/.github/workflows/fatal-guard.yml
+++ b/.github/workflows/fatal-guard.yml
@@ -15,8 +15,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Skip if triggered by push but no fatal-guard files changed
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || contains(toJSON(github.event.commits), 'packages/fatal-guard/')
+    # paths filters already gate push/PR; keep workflow_dispatch always runnable.
+    # Avoid a job-level if that can leave 0 jobs and mark the workflow as failed.
     defaults:
       run:
         working-directory: packages/fatal-guard


### PR DESCRIPTION
## Summary
/claim #514

Removes the redundant job-level `if` in `.github/workflows/fatal-guard.yml`.

### Why
- `on.push.paths` / `on.pull_request.paths` already gate when the workflow starts
- The old `contains(toJSON(github.event.commits), 'packages/fatal-guard/')` check could evaluate false even when the workflow was triggered in a way that left 0 jobs, showing as failure noise

### Behavior after
- `push` / `pull_request` still only enter the workflow when `packages/fatal-guard/**` changes
- `workflow_dispatch` still works
- No matching change → workflow skipped (not failed job)

## Testing
YAML change only; logic follows the suggested fix in #514.