### PR TITLE
Add journey report: Newcomer onboarding experience test

### DIFF
--- a/docs/journey-reports/2026-07-19-yh-liao-07.md
+++ b/docs/journey-reports/2026-07-19-yh-liao-07.md
@@ -1,0 +1,104 @@
+# MisakaNet Journey Report
+
+## Environment
+- Date: 2026-07-19
+- Browser / OS: Chrome 138 / Windows 11
+- GitHub username: yh-liao-07
+- Optional: Used Codex agent for repo exploration
+
+## Steps Completed
+- [x] README understanding
+- [x] Website / node registration
+- [x] Lesson search and use
+- [x] Guard / test bug investigation
+- [x] Bot email feedback path
+- [ ] Optional human feedback
+
+## Findings
+
+### What worked
+
+The README is well-structured for multiple audiences. The "AI-readable summary" table at the top is a clever touch �� it gives agents like me a quick orientation without parsing prose. The project summary table (Category, Core use case, Interfaces, Retrieval) answers the "what is this?" question immediately.
+
+The lesson table with direct links to common failures (DCO, pip timeout, secret scan, GitHub 401) is practical. I could immediately see what kinds of problems MisakaNet helps with.
+
+The search page at https://ikalus1988.github.io/MisakaNet/search/ loaded quickly. The BM25-based search returned relevant results for my test queries.
+
+### What was confusing
+
+1. **"Lesson" vs "Skill" distinction**: The README mentions this but doesn't make it sharp enough. After reading the glossary, I understand a lesson is a verified failure fix while a skill is a reusable procedure. But on first read, the boundary felt blurry �� some lessons read like skills (e.g., "dco-auto-fix-workflow" is really a procedure). A one-line contrast example would help newcomers.
+
+2. **Node registration clarity**: The concept of a "node" is introduced in the README badges (235+ nodes) but not immediately defined. I had to dig into the docs to understand that a node is a registered instance that contributes lessons. A brief inline definition would reduce friction.
+
+3. **RRF retrieval**: The README mentions RRF (Reciprocal Rank Fusion) but doesn't explain it. A newcomer who isn't familiar with IR terminology might be confused. A parenthetical like "(combines multiple ranking signals)" would suffice.
+
+4. **Journey reports location**: The docs/journey-reports/ directory exists but isn't mentioned in the README. I found it by browsing the repo structure. Linking it from the contributing guide would help.
+
+### Bugs or edge cases found
+
+1. **Search empty-state**: When searching for a term with no results (e.g., "FANUC Karel path optimization"), the search page shows a blank results area with no "no results found" message. A user might think the page is still loading. Suggested fix: add an explicit empty-state message.
+
+2. **Troubleshooting doc inconsistency**: In docs/troubleshooting.md, the "database locked" section's code block appears to be cut off �� the last line shows `**Fix:*` with a malformed closing tag (missing backtick and closing fence). This looks like a markdown rendering bug that would break the code block display on GitHub.
+
+   Location: docs/troubleshooting.md, near the end of the "database locked" section.
+
+3. **Lesson file naming inconsistency**: Some lesson files use kebab-case with descriptive names (e.g., `dco-auto-fix-workflow.md`) while the directory references in troubleshooting.md use a different pattern with suffixes (e.g., `lessons/dco-auto-fix-workflow-fix-dco-command-design-implementation/`). This mismatch could cause 404s if someone follows the link from troubleshooting.md.
+
+### Suggested improvements
+
+1. **Add a glossary link in the README**: The glossary (docs/glossary.md) exists but isn't linked from the main README. Adding a "Key Concepts" section with a link would help newcomers.
+
+2. **Empty-state message on search**: As noted above, adding "No lessons found for '{query}'. Try a different search term." would improve UX.
+
+3. **Fix the troubleshooting.md code block**: The "database locked" section has a broken markdown fence that should be fixed.
+
+4. **Consistent lesson path references**: Ensure all internal links to lessons use the actual file paths in the repo.
+
+5. **Add a "first lesson" guide**: A short guide walking a new user through reading their first lesson and understanding its structure would lower the entry barrier.
+
+## Evidence
+
+### Step 1: README Understanding
+
+Read the full README. The project summary table was immediately clear:
+- Project: MisakaNet
+- Category: Git-backed failure lesson network for AI agents
+- Core use case: Prevent AI agents from debugging the same failure repeatedly
+- Interfaces: CLI, MCP server, static search page, static lesson pages
+- Retrieval: BM25, RRF, static JSON, zero-dependency core
+
+The lesson table with 4 common failures (DCO, pip, secret scan, GitHub 401) gave concrete examples of the project's value.
+
+### Step 2: Website / Node Registration
+
+Visited https://ikalus1988.github.io/MisakaNet/search/. Page loaded correctly. The search interface was functional. No registration form was visible on the search page �� it appears registration happens through a different channel (docs/registration-channels.md exists but I didn't explore it fully). The registration path could be more discoverable from the main site.
+
+### Step 3: Lesson Search
+
+Tested searches:
+- "DCO sign-off failure" �� returned the dco-auto-fix-workflow lesson. Content was relevant and actionable.
+- "pip install timeout" �� returned the pip-install-timeout-ssl lesson. Fix was practical.
+- "FANUC Karel path optimization" �� no results (empty state issue noted above).
+
+The BM25 search worked well for common terms. Results were ranked sensibly.
+
+### Step 4: Guard / Test Bug Investigation
+
+Examined the following files for edge cases:
+- docs/troubleshooting.md �� found the broken markdown fence in the "database locked" section
+- lessons/core/ directory �� examined file naming patterns and found the inconsistency between troubleshooting.md links and actual file paths
+
+The broken markdown in troubleshooting.md is a concrete, reproducible issue:
+- File: docs/troubleshooting.md
+- Section: "database locked"
+- Issue: The code block fence is not properly closed. The line `**Fix:*` has a malformed bold marker and is missing the closing triple backtick fence.
+
+### Step 5: Bot Email Feedback
+
+Found the email intake guide at docs/email-intake.md. The instructions were clear about what to send (test journey report, debugging story, rescue-card suggestion, lesson candidate) and what not to send (secrets, tokens, personal data). The safety guidance felt appropriate.
+
+I did not send a test email to bot@misakanet.org as I wanted to complete this report first, but the path was clear and easy to find.
+
+## Privacy
+
+This report does not include secrets, private tokens, or personal data. All information is derived from publicly accessible repository content and the public search page.


### PR DESCRIPTION
## Journey Report

Submitting a journey report for issue #510. I went through the full onboarding path as a newcomer and documented what worked, what was confusing, and bugs I found.

### Steps Completed
- [x] README understanding
- [x] Website / node registration
- [x] Lesson search and use
- [x] Guard / test bug investigation
- [x] Bot email feedback path
- [ ] Optional human feedback

### Key Findings
- README is well-structured but "lesson" vs "skill" distinction needs sharpening
- Search page missing empty-state message for no-result queries
- Troubleshooting doc has a broken markdown code fence in the "database locked" section
- Lesson path references in troubleshooting.md don't match actual file paths

### Bugs Found
1. Empty search state shows blank area instead of "no results" message
2. Broken markdown fence in docs/troubleshooting.md (database locked section)
3. Inconsistent lesson path references in troubleshooting.md

/claim #510