### PR TITLE
feat: add VS Code extension for lesson search (fixes #317)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,53 @@
+# MisakaNet Lessons — VS Code Extension
+
+Search MisakaNet debugging lessons directly from VS Code.
+
+## Features
+
+- **Command Palette**: Search lessons by keyword (`Cmd+Shift+P` → "Search MisakaNet Lessons")
+- **Sidebar Panel**: Browse lessons by domain
+- **Click to Open**: Click any lesson to open it in the editor
+- **Local Search**: No API needed — searches local lesson files
+
+## Installation
+
+### From VS Code Marketplace
+1. Open VS Code
+2. Go to Extensions (Cmd+Shift+X)
+3. Search "MisakaNet Lessons"
+4. Click Install
+
+### From Source
+```bash
+cd vscode-extension
+npm install
+npm run compile
+# Then press F5 in VS Code to launch Extension Development Host
+```
+
+## Usage
+
+### Search Lessons
+1. Open Command Palette (Cmd+Shift+P)
+2. Type "Search MisakaNet Lessons"
+3. Enter your search query (e.g., "pip timeout", "database locked")
+4. Click a result to open the lesson
+
+### Browse by Domain
+1. Click the MisakaNet icon in the activity bar
+2. Expand a domain folder
+3. Click any lesson to open it
+
+### List All Lessons
+1. Open Command Palette (Cmd+Shift+P)
+2. Type "List MisakaNet Lessons"
+3. Browse and select a lesson
+
+## Requirements
+
+- VS Code 1.80+
+- MisakaNet repo cloned locally (with `lessons/` directory)
+
+## License
+
+MIT

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "misakanet-lessons",
+  "displayName": "MisakaNet Lessons",
+  "description": "Search MisakaNet debugging lessons from VS Code",
+  "version": "0.1.0",
+  "publisher": "misakanet",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "misakanet.search",
+        "title": "Search MisakaNet Lessons"
+      },
+      {
+        "command": "misakanet.list",
+        "title": "List MisakaNet Lessons"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "misakanet",
+          "title": "MisakaNet",
+          "icon": "$(book)"
+        }
+      ]
+    },
+    "views": {
+      "misakanet": [
+        {
+          "id": "misakanet-lessons",
+          "name": "Lessons"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.80.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,245 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Lesson data structure
+interface Lesson {
+    title: string;
+    domain: string;
+    tags: string[];
+    status: string;
+    path: string;
+    content: string;
+}
+
+// Tree data provider for sidebar
+class LessonTreeProvider implements vscode.TreeDataProvider<LessonItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<LessonItem | undefined | null | void> = new vscode.EventEmitter<LessonItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<LessonItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+    private lessons: Lesson[] = [];
+    private repoRoot: string;
+
+    constructor(repoRoot: string) {
+        this.repoRoot = repoRoot;
+        this.loadLessons();
+    }
+
+    refresh(): void {
+        this.loadLessons();
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: LessonItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: LessonItem): Thenable<LessonItem[]> {
+        if (!element) {
+            // Root level - show domains
+            const domains = [...new Set(this.lessons.map(l => l.domain || 'uncategorized'))];
+            return Promise.resolve(domains.map(d => new LessonItem(
+                d,
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'domain'
+            )));
+        }
+
+        if (element.contextValue === 'domain') {
+            // Show lessons in this domain
+            const domainLessons = this.lessons.filter(l => (l.domain || 'uncategorized') === element.label);
+            return Promise.resolve(domainLessons.map(l => new LessonItem(
+                l.title,
+                vscode.TreeItemCollapsibleState.None,
+                'lesson',
+                l
+            )));
+        }
+
+        return Promise.resolve([]);
+    }
+
+    private loadLessons(): void {
+        const lessonsDir = path.join(this.repoRoot, 'lessons');
+        this.lessons = [];
+
+        for (const subdir of ['core', 'contrib']) {
+            const dir = path.join(lessonsDir, subdir);
+            if (!fs.existsSync(dir)) continue;
+
+            const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') && f !== 'index.md');
+            for (const file of files) {
+                const filePath = path.join(dir, file);
+                const content = fs.readFileSync(filePath, 'utf-8');
+
+                // Parse frontmatter
+                const fmMatch = content.match(/^---\s*\n(.*?)\n---/s);
+                if (!fmMatch) continue;
+
+                const fm: any = {};
+                for (const line of fmMatch[1].split('\n')) {
+                    const colonIdx = line.indexOf(':');
+                    if (colonIdx > 0) {
+                        const key = line.substring(0, colonIdx).trim();
+                        const val = line.substring(colonIdx + 1).trim().replace(/^["']|["']$/g, '');
+                        fm[key] = val;
+                    }
+                }
+
+                this.lessons.push({
+                    title: fm.title || file.replace('.md', ''),
+                    domain: fm.domain || '',
+                    tags: fm.tags ? (typeof fm.tags === 'string' ? fm.tags.split(',').map((t: string) => t.trim()) : fm.tags) : [],
+                    status: fm.status || '',
+                    path: filePath,
+                    content: content.substring(fmMatch[0].length).trim().substring(0, 200),
+                });
+            }
+        }
+    }
+
+    search(query: string): Lesson[] {
+        const q = query.toLowerCase();
+        return this.lessons.filter(l =>
+            l.title.toLowerCase().includes(q) ||
+            l.domain.toLowerCase().includes(q) ||
+            l.tags.some(t => t.toLowerCase().includes(q)) ||
+            l.content.toLowerCase().includes(q)
+        );
+    }
+}
+
+// Tree item
+class LessonItem extends vscode.TreeItem {
+    public lesson?: Lesson;
+
+    constructor(
+        label: string,
+        collapsibleState: vscode.TreeItemCollapsibleState,
+        contextValue: string,
+        lesson?: Lesson
+    ) {
+        super(label, collapsibleState);
+        this.contextValue = contextValue;
+        this.lesson = lesson;
+
+        if (contextValue === 'lesson' && lesson) {
+            this.description = lesson.domain;
+            this.tooltip = lesson.title;
+            this.command = {
+                command: 'misakanet.openLesson',
+                title: 'Open Lesson',
+                arguments: [lesson]
+            };
+            this.iconPath = new vscode.ThemeIcon('file-text');
+        } else if (contextValue === 'domain') {
+            this.iconPath = new vscode.ThemeIcon('folder');
+        }
+    }
+}
+
+// Extension activation
+export function activate(context: vscode.ExtensionContext) {
+    // Find repo root
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    let repoRoot = '';
+
+    if (workspaceFolders) {
+        // Look for lessons directory
+        for (const folder of workspaceFolders) {
+            const lessonsDir = path.join(folder.uri.fsPath, 'lessons');
+            if (fs.existsSync(lessonsDir)) {
+                repoRoot = folder.uri.fsPath;
+                break;
+            }
+        }
+    }
+
+    if (!repoRoot) {
+        vscode.window.showWarningMessage('MisakaNet: No lessons directory found in workspace');
+        return;
+    }
+
+    // Create tree provider
+    const treeProvider = new LessonTreeProvider(repoRoot);
+    vscode.window.registerTreeDataProvider('misakanet-lessons', treeProvider);
+
+    // Search command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('misakanet.search', async () => {
+            const query = await vscode.window.showInputBox({
+                prompt: 'Search MisakaNet lessons',
+                placeHolder: 'e.g. pip timeout, database locked, DCO',
+            });
+
+            if (!query) return;
+
+            const results = treeProvider.search(query);
+            if (results.length === 0) {
+                vscode.window.showInformationMessage(`No lessons found for "${query}"`);
+                return;
+            }
+
+            // Show results in quick pick
+            const items = results.map(l => ({
+                label: l.title,
+                description: l.domain,
+                detail: l.tags.join(', '),
+                lesson: l,
+            }));
+
+            const selected = await vscode.window.showQuickPick(items, {
+                placeHolder: `${results.length} lessons found`,
+            });
+
+            if (selected) {
+                openLesson(selected.lesson);
+            }
+        })
+    );
+
+    // List command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('misakanet.list', async () => {
+            const lessons = treeProvider.search('');
+            const items = lessons.map(l => ({
+                label: l.title,
+                description: l.domain,
+                detail: l.tags.join(', '),
+                lesson: l,
+            }));
+
+            const selected = await vscode.window.showQuickPick(items, {
+                placeHolder: `${lessons.length} lessons available`,
+            });
+
+            if (selected) {
+                openLesson(selected.lesson);
+            }
+        })
+    );
+
+    // Open lesson command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('misakanet.openLesson', (lesson: Lesson) => {
+            openLesson(lesson);
+        })
+    );
+
+    // Refresh command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('misakanet.refresh', () => {
+            treeProvider.refresh();
+        })
+    );
+
+    vscode.window.showInformationMessage(`MisakaNet: ${treeProvider.search('').length} lessons loaded`);
+}
+
+function openLesson(lesson: Lesson) {
+    vscode.workspace.openTextDocument(lesson.path).then(doc => {
+        vscode.window.showTextDocument(doc);
+    });
+}
+
+export function deactivate() {}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2020",
+        "outDir": "out",
+        "lib": ["ES2020"],
+        "sourceMap": true,
+        "rootDir": "src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary

VS Code extension for searching MisakaNet lessons locally.

### Features
- **Command palette**: Search MisakaNet Lessons
- **Sidebar panel**: browse by domain
- **Click to open**: lesson in editor
- **Local search**: no API needed, reads from lessons/ directory

### Files
- `vscode-extension/package.json` — Extension manifest
- `vscode-extension/src/extension.ts` — Main extension code
- `vscode-extension/tsconfig.json` — TypeScript config
- `vscode-extension/README.md` — Usage guide

### Acceptance Criteria
- [x] Command palette: Search MisakaNet Lessons
- [x] Sidebar panel: browse by domain
- [x] Click to open lesson in editor
- [x] Local search (no API needed)

Fixes #317