### PR TITLE
fix(ci): lesson quality total_score 0-1 for CI threshold

### DIFF
--- a/.github/workflows/lesson-quality.yml
+++ b/.github/workflows/lesson-quality.yml
@@ -43,7 +43,7 @@ jobs:
 
           for file in ${{ steps.changed.outputs.all_changed_files }}; do
             if [[ "$file" == lessons/*.md ]]; then
-              SCORE=$(python3 scripts/quality_scorer.py "$file" --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('total_score', 0))" 2>/dev/null || echo "0")
+              SCORE=$(python3 scripts/quality_scorer.py "$file" --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('total_score') if d.get('total_score') is not None else (d.get('lessons') or [{}])[0].get('total_score') or (d.get('lessons') or [{}])[0].get('score',0)/100)" 2>/dev/null || echo "0")
               SCORES="$SCORES\n$file: $SCORE"
               if (( $(echo "$SCORE < $THRESHOLD" | bc -l) )); then
                 PASS=false

--- a/scripts/quality_scorer.py
+++ b/scripts/quality_scorer.py
@@ -526,14 +526,22 @@ def main():
 
     # Output
     if json_mode or ci_mode:
+        avg = round(sum(r.get("score", 0) for r in results) / len(results), 1)
+        # CI workflow (.github/workflows/lesson-quality.yml) reads total_score
+        # with threshold 0.5 — it expects a 0..1 value, not the 0..100 rubric.
         output = {
             "total": len(results),
             "passed": sum(1 for r in results if r.get("pass")),
             "failed": sum(1 for r in results if not r.get("pass")),
-            "avg_score": round(sum(r.get("score", 0) for r in results) / len(results), 1),
+            "avg_score": avg,
+            "total_score": round(avg / 100.0, 4),
             "threshold": threshold,
             "lessons": results,
         }
+        # also expose per-lesson total_score for single-file CI extraction
+        for r in results:
+            if isinstance(r, dict) and "score" in r:
+                r["total_score"] = round(float(r.get("score", 0)) / 100.0, 4)
         print(json.dumps(output, indent=2, ensure_ascii=False))
     else:
         # Human-readable report


### PR DESCRIPTION
## Problem
`.github/workflows/lesson-quality.yml` does:
```bash
print(d.get('total_score', 0))  # threshold 0.5
```
but `quality_scorer.py --json` only emitted 0–100 `score` / `avg_score`, so every PR got **0** and failed quality-check (including high-quality lessons scoring 80+ locally).

## Fix
- Emit `total_score = avg/100` (and per-lesson `total_score`)
- Harden CI extraction fallback

This unblocks auto-merge for docs/lesson PRs.

Related open lesson PRs: #554 #555 #556