### PR TITLE
feat(intake): add POST /api/intake endpoint for MCP/agent/sandbox feedback

### DIFF
--- a/docs/email-intake.md
+++ b/docs/email-intake.md
@@ -102,6 +102,52 @@ For when you want to register as a MisakaNet node.
 
 ---
 
+
+---
+
+## curl / API Intake (No Email, No GitHub)
+
+For MCP servers, agents, CI pipelines, and sandbox environments — the lowest-friction channel.
+
+**Endpoint:** `POST https://misakanet.org/api/intake`
+
+**Example:**
+```bash
+curl -X POST https://misakanet.org/api/intake \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "diagnostic",
+    "source": "curl",
+    "message": "pip install times out behind corporate proxy",
+    "context": {"tool": "fatal-guard", "version": "0.3.0", "platform": "linux"},
+    "consent": "private_only"
+  }'
+```
+
+**Fields:**
+
+| Field | Required | Values |
+|-------|----------|--------|
+| `type` | yes | `diagnostic`, `lesson_candidate`, `friction`, `bug`, `node_join` |
+| `source` | yes | `mcp`, `curl`, `frontend`, `agent` |
+| `message` | yes | Short description (max 2000 chars, secrets auto-redacted) |
+| `context` | no | JSON object with tool/version/platform metadata |
+| `lesson_id` | no | Related lesson ID |
+| `contact` | no | Optional contact info |
+| `consent` | no | `private_only` (default) or `allow_anonymous_publish` |
+
+**Security:**
+- IP rate limited: 10 requests/hour
+- Max body: 8KB
+- Secrets auto-redacted (API keys, tokens, private keys, passwords)
+- Default consent: `private_only` — nothing is published without explicit opt-in
+- No auto GitHub issue creation, no link execution
+
+**Response:**
+```json
+{"accepted": true, "intake_id": "uuid", "consent": "private_only"}
+```
+
 ## Privacy & Consent
 
 - **We never publish your name, email, or company without permission**

--- a/scripts/intake_digest.py
+++ b/scripts/intake_digest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Pull and classify intake submissions from KV export or local JSONL.
+
+Usage:
+    python3 scripts/intake_digest.py [--input data/intake-export.jsonl] [--top 20]
+
+If no input file, prints usage. Designed to run against a KV export
+or the local data/search-feedback.jsonl for testing.
+"""
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def load_intakes(path: Path) -> list[dict]:
+    """Load intake records from JSONL file."""
+    records = []
+    if not path.exists():
+        print(f"Error: {path} not found", file=sys.stderr)
+        sys.exit(1)
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def classify(records: list[dict]) -> dict:
+    """Classify intakes by type and source."""
+    by_type = Counter(r.get("type", "unknown") for r in records)
+    by_source = Counter(r.get("source", "unknown") for r in records)
+    by_consent = Counter(r.get("consent", "private_only") for r in records)
+    return {
+        "total": len(records),
+        "by_type": dict(by_type.most_common()),
+        "by_source": dict(by_source.most_common()),
+        "by_consent": dict(by_consent.most_common()),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Intake digest — pull and classify submissions")
+    parser.add_argument("--input", "-i", default="data/intake-export.jsonl",
+                        help="Path to JSONL intake export (default: data/intake-export.jsonl)")
+    parser.add_argument("--top", type=int, default=20, help="Show top N recent entries")
+    args = parser.parse_args()
+
+    path = Path(args.input)
+    records = load_intakes(path)
+
+    if not records:
+        print("No intake records found.")
+        return
+
+    stats = classify(records)
+    print(f"\n{'='*50}")
+    print(f"  Intake Digest — {stats['total']} records")
+    print(f"{'='*50}")
+    print(f"\n  By type:")
+    for t, c in stats["by_type"].items():
+        print(f"    {t:<20} {c}")
+    print(f"\n  By source:")
+    for s, c in stats["by_source"].items():
+        print(f"    {s:<20} {c}")
+    print(f"\n  By consent:")
+    for cs, c in stats["by_consent"].items():
+        print(f"    {cs:<25} {c}")
+
+    print(f"\n  Recent ({min(args.top, len(records))}):")
+    print(f"  {'ID':<10} {'Type':<18} {'Source':<10} {'Message'}")
+    print(f"  {'-'*10} {'-'*18} {'-'*10} {'-'*40}")
+    for r in records[-args.top:]:
+        rid = r.get("intakeId", r.get("id", "?"))[:8]
+        rtype = r.get("type", "?")[:16]
+        rsrc = r.get("source", "?")[:8]
+        msg = r.get("message", "")[:50]
+        print(f"  {rid:<10} {rtype:<18} {rsrc:<10} {msg}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -243,6 +243,78 @@ export default {
       return jsonResponse({ accepted: accepted.length });
     }
 
+
+    // POST /api/intake — general-purpose intake for MCP, agents, sandbox (Issue #589)
+    if (request.method === "POST" && url.pathname === "/api/intake") {
+      if (!env.MISAKANET_KV) return jsonResponse({ error: "KV not configured" }, 503);
+
+      // Max body 8KB
+      const contentLength = parseInt(request.headers.get("content-length") || "0");
+      if (contentLength > 8192) return jsonResponse({ error: "Request too large (max 8KB)" }, 413);
+
+      // IP rate limit: 10 per hour
+      const intakeIp = request.headers.get("CF-Connecting-IP") || "unknown";
+      const intakeRateKey = `rate:intake:${intakeIp}`;
+      const intakeRateRaw = await env.MISAKANET_KV.get(intakeRateKey, "text");
+      const intakeRateCount = intakeRateRaw ? parseInt(intakeRateRaw, 10) || 0 : 0;
+      if (intakeRateCount >= 10) return jsonResponse({ error: "Rate limited (10/hour). Try again later." }, 429);
+      await env.MISAKANET_KV.put(intakeRateKey, String(intakeRateCount + 1), { expirationTtl: 3600 });
+
+      let intakeBody;
+      try { intakeBody = await request.json(); } catch { return jsonResponse({ error: "Invalid JSON" }, 400); }
+
+      // Field whitelist + validation
+      const VALID_TYPES = ["diagnostic", "lesson_candidate", "friction", "bug", "node_join"];
+      const VALID_SOURCES = ["mcp", "curl", "frontend", "agent"];
+      const VALID_CONSENT = ["private_only", "allow_anonymous_publish"];
+
+      const { type, source, message, context, lesson_id, contact, consent, ts } = intakeBody || {};
+      if (!type || !VALID_TYPES.includes(type)) return jsonResponse({ error: "Invalid or missing 'type'. Must be one of: " + VALID_TYPES.join(", ") }, 400);
+      if (!source || !VALID_SOURCES.includes(source)) return jsonResponse({ error: "Invalid or missing 'source'. Must be one of: " + VALID_SOURCES.join(", ") }, 400);
+      if (!message || typeof message !== "string" || !message.trim()) return jsonResponse({ error: "Missing 'message'" }, 400);
+
+      // Secret redaction (reuse fatal-guard patterns)
+      const REDACT_PATTERNS = [
+        /(?:sk|pk|rk|ak)[_-][a-zA-Z0-9]{20,}/g,           // API keys
+        /(?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,}/g,      // GitHub tokens
+        /xox[bpras]-[a-zA-Z0-9\-]{10,}/g,                 // Slack tokens
+        /-----BEGIN (?:RSA |EC )?PRIVATE KEY-----[\s\S]*?-----END/g,  // Private keys
+        /(?:password|passwd|secret|token)\s*[:=]\s*\S+/gi,  // key=value secrets
+        /\b(?:\d[ -]*?){13,16}\b/g,                       // Credit card numbers
+      ];
+      function redactSecrets(text) {
+        let result = String(text).slice(0, 2000);
+        for (const pat of REDACT_PATTERNS) {
+          result = result.replace(pat, "[REDACTED]");
+        }
+        return result;
+      }
+
+      const intakeId = crypto.randomUUID();
+      const record = {
+        intakeId,
+        type,
+        source,
+        message: redactSecrets(message),
+        context: context ? JSON.parse(redactSecrets(JSON.stringify(context)).slice(0, 1000)) : {},
+        lesson_id: lesson_id ? String(lesson_id).slice(0, 200) : null,
+        contact: contact ? String(contact).slice(0, 200) : null,
+        consent: VALID_CONSENT.includes(consent) ? consent : "private_only",
+        ts: ts || new Date().toISOString(),
+        received_at: new Date().toISOString(),
+        ip_hash: intakeIp.slice(0, 8),  // partial IP for rate debugging only
+      };
+
+      await env.MISAKANET_KV.put(
+        `intake:${intakeId}`,
+        JSON.stringify(record),
+        { expirationTtl: 7776000 },  // 90 days
+      );
+
+      console.log(`Intake ${intakeId}: type=${type} source=${source}`);
+      return jsonResponse({ accepted: true, intake_id: intakeId, consent: record.consent });
+    }
+
     // GET /api/github/* - authenticated GitHub API proxy for the org frontend.
     // Keep this before the HTML landing page; otherwise the frontend receives
     // HTML and fails with: Unexpected token '<' while parsing JSON.


### PR DESCRIPTION
## What this does

Adds a general-purpose `POST /api/intake` endpoint to the Cloudflare Worker for MCP servers, agents, CI pipelines, and sandbox environments to submit feedback without needing email or GitHub.

## Deliverables

- [x] Extend `workers/register-proxy-sw.js` with `/api/intake` endpoint
- [x] Add `scripts/intake_digest.py` to pull and classify intakes
- [x] Update `docs/email-intake.md` to document curl intake option

## How to use

```bash
curl -X POST https://misakanet.org/api/intake \
  -H "Content-Type: application/json" \
  -d '{"type":"diagnostic","source":"curl","message":"test intake","consent":"private_only"}'
```

## Security checklist

- [x] IP rate limit (10/hour via KV)
- [x] Max body 8KB
- [x] Field whitelist (type, source, consent validated against allowed values)
- [x] Secret redaction on message/context (API keys, GitHub tokens, Slack tokens, private keys, passwords, credit cards)
- [x] Default `private_only` consent
- [x] No auto GitHub issue creation
- [x] No auto public lesson publishing
- [x] No attachment/link execution

## Worker does 4 things

1. **Validate** — type/source/message required, whitelist enforced
2. **Redact** — secrets stripped from message and context before storage
3. **Rate limit** — IP-based, 10/hour, KV-backed
4. **Store** — KV with 90-day TTL, keyed by UUID

## Testing

```bash
# Valid request
curl -X POST http://localhost:8787/api/intake \
  -H "Content-Type: application/json" \
  -d '{"type":"bug","source":"agent","message":"search returns 0 for pip proxy"}'

# Rate limit test (11th request should 429)
for i in $(seq 1 11); do
  curl -s -X POST http://localhost:8787/api/intake \
    -H "Content-Type: application/json" \
    -d '{"type":"friction","source":"curl","message":"test '$i'"}' | jq .
done

# Digest
python3 scripts/intake_digest.py --input data/intake-export.jsonl
```

Closes #589
