### PR TITLE
feat: wire /api/intake to redaction and demand board

### DIFF
--- a/scripts/intake_classify.py
+++ b/scripts/intake_classify.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Intake classifier — reads intake records and routes to demand board.
+
+Reads from data/intake-export.jsonl or stdin, classifies each entry,
+and records demand signals for items without matching lessons.
+
+Usage:
+    python3 scripts/intake_classify.py --input data/intake-export.jsonl
+    python3 scripts/intake_classify.py --json '{"type":"bug","message":"search crashes"}'
+    python3 scripts/intake_classify.py --stdin < intake.jsonl
+
+Classification:
+    lesson_candidate → "lesson-feedback" family
+    bug              → "bug-report" family
+    diagnostic/friction/node_join → "unclassified" family
+    noise            → skipped
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.demand_board import record_signal
+
+# ── Classifier ──
+
+LESSON_SIGNALS = [
+    "fixed", "solved", "solution", "workaround", "here's how",
+    "i figured out", "the fix was", "resolved", "tip", "trick",
+]
+
+BUG_SIGNALS = [
+    "bug", "regression", "broken", "crash", "500", "internal error",
+    "misakanet", "search_knowledge", "worker", "endpoint",
+]
+
+RESCUE_SIGNALS = [
+    "help", "stuck", "error", "fail", "timeout", "not working",
+    "can't", "cannot", "how do i", "urgent", "blocked",
+]
+
+
+def classify(entry: dict) -> str:
+    """Classify intake entry. Returns category."""
+    # Explicit type takes priority
+    explicit = str(entry.get("type", "") or "").lower()
+    if explicit == "lesson_candidate":
+        return "lesson"
+    if explicit == "bug":
+        return "bug"
+    if explicit in ("diagnostic", "friction"):
+        return "rescue"
+    if explicit == "noise":
+        return "noise"
+
+    # Positive feedback = noise (check before keyword matching)
+    if entry.get("feedback") in ("helpful", "y", "yes"):
+        return "noise"
+
+    # Keyword-based classification
+    text = " ".join([
+        str(entry.get("message", "")),
+        str(entry.get("query", "")),
+        str(entry.get("feedback", "")),
+    ]).lower()
+
+    if not text.strip():
+        return "noise"
+
+    bug_score = sum(1 for kw in BUG_SIGNALS if kw in text)
+    rescue_score = sum(1 for kw in RESCUE_SIGNALS if kw in text)
+    lesson_score = sum(1 for kw in LESSON_SIGNALS if kw in text)
+
+    if lesson_score > bug_score and lesson_score > rescue_score:
+        return "lesson"
+    if bug_score > rescue_score:
+        return "bug"
+    if rescue_score > 0:
+        return "rescue"
+
+    return "noise"
+
+
+def process_entry(entry: dict, verbose: bool = True) -> tuple[str, str]:
+    """Classify and route a single intake entry. Returns (category, family)."""
+    category = classify(entry)
+
+    if category == "noise":
+        if verbose:
+            print(f"  [noise] skipped")
+        return "noise", "skipped"
+
+    # Map category to demand board family
+    family_map = {
+        "lesson": "lesson-feedback",
+        "bug": "bug-report",
+        "rescue": "unclassified",
+    }
+    family = family_map.get(category, "unclassified")
+
+    # Record demand signal
+    reason = str(entry.get("message", entry.get("query", "")))[:64]
+    source = entry.get("source", "unknown")
+    item = record_signal(family, reason=reason, source=source, category=category)
+
+    if verbose:
+        icon = {"lesson": "\U0001f4d6", "bug": "\U0001f41b", "rescue": "\U0001f6a8"}.get(category, "?")
+        print(f"  {icon} [{category}] family={family} id={item['id']} count={item['count']}")
+
+    return category, family
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Intake classifier — route to demand board")
+    parser.add_argument("--input", "-i", help="JSONL file of intake records")
+    parser.add_argument("--json", "-j", help="Single JSON entry")
+    parser.add_argument("--stdin", action="store_true", help="Read from stdin")
+    parser.add_argument("--quiet", "-q", action="store_true")
+    args = parser.parse_args()
+
+    entries = []
+
+    if args.json:
+        try:
+            entries = [json.loads(args.json)]
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.input:
+        path = Path(args.input)
+        if not path.exists():
+            print(f"Error: {path} not found", file=sys.stderr)
+            sys.exit(1)
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    elif args.stdin or not sys.stdin.isatty():
+        for line in sys.stdin:
+            line = line.strip()
+            if line:
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    if not entries:
+        print("No entries to classify.")
+        return
+
+    verbose = not args.quiet
+    if verbose:
+        print(f"\n  Classifying {len(entries)} entr{'y' if len(entries) == 1 else 'ies'}...\n")
+
+    stats = {"lesson": 0, "bug": 0, "rescue": 0, "noise": 0}
+    for entry in entries:
+        cat, _ = process_entry(entry, verbose=verbose)
+        stats[cat] = stats.get(cat, 0) + 1
+
+    if verbose:
+        print(f"\n  Done: {stats['lesson']} lessons, {stats['bug']} bugs, "
+              f"{stats['rescue']} rescues, {stats['noise']} noise\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_intake_classify.py
+++ b/tests/test_intake_classify.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Test intake classifier — routing from intake to demand board.
+
+Covers v2.13.0 release blocker #4 (classifier constrained output).
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.intake_classify import classify, process_entry
+
+
+@pytest.fixture(autouse=True)
+def temp_board(tmp_path):
+    """Use a temporary demand board file."""
+    board_file = tmp_path / "demand-board.jsonl"
+    with patch("scripts.demand_board.BOARD_FILE", board_file):
+        yield board_file
+
+
+# ── Classification ──
+
+class TestClassify:
+    def test_explicit_lesson(self):
+        assert classify({"type": "lesson_candidate"}) == "lesson"
+
+    def test_explicit_bug(self):
+        assert classify({"type": "bug"}) == "bug"
+
+    def test_explicit_diagnostic(self):
+        assert classify({"type": "diagnostic"}) == "rescue"
+
+    def test_explicit_friction(self):
+        assert classify({"type": "friction"}) == "rescue"
+
+    def test_explicit_noise(self):
+        assert classify({"type": "noise"}) == "noise"
+
+    def test_keyword_lesson(self):
+        assert classify({"message": "I fixed it by adding retry logic"}) == "lesson"
+
+    def test_keyword_bug(self):
+        assert classify({"message": "misakanet search returns 500 error"}) == "bug"
+
+    def test_keyword_rescue(self):
+        assert classify({"message": "I'm stuck, pip install fails with timeout"}) == "rescue"
+
+    def test_positive_feedback_noise(self):
+        assert classify({"feedback": "helpful"}) == "noise"
+
+    def test_empty_is_noise(self):
+        assert classify({}) == "noise"
+
+    def test_unknown_type_keyword_fallback(self):
+        assert classify({"message": "the fix was to add --no-cache"}) == "lesson"
+
+
+# ── Process entry → demand board ──
+
+class TestProcessEntry:
+    def test_lesson_routes_to_demand_board(self):
+        cat, family = process_entry({"type": "lesson_candidate", "message": "solved it"})
+        assert cat == "lesson"
+        assert family == "lesson-feedback"
+
+    def test_bug_routes_to_demand_board(self):
+        cat, family = process_entry({"type": "bug", "message": "search crashes"})
+        assert cat == "bug"
+        assert family == "bug-report"
+
+    def test_noise_skipped(self):
+        cat, family = process_entry({"type": "noise"})
+        assert cat == "noise"
+        assert family == "skipped"
+
+    def test_rescue_routes_to_unclassified(self):
+        cat, family = process_entry({"type": "diagnostic", "message": "stuck"})
+        assert cat == "rescue"
+        assert family == "unclassified"
+
+
+# ── Constrained output ──
+
+class TestConstrainedOutput:
+    """v2.13.0 requirement: classifier output constrained to lesson/rescue/bug/noise."""
+
+    def test_all_categories_valid(self):
+        valid = {"lesson", "rescue", "bug", "noise"}
+        test_cases = [
+            {"type": "lesson_candidate"},
+            {"type": "bug"},
+            {"type": "diagnostic"},
+            {"type": "friction"},
+            {"type": "noise"},
+            {"message": "fixed it"},
+            {"message": "broken"},
+            {"message": "help stuck"},
+            {},
+        ]
+        for entry in test_cases:
+            cat = classify(entry)
+            assert cat in valid, f"classify({entry}) = {cat}, not in {valid}"
+
+    def test_no_crash_on_malformed(self):
+        """Classifier should never crash, even on bad input."""
+        bad_inputs = [
+            {"type": None},
+            {"message": ""},
+            {"type": 123},
+            {"random": "garbage"},
+        ]
+        for entry in bad_inputs:
+            cat = classify(entry)
+            assert cat in {"lesson", "rescue", "bug", "noise"}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -243,6 +243,88 @@ export default {
       return jsonResponse({ accepted: accepted.length });
     }
 
+    // POST /api/intake — general-purpose intake for MCP, agents, sandbox (#589)
+    // Redacts secrets before persistence. Records demand signals for unmatched items.
+    if (request.method === "POST" && url.pathname === "/api/intake") {
+      if (!env.MISAKANET_KV) return jsonResponse({ error: "KV not configured" }, 503);
+
+      // Max body 8KB
+      const contentLength = parseInt(request.headers.get("content-length") || "0");
+      if (contentLength > 8192) return jsonResponse({ error: "Request too large (max 8KB)" }, 413);
+
+      // IP rate limit: 10 per hour
+      const intakeIp = request.headers.get("CF-Connecting-IP") || "unknown";
+      const intakeRateKey = `rate:intake:${intakeIp}`;
+      const intakeRateRaw = await env.MISAKANET_KV.get(intakeRateKey, "text");
+      const intakeRateCount = intakeRateRaw ? parseInt(intakeRateRaw, 10) || 0 : 0;
+      if (intakeRateCount >= 10) return jsonResponse({ error: "Rate limited (10/hour). Try again later." }, 429);
+      await env.MISAKANET_KV.put(intakeRateKey, String(intakeRateCount + 1), { expirationTtl: 3600 });
+
+      let intakeBody;
+      try { intakeBody = await request.json(); } catch { return jsonResponse({ error: "Invalid JSON" }, 400); }
+
+      // Field whitelist + validation
+      const VALID_TYPES = ["diagnostic", "lesson_candidate", "friction", "bug", "node_join"];
+      const VALID_SOURCES = ["mcp", "curl", "frontend", "agent"];
+      const VALID_CONSENT = ["private_only", "allow_anonymous_publish"];
+
+      const { type, source, message, context, lesson_id, contact, consent, ts } = intakeBody || {};
+      if (!type || !VALID_TYPES.includes(type)) return jsonResponse({ error: "Invalid or missing 'type'. Must be one of: " + VALID_TYPES.join(", ") }, 400);
+      if (!source || !VALID_SOURCES.includes(source)) return jsonResponse({ error: "Invalid or missing 'source'. Must be one of: " + VALID_SOURCES.join(", ") }, 400);
+      if (!message || typeof message !== "string" || !message.trim()) return jsonResponse({ error: "Missing 'message'" }, 400);
+
+      // Secret redaction (inline — mirrors scripts/intake_redact.py patterns)
+      const REDACT_PATTERNS = [
+        [/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END(?: RSA | EC | OPENSSH )?PRIVATE KEY-----/gi, "[REDACTED:private_key]"],
+        [/(?:ghp|gho|ghu|ghs|ghr|github_pat)_[a-zA-Z0-9]{10,}/g, "[REDACTED:github_token]"],
+        [/xox[bpras]-[a-zA-Z0-9\-]{10,}/g, "[REDACTED:slack_token]"],
+        [/(?:AKIA|ABIA|ACCA|ASIA)[A-Z0-9]{16}/g, "[REDACTED:aws_key]"],
+        [/(?:sk|pk|rk|ak)[_-][a-zA-Z0-9]{10,}/g, "[REDACTED:api_key]"],
+        [/(?:Bearer|Authorization)\s+[a-zA-Z0-9\-._~+/]+=*/gi, "[REDACTED:bearer_token]"],
+        [/(?:password|passwd|secret|token|api[_-]?key|apikey|database[_-]?url)\s*[:=]\s*\S+/gi, "[REDACTED:credential]"],
+        [/:[^:]+:[^@]+@[^\s]+/g, "://[REDACTED:url_credential]@host"],
+        [/\b(?:\d[ -]*?){13,19}\b/g, "[REDACTED:card_number]"],
+      ];
+      function redactSecrets(text) {
+        let result = String(text).slice(0, 2000);
+        for (const [pat, repl] of REDACT_PATTERNS) result = result.replace(pat, repl);
+        return result;
+      }
+
+      const intakeId = crypto.randomUUID();
+      const record = {
+        intakeId,
+        type,
+        source,
+        message: redactSecrets(message),
+        context: context ? JSON.parse(redactSecrets(JSON.stringify(context)).slice(0, 1000)) : {},
+        lesson_id: lesson_id ? String(lesson_id).slice(0, 200) : null,
+        contact: contact ? String(contact).slice(0, 200) : null,
+        consent: VALID_CONSENT.includes(consent) ? consent : "private_only",
+        ts: ts || new Date().toISOString(),
+        received_at: new Date().toISOString(),
+      };
+
+      // Store intake record
+      await env.MISAKANET_KV.put(`intake:${intakeId}`, JSON.stringify(record), { expirationTtl: 7776000 });
+
+      // Record demand signal for the task family (maps type to family)
+      const FAMILY_MAP = { diagnostic: "unclassified", lesson_candidate: "lesson-feedback", friction: "unclassified", bug: "bug-report", node_join: "unclassified" };
+      const family = FAMILY_MAP[type] || "unclassified";
+      const demandKey = `demand:family:${family}`;
+      const demandRaw = await env.MISAKANET_KV.get(demandKey, "json");
+      const demand = demandRaw && typeof demandRaw === "object" ? demandRaw : { days: {} };
+      const day = new Date().toISOString().slice(0, 10);
+      demand.days[day] = demand.days[day] || { reasons: {}, count: 0 };
+      demand.days[day].count++;
+      const reasonKey = String(message).slice(0, 64);
+      demand.days[day].reasons[reasonKey] = (demand.days[day].reasons[reasonKey] || 0) + 1;
+      await env.MISAKANET_KV.put(demandKey, JSON.stringify(demand), { expirationTtl: 2592000 });
+
+      console.log(`Intake ${intakeId}: type=${type} source=${source} family=${family}`);
+      return jsonResponse({ accepted: true, intake_id: intakeId, consent: record.consent });
+    }
+
     // GET /api/github/* - authenticated GitHub API proxy for the org frontend.
     // Keep this before the HTML landing page; otherwise the frontend receives
     // HTML and fails with: Unexpected token '<' while parsing JSON.


### PR DESCRIPTION
Covers v2.13.0 blockers #1-4 (intake endpoint + classifier integration).

**Changes:**
- `workers/register-proxy-sw.js` — new POST /api/intake endpoint with:
  - Secret redaction (inline JS, mirrors intake_redact.py patterns)
  - IP rate limiting (10/hour), body size limit (8KB)
  - Field whitelist validation (type, source, message)
  - Demand signal recording on intake
- `scripts/intake_classify.py` — classifier integration script
  - Reads intake records, classifies to lesson/bug/rescue/noise
  - Routes to demand board via demand_board.py
  - CLI: --input, --json, --stdin
- `tests/test_intake_classify.py` — 17 tests
  - Constrained output (lesson/rescue/bug/noise only)
  - Malformed input safety (no crashes on None type, empty input)
  - Demand board routing verification

**Closes:** #589 (curl-first intake), #574 (feedback hub)