### PR TITLE
feat(mcp): MCP server + .cursorrules for Cursor/Claude integration

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,29 @@
+# MisakaNet Cursor Rules
+
+## Knowledge Base Integration
+
+When debugging or solving technical problems, ALWAYS search MisakaNet first:
+
+1. Use the `misakanet_search` MCP tool with the error message or topic
+2. If results found, read the top lesson with `misakanet_read_lesson`
+3. Apply the fix from the lesson
+4. If no results, proceed with normal debugging
+
+## Search Strategy
+
+- For errors: search the exact error message first, then keywords
+- For topics: search tool name + symptom (e.g., "pip timeout proxy")
+- Use `misakanet_list_domains` to discover available knowledge areas
+
+## Response Format
+
+When a MisakaNet lesson solves the problem:
+- Cite the lesson title and path
+- Summarize the fix in 2-3 sentences
+- Offer to show full lesson content
+
+## Auto-suggest
+
+When the user shares an error message or asks "how to fix X":
+- Proactively search MisakaNet before suggesting generic solutions
+- Prefer battle-tested lessons over generic advice

--- a/docs/integrations/cursor-mcp-setup.md
+++ b/docs/integrations/cursor-mcp-setup.md
@@ -1,0 +1,70 @@
+# Cursor / MCP Integration Setup
+
+## Quick Start
+
+### Option A: MCP Server (recommended)
+
+Add to your Cursor MCP config (Settings → MCP → Add Server):
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "command": "python3",
+      "args": ["/path/to/MisakaNet/integrations/mcp-server/server.py"]
+    }
+  }
+}
+```
+
+Or copy `integrations/mcp-server/cursor_mcp.json` to your project's `.cursor/mcp.json`.
+
+### Option B: .cursorrules
+
+Copy `.cursorrules` from the MisakaNet repo root to your project. This instructs
+Cursor to search MisakaNet when debugging (requires MCP server active).
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `misakanet_search` | Search lessons by query, returns ranked results |
+| `misakanet_read_lesson` | Read full lesson content by path |
+| `misakanet_list_domains` | List available knowledge domains |
+
+## How It Works
+
+```
+Cursor → MCP (stdio JSON-RPC) → server.py → search_knowledge.py → results
+```
+
+The MCP server wraps `search_knowledge.py --json` and exposes it as tools.
+No external dependencies beyond Python 3.10+ and misakanet-core.
+
+## Auto-suggest Behavior
+
+With `.cursorrules` active, Cursor will:
+1. Detect error messages in your conversation
+2. Proactively search MisakaNet for matching lessons
+3. Suggest battle-tested fixes before generic advice
+
+## Claude Desktop
+
+Same MCP config works in `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "command": "python3",
+      "args": ["/path/to/MisakaNet/integrations/mcp-server/server.py"]
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+- **"python3 not found"**: Use full path or `python` instead
+- **No results**: Ensure `misakanet-core` is installed (`pip install misakanet-core`)
+- **Timeout**: Large repos may need >15s; adjust timeout in server.py

--- a/integrations/mcp-server/README.md
+++ b/integrations/mcp-server/README.md
@@ -1,0 +1,30 @@
+# MisakaNet MCP Server
+
+A Model Context Protocol server that exposes MisakaNet lesson search to AI tools.
+
+## Compatible Clients
+
+- Cursor (via MCP settings)
+- Claude Desktop (via claude_desktop_config.json)
+- Continue.dev (via MCP config)
+- Any MCP-compatible client
+
+## Run
+
+```bash
+python3 integrations/mcp-server/server.py
+```
+
+The server communicates via stdio (JSON-RPC). It does not listen on a port.
+
+## Tools
+
+- `misakanet_search(query, top_k, domain)` — search lessons
+- `misakanet_read_lesson(path)` — read full lesson
+- `misakanet_list_domains()` — list knowledge areas
+
+## Requirements
+
+- Python 3.10+
+- misakanet-core (`pip install misakanet-core`)
+- MisakaNet repo cloned locally

--- a/integrations/mcp-server/cursor_mcp.json
+++ b/integrations/mcp-server/cursor_mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "misakanet": {
+      "command": "python3",
+      "args": [
+        "integrations/mcp-server/server.py"
+      ],
+      "cwd": "."
+    }
+  }
+}

--- a/integrations/mcp-server/server.py
+++ b/integrations/mcp-server/server.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""MisakaNet MCP Server — exposes lesson search as an MCP tool.
+
+Works with Cursor, Claude Desktop, Continue.dev, and any MCP-compatible client.
+
+Usage:
+    python3 integrations/mcp-server/server.py
+
+MCP Config (cursor_mcp.json or claude_desktop_config.json):
+    {
+      "mcpServers": {
+        "misakanet": {
+          "command": "python3",
+          "args": ["/path/to/MisakaNet/integrations/mcp-server/server.py"]
+        }
+      }
+    }
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SEARCH_SCRIPT = REPO_ROOT / "search_knowledge.py"
+
+
+def search_lessons(query: str, top_k: int = 5, domain: str = "") -> list[dict]:
+    """Search MisakaNet knowledge base."""
+    cmd = [sys.executable, str(SEARCH_SCRIPT), query, "--json", "--top", str(top_k)]
+    if domain:
+        cmd.extend(["--domain", domain])
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT)
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        pass
+    return []
+
+
+def get_lesson_content(path: str) -> str:
+    """Read full lesson content by relative path."""
+    full = REPO_ROOT / path
+    if full.exists() and full.suffix == ".md":
+        return full.read_text(encoding="utf-8")[:5000]
+    return f"Lesson not found: {path}"
+
+
+def list_domains() -> list[str]:
+    """List available knowledge domains."""
+    lessons_dir = REPO_ROOT / "lessons"
+    if not lessons_dir.exists():
+        return []
+    domains = set()
+    for f in lessons_dir.rglob("*.md"):
+        rel = f.relative_to(lessons_dir)
+        if len(rel.parts) > 1:
+            domains.add(rel.parts[0])
+    return sorted(domains)
+
+
+# ── MCP Protocol (stdio JSON-RPC) ──
+
+TOOLS = [
+    {
+        "name": "misakanet_search",
+        "description": "Search MisakaNet knowledge base for debugging lessons, fixes, and technical references. Returns ranked results with title, score, domain, and preview.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query (error message, topic, tool name)"},
+                "top_k": {"type": "integer", "description": "Number of results (default 5)", "default": 5},
+                "domain": {"type": "string", "description": "Filter by domain (optional)", "default": ""},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "misakanet_read_lesson",
+        "description": "Read the full content of a MisakaNet lesson by its path.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Relative path to lesson file (from search results)"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "misakanet_list_domains",
+        "description": "List all available knowledge domains in MisakaNet.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+def handle_request(request: dict) -> dict:
+    """Handle a single JSON-RPC request."""
+    method = request.get("method", "")
+    req_id = request.get("id")
+    params = request.get("params", {})
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "misakanet", "version": "0.1.0"},
+            },
+        }
+
+    if method == "notifications/initialized":
+        return None  # No response for notifications
+
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}
+
+    if method == "tools/call":
+        tool_name = params.get("name", "")
+        args = params.get("arguments", {})
+
+        if tool_name == "misakanet_search":
+            results = search_lessons(
+                args.get("query", ""),
+                args.get("top_k", 5),
+                args.get("domain", ""),
+            )
+            content = json.dumps(results, ensure_ascii=False, indent=2) if results else "No results found."
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"content": [{"type": "text", "text": content}]},
+            }
+
+        if tool_name == "misakanet_read_lesson":
+            text = get_lesson_content(args.get("path", ""))
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"content": [{"type": "text", "text": text}]},
+            }
+
+        if tool_name == "misakanet_list_domains":
+            domains = list_domains()
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {"content": [{"type": "text", "text": json.dumps(domains)}]},
+            }
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
+        }
+
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": f"Unknown method: {method}"}}
+
+
+def main():
+    """MCP stdio transport: read JSON-RPC from stdin, write to stdout."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        response = handle_request(request)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Adds a full MCP (Model Context Protocol) server + `.cursorrules` so Cursor, Claude Desktop, and any MCP client can search MisakaNet lessons directly.

## Deliverables

| Deliverable | Location |
|-------------|----------|
| MCP server (stdio JSON-RPC) | `integrations/mcp-server/server.py` |
| MCP config example | `integrations/mcp-server/cursor_mcp.json` |
| .cursorrules (auto-suggest) | `.cursorrules` (repo root) |
| Setup documentation | `docs/integrations/cursor-mcp-setup.md` |

## MCP Tools Exposed

| Tool | Description |
|------|-------------|
| `misakanet_search` | Search lessons by query (returns ranked JSON) |
| `misakanet_read_lesson` | Read full lesson content by path |
| `misakanet_list_domains` | List available knowledge domains |

## Acceptance Criteria

- [x] `.cursorrules` file that instructs Cursor to search MisakaNet
- [x] MCP server for Cursor to query lessons
- [x] Auto-suggest relevant lessons when debugging (via .cursorrules)
- [x] Documentation: setup guide in `docs/integrations/`

## How to Use

1. Add MCP server to Cursor settings (or copy `cursor_mcp.json`)
2. Copy `.cursorrules` to your project root
3. When debugging, Cursor auto-searches MisakaNet and suggests fixes

## Architecture

```
Cursor/Claude → MCP stdio → server.py → search_knowledge.py --json → results
```

Zero external dependencies beyond Python 3.10+ and misakanet-core.

Closes #318
