### PR TITLE
fix(ci): quality-check continue-on-error when fork cannot comment

### DIFF
--- a/.github/workflows/lesson-quality.yml
+++ b/.github/workflows/lesson-quality.yml
@@ -53,9 +53,19 @@ jobs:
 
           echo "scores=$SCORES" >> $GITHUB_OUTPUT
           echo "pass=$PASS" >> $GITHUB_OUTPUT
+          {
+            echo "### Lesson quality"
+            echo "pass=$PASS threshold=$THRESHOLD"
+            echo '```'
+            echo -e "$SCORES"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment on PR
+        # Fork PRs often get HttpError: Resource not accessible by integration
+        # when commenting. Scores still ran; don't fail the check for that.
         if: steps.changed.outputs.any_changed == 'true'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem
Lesson PRs from forks get real scores ≥0.8 then **fail quality-check** because the "Comment on PR" step hits:

`HttpError: Resource not accessible by integration`

That is a permissions issue on fork workflows, not a content failure.

## Fix
- `continue-on-error: true` on the comment step
- Write scores to `$GITHUB_STEP_SUMMARY`

Unblocks open lesson PRs #556 #558.