### PR TITLE
docs: clean up historical Agent-Medici references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent-Medici 节点接入规则
+# MisakaNet 节点接入规则
 
 > 任何节点加入虫群后，按以下规则检索和贡献知识。
 
@@ -49,7 +49,7 @@ python3 scripts/queue_lesson.py \
 
 ```bash
 # 每次会话开始时
-cd ~/Agent-Medici && git pull --ff-only
+cd ~/MisakaNet && git pull --ff-only
 ```
 
 ## 详细指南

--- a/docs/agents/knowledge-structure.md
+++ b/docs/agents/knowledge-structure.md
@@ -3,7 +3,7 @@
 ## 目录结构
 
 ```
-Agent-Medici/
+MisakaNet/
 ├── lessons/                  # 跨节点共享知识（踩坑记录）
 ├── reference/                # 完整方案文档
 ├── misakanet/                # 通信模块

--- a/docs/agents/node-injection.md
+++ b/docs/agents/node-injection.md
@@ -40,7 +40,7 @@ python3 search_knowledge.py "错误关键词" --lessons
 每次会话开始时执行：
 
 ```bash
-cd ~/Agent-Medici && git pull --ff-only
+cd ~/MisakaNet && git pull --ff-only
 python3 search_knowledge.py "当前话题" --lessons
 ```
 
@@ -50,15 +50,15 @@ python3 search_knowledge.py "当前话题" --lessons
 
 ```bash
 # cron 配置
-*/10 * * * * cd ~/Agent-Medici && git pull --ff-only
+*/10 * * * * cd ~/MisakaNet && git pull --ff-only
 ```
 
 ## 保持同步
 
 ```bash
 # 每次会话开始时
-cd ~/Agent-Medici && git pull --ff-only
+cd ~/MisakaNet && git pull --ff-only
 
 # 或设 cron（Hermes/cc-haha 等常驻节点）
-*/10 * * * * cd ~/Agent-Medici && git pull --ff-only
+*/10 * * * * cd ~/MisakaNet && git pull --ff-only
 ```

--- a/docs/domains/hub.md
+++ b/docs/domains/hub.md
@@ -18,7 +18,7 @@ Lessons about the Hermes Hub — central coordination layer for the MisakaNet sw
 
 **Problem:** Gateway and Hub have separate credential stores — updating one does not update the other.
 
-**Fix:** Gateway uses `~/.hermes/.env`, Hub uses `~/Agent-Medici/config.yaml` + environment variables. Both must be updated separately.
+**Fix:** Gateway uses `~/.hermes/.env`, Hub uses `~/MisakaNet/config.yaml` + environment variables. Both must be updated separately.
 
 **Verify:** Both Gateway and Hub can authenticate to Feishu independently.
 

--- a/docs/human/intuitive-flow-setup.md
+++ b/docs/human/intuitive-flow-setup.md
@@ -81,7 +81,7 @@ python3 scripts/queue_lesson.py \
 
 ```bash
 # 每次会话开始时
-cd ~/Agent-Medici && git pull --ff-only
+cd ~/MisakaNet && git pull --ff-only
 ```
 
 ## 优先技能

--- a/misakanet/README.md
+++ b/misakanet/README.md
@@ -1,6 +1,6 @@
 ## MisakaNet — 节点技能反馈通信模块
 
-**MisakaNet 是 Agent-Medici 的通信子模块。**  
+**MisakaNet 是通信子模块。** (注：Agent-Medici 是其前身项目，现已全面迁移至 MisakaNet。)  
 节点通过 GitHub Issues 上报 skill 使用反馈，Hub 消费后更新 Knowledge Graph。
 
 ### 目录结构
@@ -37,13 +37,13 @@ misakanet/
 
 **节点侧（WSL）：**
 ```bash
-cd /path/to/agent-medici
+cd /path/to/MisakaNet
 python misakanet/scripts/feedback_report.py
 ```
 
 **Hub 侧（Windows）：**
 ```powershell
-cd C:\Users\Eric Jia\agent-medici
+cd C:\Users\Eric Jia\MisakaNet
 $env:MISAKANET_TOKEN = "ghp_..."
 python misakanet\scripts\hub_poller.py
 ```

--- a/misakanet/scripts/bulk_import_lessons.py
+++ b/misakanet/scripts/bulk_import_lessons.py
@@ -24,7 +24,7 @@ MisakaNet 历史教训批量提取工具 (Phase 1)
   python3 misakanet/scripts/bulk_import_lessons.py wizard node1_hermes
 
 Schema:
-  见 schema 说明：https://github.com/Ikalus1988/Agent-Medici
+  见 schema 说明：https://github.com/Ikalus1988/MisakaNet
 """
 import argparse
 import json

--- a/misakanet/scripts/draft_reminder.py
+++ b/misakanet/scripts/draft_reminder.py
@@ -7,7 +7,7 @@ MisakaNet Lesson Draft Reminder (v2)
 用法:
   python3 misakanet/scripts/draft_reminder.py
 
-Cron: 0 9,14 * * * python3 /path/to/Agent-Medici/misakanet/scripts/draft_reminder.py
+Cron: 0 9,14 * * * python3 /path/to/MisakaNet/misakanet/scripts/draft_reminder.py
        (每天 9:00 和 14:00 各跑一次)
 """
 

--- a/misakanet/scripts/draft_reminder.sh
+++ b/misakanet/scripts/draft_reminder.sh
@@ -3,7 +3,7 @@
 # ================================
 # ⚠️ DEPRECATED — 请使用 Python 版: draft_reminder.py
 # 保留以兼容已有 cron 迁移。新部署请用 Python 版。
-# Cron: 0 9,14 * * * python3 ~/Agent-Medici/misakanet/scripts/draft_reminder.py
+# Cron: 0 9,14 * * * python3 ~/MisakaNet/misakanet/scripts/draft_reminder.py
 
 set -e
 
@@ -63,7 +63,7 @@ if [ -n "$FEISHU_WEBHOOK" ]; then
         TITLE=$(grep -m1 'title:' "$f" | sed 's/.*title: *//; s/^"//; s/"$//')
         MSG="$MSG  • $TITLE (${FILE_AGE}h)\\n"
     done
-    MSG="$MSG\n审核: python3 ~/Agent-Medici/misakanet/scripts/queue_hook_stats.py list-drafts"
+    MSG="$MSG\n审核: python3 ~/MisakaNet/misakanet/scripts/queue_hook_stats.py list-drafts"
 
     curl -s -X POST "$FEISHU_WEBHOOK" \
       -H "Content-Type: application/json" \

--- a/misakanet/scripts/feedback_report.py
+++ b/misakanet/scripts/feedback_report.py
@@ -5,8 +5,8 @@ MisakaNet Feedback Reporter (节点侧)
 收集近期 skill 使用记录，通过 GitHub Issues 上报到 Hub。
 
 运行方式:
-  1. 手动: python3 /path/to/Agent-Medici/misakanet/scripts/feedback_report.py
-  2. Cron: */5 * * * * python3 /path/to/Agent-Medici/misakanet/scripts/feedback_report.py
+  1. 手动: python3 /path/to/MisakaNet/misakanet/scripts/feedback_report.py
+  2. Cron: */5 * * * * python3 /path/to/MisakaNet/misakanet/scripts/feedback_report.py
 
 依赖: curl + GitHub token（从 ~/.git-credentials 读取）
 """

--- a/misakanet/scripts/hub_poller.py
+++ b/misakanet/scripts/hub_poller.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-MisakaNet Hub Poller (Hub 侧 - Agent-Medici 集成版)
+MisakaNet Hub Poller (Hub 侧 - MisakaNet 集成版)
 ====================================================
 从 GitHub Issues 消费节点上报的反馈，直接更新 Hub 的 Knowledge Graph。
 
-部署: agent-medici/misakanet/scripts/hub_poller.py
-运行: cd /path/to/agent-medici && python misakanet/scripts/hub_poller.py
+部署: MisakaNet/misakanet/scripts/hub_poller.py
+运行: cd /path/to/MisakaNet && python misakanet/scripts/hub_poller.py
 
 依赖:
   pip install requests pyyaml
@@ -18,7 +18,7 @@ import sys
 import yaml
 from datetime import datetime, timezone
 
-# 项目根目录 (agent-medici/)
+# 项目根目录 (MisakaNet/)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
@@ -28,7 +28,7 @@ API_BASE = "https://api.github.com"
 
 
 def _load_config():
-    """读取 Agent-Medici config.yaml"""
+    """读取 MisakaNet config.yaml"""
     config_path = os.path.join(PROJECT_ROOT, "config.yaml")
     with open(config_path, encoding="utf-8") as f:
         return yaml.safe_load(f)
@@ -178,7 +178,7 @@ def mark_processed(issue_number, feedback, success):
 
 def main():
     print("=" * 55)
-    print(f"  MisakaNet Hub Poller (Agent-Medici 集成)")
+    print(f"  MisakaNet Hub Poller (MisakaNet 集成)")
     print(f"  repo: {REPO}")
     print(f"  time: {datetime.now(timezone.utc).isoformat()}")
     print("=" * 55)
@@ -192,7 +192,7 @@ def main():
         kg = _get_graph()
     except ImportError as e:
         print(f"[error] 无法加载 KnowledgeGraph: {e}", file=sys.stderr)
-        print("  确保在 Agent-Medici 项目根目录下运行本脚本", file=sys.stderr)
+        print("  确保在 MisakaNet 项目根目录下运行本脚本", file=sys.stderr)
         sys.exit(1)
 
     # 检查 hook stats 并推送飞书（独立于 Issues，每次均执行）

--- a/misakanet/scripts/standby_poller.py
+++ b/misakanet/scripts/standby_poller.py
@@ -10,7 +10,7 @@ MisakaNet Standby Poller (备 Hub 节点侧)
   python3 misakanet/scripts/standby_poller.py
 
   # Cron 模式（每 5 分钟）
-  */5 * * * * python3 /path/to/Agent-Medici/misakanet/scripts/standby_poller.py
+  */5 * * * * python3 /path/to/MisakaNet/misakanet/scripts/standby_poller.py
 
 依赖:
   pip install requests pyyaml
@@ -33,7 +33,7 @@ STARTUP_DELAY = 300  # 5 分钟
 
 
 def _load_config():
-    """读取 Agent-Medici config.yaml"""
+    """读取 MisakaNet config.yaml"""
     import yaml
     config_path = PROJECT_ROOT / "config.yaml"
     if config_path.exists():


### PR DESCRIPTION
Resolves #516

This PR cleans up all remaining active references to the predecessor project Agent-Medici (updated paths to MisakaNet, config.yaml paths, and module integration descriptions) while leaving lessons and git history untouched as requested.