### PR TITLE
docs: add standard MCP listing badges (CI, PyPI, Python, Glama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ mcp-name: io.github.Ikalus1988/misakanet
 </p>
 
 <p align="center">
-  <a href="https://github.com/Ikalus1988/MisakaNet/stargazers"><img src="https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social" alt="Stars"/></a>
-  <a href="https://img.shields.io/badge/nodes-235+-green"><img src="https://img.shields.io/badge/nodes-235+-green?label=Nodes" alt="Nodes"/></a>
-  <a href="https://img.shields.io/badge/lessons-244-blue"><img src="https://img.shields.io/badge/lessons-244-blue?label=Lessons" alt="Lessons"/></a>
-  <a href="https://glama.ai/mcp/servers"><img src="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badge" alt="MCP Server on Glama"/></a>
-  <a href="https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet"><img src="https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg" alt="MCP Toplist: Top 1% of 81,852"/></a>
+  <a href="https://github.com/Ikalus1988/MisakaNet/actions/workflows/pr-quality-gate.yml"><img src="https://github.com/Ikalus1988/MisakaNet/actions/workflows/pr-quality-gate.yml/badge.svg" alt="CI"/></a>
+  <a href="https://pypi.org/project/misakanet-core/"><img src="https://img.shields.io/pypi/v/misakanet-core" alt="PyPI"/></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue" alt="Python"/></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Ikalus1988/MisakaNet?style=flat&color=blueviolet" alt="License"/></a>
+  <a href="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet"><img src="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badges/score.svg" alt="Glama score"/></a>
+  <a href="https://github.com/Ikalus1988/MisakaNet/stargazers"><img src="https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social" alt="Stars"/></a>
+  <a href="https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet"><img src="https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg" alt="MCP Toplist: Top 1% of 81,852"/></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Update README badges to match awesome-mcp-servers listing requirements.

## Changes

- **CI**: Added pr-quality-gate.yml workflow badge
- **PyPI**: Added misakanet-core version badge
- **Python**: Added 3.10+ badge
- **Glama**: Replaced /badge (PNG) with /badges/score.svg (SVG)

All badge URLs verified HTTP 200.

Closes #635 (replaced: was main→main, no CI triggered)