### PR TITLE
ci: add npm publish workflow for fatal-guard (fixes #582)

### DIFF
--- a/.github/workflows/fatal-guard-publish.yml
+++ b/.github/workflows/fatal-guard-publish.yml
@@ -1,0 +1,36 @@
+name: Publish @misaka-net/fatal-guard
+
+on:
+  push:
+    tags:
+      - "fatal-guard-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/fatal-guard
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub Actions workflow that publishes `@misaka-net/fatal-guard` to npm when a version tag is pushed.

## Trigger

```
on:
  push:
    tags:
      - "fatal-guard-v*"
```

## Steps

1. Checkout code
2. Setup Node.js 20 with npm registry
3. Install dependencies (`npm ci`)
4. Run tests (`npm test`)
5. Publish to npm (`npm publish --access public`)

## Requirements

- Secret `NPM_TOKEN` must be configured in repo settings
- Tag format: `fatal-guard-v*` (e.g., `fatal-guard-v0.2.3`)

## Usage

```bash
# Tag a release
git tag fatal-guard-v0.3.0
git push origin fatal-guard-v0.3.0

# Workflow will auto-publish to npm
```

Closes #582