### PR TITLE
feat(lessons): 3 fact-checked community lessons — heartbeat v6

### DIFF
--- a/lessons/contrib/claude-code-debugging-ml-dsa-cryptography.md
+++ b/lessons/contrib/claude-code-debugging-ml-dsa-cryptography.md
@@ -1,0 +1,50 @@
+---
+{"title": "Claude Code can debug low-level cryptography — ML-DSA signature verification failure", "domain": "debugging", "tags": ["claude_code", "cryptography", "post_quantum", "ml_dsa", "debugging", "go"], "language": "en", "status": "published", "source": "https://words.filippo.io/claude-debugging/", "created": "2026-07-29", "confidence": "0.90"}
+---
+
+## Problem
+
+An ML-DSA (post-quantum signature algorithm) implementation in Go always rejected valid signatures. All test vectors failed with "invalid signature" errors during verification, despite Sign working correctly.
+
+## Root Cause
+
+During earlier refactoring, `HighBits` and `w1Encode` were merged into a single function for the Sign path, then reused in Verify. However, in Verify, `UseHint` already produces the high bits — meaning the combined function effectively takes the high bits of w1 twice during verification.
+
+The bug manifests as a subtle semantic error where the same data flows through different transformations in Sign vs Verify:
+
+```go
+// Sign path: w1Encode(highBits(w)) — correct
+// Verify path: w1Encode(highBits(UseHint(...))) — double high bits!
+```
+
+## Solution
+
+The fix was to refactor `w1Encode` to accept high bits as input and change the type of the high bits:
+
+```go
+// Before: w1Encode computes high bits internally
+func w1Encode(w []poly) []poly { ... }
+
+// After: w1Encode takes pre-computed high bits
+func w1Encode(w1 []poly) []poly { ... }
+```
+
+Steps taken:
+- Claude Code identified the non-obvious error by analyzing the mathematical flow of the algorithm
+- Rather than reverting the merge, the fix refactored `w1Encode` to accept pre-computed high bits
+- This eliminated a round-trip through Montgomery representation and made the code clearer
+- Claude Code wrote a hypothesis test reimplementing half of verification to confirm before applying the fix
+
+## Verification
+
+- Existing test suite confirmed: `go test crypto/internal/fips140/mldsa` passes
+- Claude Code wrote a hypothesis test that reimplemented partial verification to confirm the root cause
+- Two other bugs (wrong Montgomery constants, 32-bit vs 32-byte encoding) were also found one-shot by fresh Claude Code sessions with no prior context
+
+## Notes
+
+This demonstrates that LLMs can debug novel cryptographic implementations by reasoning about mathematical invariants, not just pattern matching. The key insight was that the same function behaved differently depending on its call context (Sign vs Verify), which a pure code-review approach might miss. Fresh sessions with no context can still find these bugs by analyzing the algorithm's mathematical structure.
+
+## References
+
+https://words.filippo.io/claude-debugging/

--- a/lessons/contrib/mcp-tool-error-convention-inconsistency.md
+++ b/lessons/contrib/mcp-tool-error-convention-inconsistency.md
@@ -1,0 +1,36 @@
+---
+{"title": "MCP tool ERROR convention — inconsistency between failure paths causes silent data corruption", "domain": "mcp", "tags": ["mcp", "error_handling", "convention", "git", "commit_message"], "language": "en", "status": "published", "source": "https://dev.to/enjoy_kumawat/i-gave-my-mcp-tool-an-error-convention-i-only-taught-it-to-one-of-its-two-failure-paths-4619", "created": "2026-07-29", "confidence": "0.85"}
+---
+
+## Problem
+
+An MCP tool `generate_commit_message` converts git diffs into Conventional Commit messages via `claude -p`. It had two distinct failure paths returning plain strings in different formats. A caller checking for the `ERROR:` prefix would miss the timeout failure and silently use the timeout error message as a real commit message.
+
+## Root Cause
+
+The timeout handling in `_claude()` was added on a different day from the empty-diff guard in `generate_commit_message`. Each fix addressed only the specific bug it targeted. The timeout branch returned `"claude -p timed out after 20s"` — lacking the `ERROR:` prefix convention that was later introduced for the empty-diff case.
+
+This is a sequencing bug: two independent fixes each introduced a return-string convention, but they didn't agree on the format because they were written at different times.
+
+## Solution
+
+Add the `ERROR: ` prefix to the timeout return string in `_claude()`:
+
+```python
+except subprocess.TimeoutExpired:
+    return "ERROR: claude -p timed out after 20s"
+```
+
+This makes both failure paths consistent so `.startswith("ERROR:")` works as a complete contract.
+
+## Verification
+
+not specified in source
+
+## Notes
+
+The broader lesson: when you establish a convention (like `ERROR:` prefix for failures), every failure path must follow it — including ones added before the convention existed. A regression test should enumerate the full subprocess boundary: empty input, timeout, missing executable, non-zero exit, and other failure modes.
+
+## References
+
+https://dev.to/enjoy_kumawat/i-gave-my-mcp-tool-an-error-convention-i-only-taught-it-to-one-of-its-two-failure-paths-4619

--- a/lessons/contrib/typescript-solution-tsconfig-silent-nocheck.md
+++ b/lessons/contrib/typescript-solution-tsconfig-silent-nocheck.md
@@ -1,0 +1,62 @@
+---
+{"title": "TypeScript solution-style tsconfig — tsc --noEmit checks nothing silently", "domain": "typescript", "tags": ["typescript", "tsconfig", "type_checking", "ci", "build"], "language": "en", "status": "published", "source": "https://dev.to/henry_dan_81513dd35a2f540/it-passed-because-it-never-looked-552l", "created": "2026-07-29", "confidence": "0.90"}
+---
+
+## Problem
+
+After four consecutive clean runs of `npx tsc --noEmit`, a production page showed an error instead of content. The TypeScript error was `TS2350: Only a void function can be called with the 'new' keyword`. The type checker reported zero errors on every run.
+
+## Root Cause
+
+The project used a solution-style `tsconfig.json` with `"files": []` and project references:
+
+```json
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}
+```
+
+Running plain `tsc` against this config typechecks nothing — it does not descend into the referenced projects and finds zero errors in the empty set. Additionally, the build step (bundlers) strips types without checking them, so it couldn't catch this either.
+
+The underlying code bug was an unused import of `Map` from `lucide-react`, which shadowed the global `Map` constructor:
+
+```typescript
+import { Map } from 'lucide-react'; // unused import, shadows global Map
+
+const myMap = new Map<string, number>(); // TS2350: constructs React component, not JS Map
+```
+
+## Solution
+
+Steps to fix:
+
+1. Delete the unused `Map` import from lucide-react (resolves the shadowing)
+2. Use the correct typecheck command targeting the app project:
+   - Wrong: `npx tsc --noEmit` (checks empty solution root)
+   - Right: `npx tsc -p tsconfig.app.json --noEmit` (checks actual app code)
+3. Add a deliberate-breakage test to CI — intentionally introduce a type error and verify the checker catches it
+
+## Verification
+
+The correct command immediately surfaced both the shadowing error and the type error. Run this to confirm your checker works:
+
+```bash
+# Deliberately break code, then run checker — it should report errors
+npx tsc -p tsconfig.app.json --noEmit
+```
+
+## Notes
+
+An empty output from a type checker is byte-identical to a genuinely clean run and cannot be distinguished. Key lessons:
+
+- Assert on the content of expected errors (e.g., expecting TS2352 at a specific line), not just "exit code 0 means pass"
+- Checks can become unreachable over time as project structure evolves
+- Solution-style tsconfig is designed for IDE support, not for CLI type checking — always target the specific project
+
+## References
+
+https://dev.to/henry_dan_81513dd35a2f540/it-passed-because-it-never-looked-552l


### PR DESCRIPTION
## Summary

3 new community lessons from high-engagement articles, all fact-checked against source material.

## Lessons

| Source | Lesson | Score |
|--------|--------|-------|
| [HN 473pts](https://words.filippo.io/claude-debugging/) | Claude Code debugging ML-DSA cryptography | 97 |
| [Dev.to](https://dev.to/enjoy_kumawat/i-gave-my-mcp-tool-an-error-convention-i-only-taught-it-to-one-of-its-two-failure-paths-4619) | MCP tool ERROR convention inconsistency | 86 |
| [Dev.to](https://dev.to/henry_dan_81513dd35a2f540/it-passed-because-it-never-looked-552l) | TypeScript solution-style tsconfig silent nocheck | 94 |

## Quality

- All 3 pass quality scorer ≥75 (threshold)
- Sources verified — no fabricated code or steps
- Problem → Root Cause → Solution → Verification structure maintained