### PR TITLE
docs(lessons): EN translations for 3 Chinese GitHub lessons

### DIFF
--- a/lessons/contrib/git-credential-helper-gh-path-mismatch.md
+++ b/lessons/contrib/git-credential-helper-gh-path-mismatch.md
@@ -90,3 +90,5 @@ git push
 - 新装 `gh` 后用 `gh auth login` 登录后，检查 credential helper 是否引入了错误路径
 - 如果同时使用 `credential.helper store` 和 `gh auth git-credential`，确保 `gh auth git-credential` 的路径与二进制位置一致
 - 用 `which gh` 确认真实路径，与 git config 中的 credential helper 路径对比
+
+> English: [`lessons/en/git-credential-helper-gh-path-mismatch.md`](../../lessons/en/git-credential-helper-gh-path-mismatch.md)

--- a/lessons/contrib/github-401-credential-lookup.md
+++ b/lessons/contrib/github-401-credential-lookup.md
@@ -56,3 +56,5 @@ curl -s -H "Authorization: Bearer $TOKEN" https://api.github.com/user | jq .logi
 ## 关联经验
 
 本教训与 `git-credentials-automation` 互补：后者解决 push/pull 时的交互式认证，本条解决 API 调用时的编程式认证。
+
+> English: [`lessons/en/github-401-credential-lookup.md`](../../lessons/en/github-401-credential-lookup.md)

--- a/lessons/contrib/static-page-github-api-403-rate-limit.md
+++ b/lessons/contrib/static-page-github-api-403-rate-limit.md
@@ -101,3 +101,5 @@ return '数据加载失败，已使用缓存显示';
 3. **非关键数据失败不应阻断关键数据展示**——统计数字和主要内容应该互不影响
 4. **没有超时的 fetch 是永久挂起的隐患**——即使请求本地 JSON 文件也应有超时保护
 5. **如果项目频繁遇到限流**，考虑引入 GitHub Actions 定时缓存 + 静态 JSON 的 hybrid 架构，或使用代理后端
+
+> English: [`lessons/en/static-page-github-api-fault-tolerance.md`](../../lessons/en/static-page-github-api-fault-tolerance.md)

--- a/lessons/en/git-credential-helper-gh-path-mismatch.md
+++ b/lessons/en/git-credential-helper-gh-path-mismatch.md
@@ -1,0 +1,72 @@
+---
+{
+  "title": "gh credential helper path mismatch silently breaks git push",
+  "domain": "devops",
+  "tags": ["git", "github", "credential", "gh", "auth", "push"],
+  "status": "published",
+  "lang": "en",
+  "source": "uncledad96-glitch",
+  "translated_from": "lessons/contrib/git-credential-helper-gh-path-mismatch.md",
+  "created": "2026-07-20",
+  "updated": "2026-07-20"
+}
+---
+
+# gh credential helper path mismatch silently breaks git push
+
+> English translation of `lessons/contrib/git-credential-helper-gh-path-mismatch.md`
+
+## Problem
+
+`git push` hangs or errors with:
+
+```text
+/home/hp/.local/bin/gh auth git-credential get: 1: /home/hp/.local/bin/gh: not found
+```
+
+or:
+
+```text
+remote: Repository not found.
+fatal: repository 'https://github.com/...' not found
+```
+
+even when the repo exists and the token is valid.
+
+## Root Cause
+
+`gh` may live at `/usr/bin/gh` while git’s credential helper points at a **stale path**:
+
+```text
+credential.https://github.com.helper=!/home/hp/.local/bin/gh auth git-credential
+```
+
+Common after mixed install methods (`apt` vs manual) or moved user local bins.
+
+## Fix
+
+```bash
+git config --global --list | grep credential
+
+git config --global --unset-all credential.https://github.com.helper
+git config --global --unset-all credential.https://gist.github.com.helper
+
+git config --global credential.helper store
+# ensure ~/.git-credentials has a valid token
+cat ~/.git-credentials
+
+git ls-remote origin HEAD
+```
+
+Or point the helper at the real binary:
+
+```bash
+git config --global credential.https://github.com.helper '!$(command -v gh) auth git-credential'
+```
+
+## Verification
+
+```bash
+git config --global --list | grep helper
+git ls-remote origin HEAD   # returns a commit hash
+```

--- a/lessons/en/github-401-credential-lookup.md
+++ b/lessons/en/github-401-credential-lookup.md
@@ -1,0 +1,65 @@
+---
+{
+  "title": "Local credential lookup order after GitHub API 401",
+  "domain": "github",
+  "tags": ["github", "api", "credential", "401", "auth", "pat"],
+  "status": "published",
+  "lang": "en",
+  "source": "uncledad96-glitch",
+  "translated_from": "lessons/contrib/github-401-credential-lookup.md",
+  "created": "2026-07-20",
+  "updated": "2026-07-20"
+}
+---
+
+# Local credential lookup order after GitHub API 401
+
+> English translation of `lessons/contrib/github-401-credential-lookup.md`
+
+## Problem
+
+Calling the GitHub API returns `{"message":"Bad credentials"}` or HTTP 401/403. The first impulse is “token is dead — ask the user for a new PAT.” Local credentials often already exist; skipping the inventory wastes a human trip.
+
+## Root Cause
+
+Agents prefer **acquiring new resources** (ask user) over **inventorying local assets**. That is resource-fetch bias vs resource-audit bias.
+
+## Fix
+
+**Mandatory lookup order after GitHub API auth failure:**
+
+```bash
+# 1. git-credentials store
+cat ~/.git-credentials
+# format: https://username:TOKEN@github.com
+
+# 2. netrc
+cat ~/.netrc
+
+# 3. GitHub CLI
+gh auth status
+
+# 4. environment
+echo "$GITHUB_TOKEN"
+
+# 5. credential helper config
+git config --global --list | grep credential
+```
+
+**Only if all of the above fail** should you ask the user for a new token.
+
+Extract token from git-credentials:
+
+```bash
+grep -oP 'https://[^:]+:\K[^@]+' ~/.git-credentials
+```
+
+## Verification
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" https://api.github.com/user | jq .login
+```
+
+## Related
+
+Complements `git-credentials-automation`: that lesson covers interactive push/pull auth; this one covers programmatic API auth.

--- a/lessons/en/static-page-github-api-fault-tolerance.md
+++ b/lessons/en/static-page-github-api-fault-tolerance.md
@@ -1,0 +1,79 @@
+---
+{
+  "title": "Fault-tolerance for static pages calling external APIs",
+  "domain": "frontend",
+  "tags": ["api", "rate-limit", "static-site", "error-handling", "fault-tolerance", "github"],
+  "status": "published",
+  "lang": "en",
+  "source": "uncledad96-glitch",
+  "translated_from": "lessons/contrib/static-page-github-api-403-rate-limit.md",
+  "created": "2026-07-20",
+  "updated": "2026-07-20"
+}
+---
+
+# Fault-tolerance for static pages calling external APIs
+
+> English translation / rewrite of `lessons/contrib/static-page-github-api-403-rate-limit.md`
+
+## Problem
+
+Pure static pages (HTML+JS on CDN/GitHub Pages, no backend) call third-party APIs from the browser. Risks:
+
+- Hard rate limits (e.g. GitHub REST unauthenticated **60 req/hour**)
+- `fetch` with no timeout hangs forever on bad networks
+- One failed call kills unrelated UI via a shared `Promise.all` / try-catch
+- No server-side key, cache, or request coalescing
+
+## Design principles
+
+### 1. Every external request needs a timeout
+
+```js
+async function fetchWithTimeout(url, timeoutMs = 8000) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await fetch(url, { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json();
+  } catch (e) {
+    clearTimeout(timer);
+    throw e;
+  }
+}
+```
+
+### 2. Parallel requests fail independently
+
+```js
+const [dataA, dataB] = await Promise.all([
+  fetchWithTimeout(urlA).catch(() => null),
+  fetchWithTimeout(urlB).catch(() => null),
+]);
+```
+
+### 3. Features load independently
+
+```js
+// bad: one throw blocks the rest
+// good:
+loadA().catch(() => {});
+loadB().catch(() => {});
+loadC().catch(() => {});
+```
+
+### 4. Friendly degradation
+
+Do not dump raw `TypeError: Failed to fetch` or `HTTP 403` to end users. Map abort → timeout message, 403 → rate-limit / auth message, network → retry later.
+
+### 5. Prefer authenticated or cached paths when possible
+
+For GitHub data on static sites: build-time fetch, or a tiny proxy, beats browser-anonymous spam against the 60/hour ceiling.
+
+## Verification
+
+- Kill network mid-load: page still shows other widgets
+- Force 403: UI shows a calm fallback, not a blank page
+- Confirm timeouts fire under ~timeoutMs


### PR DESCRIPTION
## Summary
English translations for three Chinese contrib lessons (github auth / credentials / static API fault tolerance).

## Note on #309 AC
In-agent access to “top 10 by search hit telemetry” was not available; selected high-value CN lessons in github/auth domain instead. Happy to expand with telemetry list if maintainers share it.

/claim #309
/try