### PR TITLE
feat(integrations): VS Code extension + shell plugin for MisakaNet search

### DIFF
--- a/docs/integrations/search-plugins.md
+++ b/docs/integrations/search-plugins.md
@@ -1,0 +1,47 @@
+# Search Plugins & Integrations
+
+Search MisakaNet from your favorite tools.
+
+## Available Integrations
+
+| Tool | Location | Type |
+|------|----------|------|
+| VS Code | `integrations/vscode-misakanet/` | Extension |
+| Shell (Bash/Zsh) | `integrations/shell/misaka.sh` | Function + completion |
+| Aider | via shell integration | Custom command |
+
+## VS Code Extension
+
+**Shortcut:** `Ctrl+Shift+M` (Cmd+Shift+M on Mac)
+
+1. Clone MisakaNet and install `misakanet-core`
+2. Open VS Code → Extensions → Install from VSIX (or symlink)
+3. Set `misakanet.repoPath` if not auto-detected
+4. Press `Ctrl+Shift+M`, type your query, click a result to open
+
+## Shell
+
+```bash
+source integrations/shell/misaka.sh
+misaka "pip timeout" --top 5
+```
+
+## Building Your Own
+
+Any tool that can call `python3 search_knowledge.py "<query>" --json` can integrate:
+
+```python
+import subprocess, json
+
+def search_misakanet(query: str, top_k: int = 5) -> list[dict]:
+    result = subprocess.run(
+        ["python3", "search_knowledge.py", query, "--json", "--top", str(top_k)],
+        capture_output=True, text=True, cwd="/path/to/MisakaNet"
+    )
+    return json.loads(result.stdout)
+```
+
+## Related Issues
+
+- #268 — Build a MisakaNet search plugin for your AI tool
+- #318 — Cursor integration (MCP server)

--- a/integrations/shell/README.md
+++ b/integrations/shell/README.md
@@ -1,0 +1,29 @@
+# MisakaNet Shell Integration
+
+## Install
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc:
+source /path/to/MisakaNet/integrations/shell/misaka.sh
+
+# Or set custom repo path:
+export MISAKA_REPO=/path/to/MisakaNet
+source /path/to/MisakaNet/integrations/shell/misaka.sh
+```
+
+## Usage
+
+```bash
+misaka "pip timeout"              # Search lessons
+misaka "docker M1" --top 3        # Top 3 results
+misaka "git rebase" --json        # JSON output (pipe to jq)
+misaka "kubernetes" --domain k8s  # Filter by domain
+```
+
+## Aider Integration
+
+```yaml
+# .aider.conf.yml
+read:
+  - $(misaka "current error" --json --top 1 | jq -r '.[0].path // empty')
+```

--- a/integrations/shell/misaka.sh
+++ b/integrations/shell/misaka.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# MisakaNet shell integration — add to ~/.bashrc or ~/.zshrc
+# Usage: misaka "pip timeout" [--top 5] [--json]
+
+MISAKA_REPO="${MISAKA_REPO:-$HOME/MisakaNet}"
+
+misaka() {
+  if [ ! -d "$MISAKA_REPO" ]; then
+    echo "MisakaNet not found at $MISAKA_REPO"
+    echo "Set MISAKA_REPO or clone: git clone https://github.com/Ikalus1988/MisakaNet.git ~/MisakaNet"
+    return 1
+  fi
+
+  if [ $# -eq 0 ]; then
+    echo "Usage: misaka <query> [--top N] [--json] [--broad] [--domain X]"
+    echo "Examples:"
+    echo "  misaka 'pip timeout'"
+    echo "  misaka 'docker M1' --top 3"
+    echo "  misaka 'git rebase' --json | jq '.[0].title'"
+    return 0
+  fi
+
+  cd "$MISAKA_REPO" && python3 search_knowledge.py "$@"
+}
+
+# Aider integration: use as custom command
+# In .aider.conf.yml:
+#   read:
+#     - $(misaka "current error" --json --top 1 | jq -r '.[0].path // empty')
+
+# Completion (bash)
+_misaka_completions() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "--top --json --broad --domain --lessons --ref --titles --explain --verbose" -- "$cur"))
+}
+complete -F _misaka_completions misaka

--- a/integrations/vscode-misakanet/README.md
+++ b/integrations/vscode-misakanet/README.md
@@ -1,0 +1,25 @@
+# MisakaNet Search — VS Code Extension
+
+Search the MisakaNet knowledge base without leaving VS Code.
+
+## Features
+
+- `Ctrl+Shift+M` (Cmd+Shift+M on Mac) to search
+- Results show title, domain, score, and preview
+- Click a result to open the full lesson file
+
+## Setup
+
+1. Clone MisakaNet: `git clone https://github.com/Ikalus1988/MisakaNet.git`
+2. Install dependency: `cd MisakaNet && pip install misakanet-core`
+3. Install this extension (or symlink into `~/.vscode/extensions/`)
+4. Set `misakanet.repoPath` in VS Code settings if not auto-detected
+
+## Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `misakanet.repoPath` | auto-detect | Path to MisakaNet repo |
+| `misakanet.topResults` | 5 | Number of results |
+
+## Part of MisakaNet Bounty #268

--- a/integrations/vscode-misakanet/package.json
+++ b/integrations/vscode-misakanet/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "misakanet-search",
+  "displayName": "MisakaNet Search",
+  "description": "Search MisakaNet knowledge base from VS Code",
+  "version": "0.1.0",
+  "publisher": "gpcaom-svg",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [],
+  "main": "./src/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "misakanet.search",
+        "title": "MisakaNet: Search Lessons"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "misakanet.search",
+        "key": "ctrl+shift+m",
+        "mac": "cmd+shift+m"
+      }
+    ],
+    "configuration": {
+      "title": "MisakaNet",
+      "properties": {
+        "misakanet.repoPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to MisakaNet repo (auto-detected if empty)"
+        },
+        "misakanet.topResults": {
+          "type": "number",
+          "default": 5,
+          "description": "Number of results to show"
+        }
+      }
+    }
+  }
+}

--- a/integrations/vscode-misakanet/src/extension.js
+++ b/integrations/vscode-misakanet/src/extension.js
@@ -1,0 +1,108 @@
+// MisakaNet Search — VS Code Extension
+// Searches the MisakaNet knowledge base and shows results in a quick pick.
+
+const vscode = require("vscode");
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+function findRepoPath(configPath) {
+  if (configPath && fs.existsSync(configPath)) return configPath;
+  // Common locations
+  const candidates = [
+    path.join(require("os").homedir(), "MisakaNet"),
+    path.join(require("os").homedir(), "Desktop", "MisakaNet"),
+    path.join(require("os").homedir(), "projects", "MisakaNet"),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(path.join(c, "search_knowledge.py"))) return c;
+  }
+  return null;
+}
+
+function searchMisakaNet(repoPath, query, topK) {
+  const script = path.join(repoPath, "search_knowledge.py");
+  const cmd = `python3 "${script}" "${query.replace(/"/g, '\\"')}" --json --top ${topK}`;
+  try {
+    const output = execSync(cmd, {
+      cwd: repoPath,
+      encoding: "utf-8",
+      timeout: 15000,
+      shell: true,
+    });
+    return JSON.parse(output);
+  } catch (e) {
+    // Fallback: try python instead of python3
+    try {
+      const cmd2 = `python "${script}" "${query.replace(/"/g, '\\"')}" --json --top ${topK}`;
+      const output = execSync(cmd2, { cwd: repoPath, encoding: "utf-8", timeout: 15000, shell: true });
+      return JSON.parse(output);
+    } catch (e2) {
+      return null;
+    }
+  }
+}
+
+function activate(context) {
+  const disposable = vscode.commands.registerCommand("misakanet.search", async () => {
+    const config = vscode.workspace.getConfiguration("misakanet");
+    const repoPath = findRepoPath(config.get("repoPath", ""));
+
+    if (!repoPath) {
+      vscode.window.showErrorMessage(
+        "MisakaNet repo not found. Set misakanet.repoPath in settings."
+      );
+      return;
+    }
+
+    const query = await vscode.window.showInputBox({
+      prompt: "Search MisakaNet knowledge base",
+      placeHolder: "e.g., pip timeout, docker M1, git rebase",
+    });
+
+    if (!query) return;
+
+    const topK = config.get("topResults", 5);
+
+    vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title: "Searching MisakaNet..." },
+      () => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            const results = searchMisakaNet(repoPath, query, topK);
+            resolve(results);
+          }, 100);
+        });
+      }
+    ).then((results) => {
+      if (!results || results.length === 0) {
+        vscode.window.showInformationMessage(`No MisakaNet results for "${query}"`);
+        return;
+      }
+
+      const items = results.map((r) => ({
+        label: `$(book) ${r.title}`,
+        description: `[${r.domain || "?"}] score: ${r.score}`,
+        detail: r.preview || r.match_reason || "",
+        filePath: r.path,
+      }));
+
+      vscode.window.showQuickPick(items, {
+        placeHolder: `${results.length} result(s) for "${query}"`,
+      }).then((selected) => {
+        if (selected && selected.filePath) {
+          const fullPath = path.join(repoPath, selected.filePath);
+          if (fs.existsSync(fullPath)) {
+            vscode.window.showTextDocument(vscode.Uri.file(fullPath));
+          }
+        }
+      });
+    });
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };


### PR DESCRIPTION
## What this does

Adds search integrations for MisakaNet — VS Code extension + shell function — so users can search the knowledge base from within their AI/coding tools.

## Integrations included

| Tool | Location | Usage |
|------|----------|-------|
| **VS Code** | `integrations/vscode-misakanet/` | `Ctrl+Shift+M` → type query → click result |
| **Shell (Bash/Zsh)** | `integrations/shell/misaka.sh` | `misaka "pip timeout" --top 5` |
| **Aider** | via shell | Custom command in `.aider.conf.yml` |

## VS Code Extension

- Command palette: "MisakaNet: Search Lessons"
- Keyboard shortcut: `Ctrl+Shift+M`
- Results in quick pick with title, domain, score
- Click to open full lesson file
- Auto-detects repo path (or configure `misakanet.repoPath`)

## Shell

```bash
source integrations/shell/misaka.sh
misaka "docker M1" --top 3
misaka "git rebase" --json | jq '.[0].title'
```

Includes bash tab completion for flags.

## Acceptance Criteria

- [x] User can search MisakaNet from within their AI tool (VS Code)
- [x] Results show lesson title, score, and relevant snippet
- [x] Installation documented (README per integration + docs/integrations/)
- [x] Shell alias for terminal users
- [x] Aider integration example

## Documentation

- `integrations/vscode-misakanet/README.md`
- `integrations/shell/README.md`
- `docs/integrations/search-plugins.md` (overview + "build your own" guide)

Closes #268
