### PR TITLE
feat: add demand board data model with maintainer override

### DIFF
--- a/scripts/demand_board.py
+++ b/scripts/demand_board.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Demand board — track intake clusters and their triage states.
+
+States: new → reviewed → routed | rejected
+Maintainers can override category and state.
+
+Usage:
+    # Add an intake signal
+    python3 scripts/demand_board.py record --family python-env --reason "pip timeout" --source curl
+
+    # List all demand items
+    python3 scripts/demand_board.py list
+
+    # Override category/state
+    python3 scripts/demand_board.py override --id <item-id> --state reviewed --category lesson
+
+    # Summary (for API/dashboard)
+    python3 scripts/demand_board.py summary --json
+"""
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_FILE = REPO_ROOT / "data" / "demand-board.jsonl"
+
+TASK_FAMILY_WHITELIST = [
+    "github-auth", "npm-publish", "cloudflare-worker", "mcp-registry",
+    "glama-release", "python-env", "database-lock", "crawler-block",
+    "agent-tooling", "lesson-feedback", "rescue-feedback", "bug-report",
+    "unclassified",
+]
+
+VALID_STATES = {"new", "reviewed", "routed", "rejected"}
+VALID_CATEGORIES = {"lesson", "rescue", "bug", "noise", "unknown"}
+
+
+def normalize_family(family: str) -> str:
+    """Constrain to whitelist."""
+    return family if family in TASK_FAMILY_WHITELIST else "unclassified"
+
+
+def load_board() -> list[dict]:
+    """Load all demand board items."""
+    if not BOARD_FILE.exists():
+        return []
+    items = []
+    for line in BOARD_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                items.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return items
+
+
+def save_board(items: list[dict]) -> None:
+    """Write board items to JSONL."""
+    BOARD_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(BOARD_FILE, "w", encoding="utf-8") as f:
+        for item in items:
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+
+def record_signal(family: str, reason: str = "", source: str = "", category: str = "unknown") -> dict:
+    """Record a new unsolved signal."""
+    items = load_board()
+    now = datetime.now(timezone.utc).isoformat()
+    item = {
+        "id": uuid.uuid4().hex[:12],
+        "family": normalize_family(family),
+        "reason": reason[:200] if reason else "unspecified",
+        "source": source[:50] if source else "unknown",
+        "category": category if category in VALID_CATEGORIES else "unknown",
+        "state": "new",
+        "count": 1,
+        "first_seen": now,
+        "last_seen": now,
+        "override_history": [],
+    }
+
+    # Check for existing item with same family+reason (aggregate)
+    for existing in items:
+        if existing["family"] == item["family"] and existing["reason"] == item["reason"]:
+            existing["count"] += 1
+            existing["last_seen"] = now
+            save_board(items)
+            return existing
+
+    items.append(item)
+    save_board(items)
+    return item
+
+
+def override_item(item_id: str, state: str = "", category: str = "", note: str = "") -> dict | None:
+    """Maintainer override: change state or category."""
+    items = load_board()
+    for item in items:
+        if item["id"] == item_id:
+            history_entry = {"ts": datetime.now(timezone.utc).isoformat()}
+
+            if state and state in VALID_STATES:
+                history_entry["old_state"] = item["state"]
+                history_entry["new_state"] = state
+                item["state"] = state
+
+            if category and category in VALID_CATEGORIES:
+                history_entry["old_category"] = item["category"]
+                history_entry["new_category"] = category
+                item["category"] = category
+
+            if note:
+                history_entry["note"] = note[:200]
+
+            item["override_history"].append(history_entry)
+            save_board(items)
+            return item
+    return None
+
+
+def get_summary() -> dict:
+    """Aggregate summary for API/dashboard."""
+    items = load_board()
+    by_state = {}
+    by_family = {}
+    by_category = {}
+
+    for item in items:
+        state = item.get("state", "new")
+        family = item.get("family", "unclassified")
+        category = item.get("category", "unknown")
+
+        by_state[state] = by_state.get(state, 0) + 1
+        by_family[family] = by_family.get(family, 0) + 1
+        by_category[category] = by_category.get(category, 0) + 1
+
+    return {
+        "total": len(items),
+        "by_state": dict(sorted(by_state.items())),
+        "by_family": dict(sorted(by_family.items(), key=lambda x: -x[1])),
+        "by_category": dict(sorted(by_category.items(), key=lambda x: -x[1])),
+        "states": list(VALID_STATES),
+        "categories": list(VALID_CATEGORIES),
+    }
+
+
+def list_items(state: str = "", family: str = "", limit: int = 50) -> list[dict]:
+    """List items with optional filters."""
+    items = load_board()
+    if state:
+        items = [i for i in items if i.get("state") == state]
+    if family:
+        items = [i for i in items if i.get("family") == family]
+    return items[-limit:]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Demand board — intake cluster tracking")
+    sub = parser.add_subparsers(dest="cmd")
+
+    # record
+    p_rec = sub.add_parser("record", help="Record an unsolved signal")
+    p_rec.add_argument("--family", required=True, help="Task family")
+    p_rec.add_argument("--reason", default="", help="Short reason (max 200 chars)")
+    p_rec.add_argument("--source", default="", help="Source type (curl, mcp, agent, etc.)")
+    p_rec.add_argument("--category", default="unknown", help="Initial category")
+
+    # list
+    p_list = sub.add_parser("list", help="List demand items")
+    p_list.add_argument("--state", default="", help="Filter by state")
+    p_list.add_argument("--family", default="", help="Filter by family")
+    p_list.add_argument("--limit", type=int, default=50)
+    p_list.add_argument("--json", action="store_true")
+
+    # override
+    p_ovr = sub.add_parser("override", help="Maintainer override")
+    p_ovr.add_argument("--id", required=True, help="Item ID")
+    p_ovr.add_argument("--state", default="", help="New state")
+    p_ovr.add_argument("--category", default="", help="New category")
+    p_ovr.add_argument("--note", default="", help="Override note")
+
+    # summary
+    p_sum = sub.add_parser("summary", help="Show summary")
+    p_sum.add_argument("--json", action="store_true")
+
+    args = parser.parse_args()
+
+    if args.cmd == "record":
+        item = record_signal(args.family, args.reason, args.source, args.category)
+        print(f"  Recorded: {item['id']} ({item['family']}) count={item['count']}")
+
+    elif args.cmd == "list":
+        items = list_items(args.state, args.family, args.limit)
+        if getattr(args, "json", False):
+            print(json.dumps(items, ensure_ascii=False, indent=2))
+        else:
+            if not items:
+                print("  No items.")
+                return
+            print(f"\n  {'ID':<14} {'State':<10} {'Family':<20} {'Cat':<10} {'Count':<6} {'Reason'}")
+            print(f"  {'-'*14} {'-'*10} {'-'*20} {'-'*10} {'-'*6} {'-'*40}")
+            for i in items:
+                print(f"  {i['id']:<14} {i['state']:<10} {i['family']:<20} {i['category']:<10} {i['count']:<6} {i['reason'][:40]}")
+        print()
+
+    elif args.cmd == "override":
+        item = override_item(args.id, args.state, args.category, args.note)
+        if item:
+            print(f"  Updated: {item['id']} state={item['state']} category={item['category']}")
+        else:
+            print(f"  Not found: {args.id}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.cmd == "summary":
+        summary = get_summary()
+        if getattr(args, "json", False):
+            print(json.dumps(summary, ensure_ascii=False, indent=2))
+        else:
+            print(f"\n  Demand Board — {summary['total']} items")
+            print(f"\n  By state:")
+            for s, c in summary["by_state"].items():
+                print(f"    {s:<12} {c}")
+            print(f"\n  By family:")
+            for f, c in summary["by_family"].items():
+                print(f"    {f:<20} {c}")
+            print(f"\n  By category:")
+            for cat, c in summary["by_category"].items():
+                print(f"    {cat:<12} {c}")
+        print()
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demand_board_model.py
+++ b/tests/test_demand_board_model.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Test demand board data model — states, override, aggregation.
+
+Covers v2.13.0 release blocker #5 (demand board states) and #6 (maintainer override).
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.demand_board import (
+    VALID_CATEGORIES,
+    VALID_STATES,
+    get_summary,
+    list_items,
+    load_board,
+    normalize_family,
+    override_item,
+    record_signal,
+    save_board,
+)
+
+
+@pytest.fixture(autouse=True)
+def temp_board(tmp_path):
+    """Use a temporary board file for each test."""
+    board_file = tmp_path / "demand-board.jsonl"
+    with patch("scripts.demand_board.BOARD_FILE", board_file):
+        yield board_file
+
+
+# ── Family normalization ──
+
+class TestNormalizeFamily:
+    def test_known_family(self):
+        assert normalize_family("python-env") == "python-env"
+
+    def test_unknown_family(self):
+        assert normalize_family("random-garbage") == "unclassified"
+
+    def test_empty(self):
+        assert normalize_family("") == "unclassified"
+
+
+# ── Record signal ──
+
+class TestRecordSignal:
+    def test_basic_record(self):
+        item = record_signal("python-env", "pip timeout", "curl")
+        assert item["family"] == "python-env"
+        assert item["reason"] == "pip timeout"
+        assert item["source"] == "curl"
+        assert item["state"] == "new"
+        assert item["count"] == 1
+        assert item["category"] == "unknown"
+
+    def test_duplicate_aggregation(self):
+        item1 = record_signal("python-env", "pip timeout", "curl")
+        item2 = record_signal("python-env", "pip timeout", "mcp")
+        assert item1["id"] == item2["id"]
+        assert item2["count"] == 2
+
+    def test_different_reason_separate(self):
+        item1 = record_signal("python-env", "pip timeout")
+        item2 = record_signal("python-env", "ssl error")
+        assert item1["id"] != item2["id"]
+
+    def test_reason_truncated(self):
+        item = record_signal("test", "x" * 500)
+        assert len(item["reason"]) == 200
+
+    def test_category_set(self):
+        item = record_signal("test", reason="", source="", category="lesson")
+        assert item["category"] == "lesson"
+
+    def test_invalid_category_fallback(self):
+        item = record_signal("test", category="bogus")
+        assert item["category"] == "unknown"
+
+
+# ── States ──
+
+class TestStates:
+    def test_valid_states(self):
+        assert VALID_STATES == {"new", "reviewed", "routed", "rejected"}
+
+    def test_initial_state_is_new(self):
+        item = record_signal("test", "reason")
+        assert item["state"] == "new"
+
+
+# ── Maintainer override ──
+
+class TestOverride:
+    def test_override_state(self):
+        item = record_signal("test", "reason")
+        updated = override_item(item["id"], state="reviewed")
+        assert updated["state"] == "reviewed"
+        assert len(updated["override_history"]) == 1
+        assert updated["override_history"][0]["old_state"] == "new"
+        assert updated["override_history"][0]["new_state"] == "reviewed"
+
+    def test_override_category(self):
+        item = record_signal("test", "reason")
+        updated = override_item(item["id"], category="lesson")
+        assert updated["category"] == "lesson"
+
+    def test_override_both(self):
+        item = record_signal("test", "reason")
+        updated = override_item(item["id"], state="routed", category="bug", note="confirmed bug")
+        assert updated["state"] == "routed"
+        assert updated["category"] == "bug"
+        assert updated["override_history"][0]["note"] == "confirmed bug"
+
+    def test_override_invalid_state_ignored(self):
+        item = record_signal("test", "reason")
+        updated = override_item(item["id"], state="bogus")
+        assert updated["state"] == "new"  # unchanged
+
+    def test_override_not_found(self):
+        result = override_item("nonexistent", state="reviewed")
+        assert result is None
+
+    def test_override_history_accumulates(self):
+        item = record_signal("test", "reason")
+        override_item(item["id"], state="reviewed")
+        updated = override_item(item["id"], state="routed")
+        assert len(updated["override_history"]) == 2
+
+
+# ── List items ──
+
+class TestListItems:
+    def test_list_all(self):
+        record_signal("a", "r1")
+        record_signal("b", "r2")
+        items = list_items()
+        assert len(items) == 2
+
+    def test_filter_by_state(self):
+        item = record_signal("test", "r1")
+        record_signal("test", "r2")
+        override_item(item["id"], state="reviewed")
+        reviewed = list_items(state="reviewed")
+        assert len(reviewed) == 1
+
+    def test_filter_by_family(self):
+        record_signal("python-env", "r1")
+        record_signal("npm-publish", "r2")
+        items = list_items(family="python-env")
+        assert len(items) == 1
+
+
+# ── Summary ──
+
+class TestSummary:
+    def test_empty_board(self):
+        summary = get_summary()
+        assert summary["total"] == 0
+
+    def test_summary_counts(self):
+        record_signal("python-env", "r1")
+        record_signal("python-env", "r2")
+        record_signal("npm-publish", "r3")
+        summary = get_summary()
+        assert summary["total"] == 3
+        assert summary["by_family"]["python-env"] == 2
+        assert summary["by_family"]["npm-publish"] == 1
+
+    def test_summary_by_state(self):
+        item = record_signal("test", "r1")
+        record_signal("test", "r2")
+        override_item(item["id"], state="reviewed")
+        summary = get_summary()
+        assert summary["by_state"]["new"] == 1
+        assert summary["by_state"]["reviewed"] == 1
+
+
+# ── Persistence ──
+
+class TestPersistence:
+    def test_save_and_load(self):
+        record_signal("test", "r1")
+        items = load_board()
+        assert len(items) == 1
+        assert items[0]["reason"] == "r1"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Covers v2.13.0 release blockers #5 (demand board states) and #6 (maintainer override).

**New files:**
- `scripts/demand_board.py` — demand board data model + CLI
- `tests/test_demand_board_model.py` — 24 tests

**Features:**
- States: new → reviewed → routed | rejected
- Maintainer override with full history trail
- Task family whitelist (consistent with `register-proxy.js`)
- Duplicate aggregation (same family+reason → count++)
- JSONL persistence in `data/demand-board.jsonl`
- CLI commands: `record`, `list`, `override`, `summary`

**Test coverage:**
- Family normalization, state transitions, override logic
- Filtering by state/family, summary aggregation
- Persistence round-trip