### PR TITLE
feat: add misakanet_usage_status MCP tool

### DIFF
--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """MisakaNet MCP Server — thin adapter for Claude Code, Cursor, Continue, etc.
 
-Exposes 3 tools:
+Exposes 4 tools:
   misakanet.search(query, domain?, top?)
   misakanet.get_lesson(path_or_id)
   misakanet.submit_usage(lesson_id, tool, outcome)
+  misakanet.usage_status(user?)
 
 Usage:
     # As MCP server (stdio transport)
@@ -110,6 +111,25 @@ def handle_submit_usage(args: dict) -> dict:
 
     # TODO: POST to /api/usage or create GitHub Issue
     return report
+
+
+def handle_usage_status(args: dict) -> dict:
+    """Show current usage status and remaining quota."""
+    try:
+        from scripts.usage_meter import get_status, hash_ip
+        user = args.get("user", "anon:mcp-default")
+        status = get_status(user)
+        return {
+            "user": status["user"],
+            "free_reads_used": status["free_reads_used"],
+            "free_reads_limit": status["free_reads_limit"],
+            "free_reads_remaining": status["free_reads_remaining"],
+            "credits": status["credits"],
+            "is_registered": status["is_registered"],
+            "next": "Use misakanet_submit_intake or misakanet_contribute_lesson to request more credits."
+        }
+    except Exception as e:
+        return {"error": str(e), "user": "unknown", "free_reads_remaining": -1}
 
 
 # ── MCP Resources ──
@@ -363,6 +383,22 @@ TOOLS = [
             "required": ["lesson_id"],
         },
     },
+    {
+        "name": "misakanet_usage_status",
+        "description": (
+            "Check current usage status and remaining quota. Use to see how many free lesson reads "
+            "remain and how many credits are available. Input semantics: user is optional (defaults to "
+            "anonymous). Output schema: JSON with user, free_reads_used, free_reads_limit, "
+            "free_reads_remaining, credits, is_registered, and next steps. Error cases: none. Side "
+            "effects: none. Auth: none. Rate limits: none."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "user": {"type": "string", "description": "Optional user identifier (e.g. 'anon:iphash' or 'token:xxx'). Defaults to 'anon:mcp-default'."},
+            },
+        },
+    },
 ]
 
 
@@ -405,6 +441,7 @@ def handle_request(request: dict) -> dict:
             "misakanet_search": handle_search,
             "misakanet_get_lesson": handle_get_lesson,
             "misakanet_submit_usage": handle_submit_usage,
+            "misakanet_usage_status": handle_usage_status,
         }
 
         handler = handlers.get(tool_name)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -169,6 +169,22 @@ def test_no_drafts_in_search():
     check("no drafts in results", draft_count == 0, f"found {draft_count} drafts")
 
 
+def test_usage_status():
+    print("\n-- tools/call: misakanet_usage_status --")
+    resp = rpc("tools/call", {
+        "name": "misakanet_usage_status",
+        "arguments": {"user": "anon:test-mcp"},
+    })
+    result_text = resp.get("result", {}).get("content", [{}])[0].get("text", "{}")
+    result = json.loads(result_text)
+    check("returns user", "user" in result)
+    check("returns free_reads_used", "free_reads_used" in result)
+    check("returns free_reads_limit", "free_reads_limit" in result)
+    check("returns free_reads_remaining", "free_reads_remaining" in result)
+    check("returns credits", "credits" in result)
+    check("returns is_registered", "is_registered" in result)
+
+
 if __name__ == "__main__":
     print("MisakaNet MCP Server smoke test")
     test_initialize()
@@ -179,6 +195,7 @@ if __name__ == "__main__":
     test_submit_usage()
     test_unknown_tool()
     test_no_drafts_in_search()
+    test_usage_status()
 
     print(f"\n{'=' * 40}")
     print(f"Results: {PASS} passed, {FAIL} failed")


### PR DESCRIPTION
PR 2 of v2.14 MVP — MCP usage status tool.

**Changes:**
- `scripts/mcp_server.py` — new `misakanet_usage_status` tool (4th tool)
- `tests/test_mcp_server.py` — added usage_status test (9 tests total)

**Tool contract:**
- Input: `user` (optional, defaults to anonymous)
- Output: `free_reads_used`, `free_reads_limit`, `free_reads_remaining`, `credits`, `is_registered`, `next`
- Side effects: none
- Auth: none