### PR TITLE
feat: add maintainer review CLI with credit grants

### DIFF
--- a/scripts/contribution_review.py
+++ b/scripts/contribution_review.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Maintainer review CLI — accept/reject contributions and grant credits.
+
+Usage:
+    python3 scripts/contribution_review.py list [--status pending]
+    python3 scripts/contribution_review.py show contrib_abc123
+    python3 scripts/contribution_review.py accept contrib_abc123 --credits 20 [--note "verified"]
+    python3 scripts/contribution_review.py reject contrib_abc123 --reason duplicate
+    python3 scripts/contribution_review.py grant contrib_abc123 --credits 20
+
+Credits are only granted on "accept". No auto-accept. No auto-grant.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.contribution_queue import get_contribution, list_contributions, update_status
+from scripts.usage_meter import grant_credits
+
+CREDIT_REWARDS = {
+    "intake": 5,       # accepted intake report
+    "lesson": 20,      # accepted lesson draft
+}
+
+
+def accept_contribution(contrib_id: str, credits: int = 0, note: str = "", reviewer: str = "maintainer") -> dict:
+    """Accept a contribution and grant credits to the user."""
+    contrib = get_contribution(contrib_id)
+    if not contrib:
+        return {"error": f"Not found: {contrib_id}"}
+
+    if contrib["status"] != "pending":
+        return {"error": f"Cannot accept: status is '{contrib['status']}', expected 'pending'"}
+
+    # Update status to accepted
+    updated = update_status(contrib_id, "accepted", note=note, reviewer=reviewer)
+    if not updated:
+        return {"error": "Failed to update status"}
+
+    # Grant credits
+    credit_amount = credits or CREDIT_REWARDS.get(contrib["type"], 10)
+    user = contrib.get("user", "anonymous")
+    grant_result = grant_credits(user, credit_amount, reason="accepted_contribution", contribution_id=contrib_id)
+
+    return {
+        "accepted": True,
+        "id": contrib_id,
+        "user": user,
+        "credits_granted": credit_amount,
+        "credits_total": grant_result["credits_total"],
+        "note": note,
+    }
+
+
+def reject_contribution(contrib_id: str, reason: str = "", reviewer: str = "maintainer") -> dict:
+    """Reject a contribution. No credits granted."""
+    contrib = get_contribution(contrib_id)
+    if not contrib:
+        return {"error": f"Not found: {contrib_id}"}
+
+    if contrib["status"] != "pending":
+        return {"error": f"Cannot reject: status is '{contrib['status']}', expected 'pending'"}
+
+    updated = update_status(contrib_id, "rejected", note=reason, reviewer=reviewer)
+    if not updated:
+        return {"error": "Failed to update status"}
+
+    return {
+        "rejected": True,
+        "id": contrib_id,
+        "reason": reason,
+    }
+
+
+def show_review_summary() -> dict:
+    """Show summary of pending contributions for review."""
+    pending = list_contributions(status="pending")
+    accepted = list_contributions(status="accepted")
+    rejected = list_contributions(status="rejected")
+
+    return {
+        "pending": len(pending),
+        "accepted": len(accepted),
+        "rejected": len(rejected),
+        "pending_items": [
+            {"id": i["id"], "type": i["type"], "title": (i.get("title") or i.get("message", ""))[:60]}
+            for i in pending
+        ],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Contribution review — accept/reject/grant")
+    sub = parser.add_subparsers(dest="cmd")
+
+    # list
+    p_list = sub.add_parser("list", help="List contributions")
+    p_list.add_argument("--status", default="pending")
+    p_list.add_argument("--json", action="store_true")
+
+    # show
+    p_show = sub.add_parser("show", help="Show contribution details")
+    p_show.add_argument("id")
+
+    # accept
+    p_accept = sub.add_parser("accept", help="Accept contribution and grant credits")
+    p_accept.add_argument("id")
+    p_accept.add_argument("--credits", type=int, default=0, help="Override credit amount (0=auto)")
+    p_accept.add_argument("--note", default="")
+    p_accept.add_argument("--reviewer", default="maintainer")
+
+    # reject
+    p_reject = sub.add_parser("reject", help="Reject contribution")
+    p_reject.add_argument("id")
+    p_reject.add_argument("--reason", default="")
+    p_reject.add_argument("--reviewer", default="maintainer")
+
+    # summary
+    sub.add_parser("summary", help="Show review summary")
+
+    args = parser.parse_args()
+
+    if args.cmd == "list":
+        items = list_contributions(args.status)
+        if getattr(args, "json", False):
+            print(json.dumps(items, ensure_ascii=False, indent=2))
+        else:
+            if not items:
+                print(f"  No {args.status} contributions.")
+                return
+            print(f"\n  {'ID':<22} {'Type':<8} {'User':<20} {'Title'}")
+            print(f"  {'-'*22} {'-'*8} {'-'*20} {'-'*40}")
+            for i in items:
+                title = (i.get("title") or i.get("message", ""))[:40]
+                print(f"  {i['id']:<22} {i['type']:<8} {i.get('user',''):<20} {title}")
+        print()
+
+    elif args.cmd == "show":
+        contrib = get_contribution(args.id)
+        if contrib:
+            print(json.dumps(contrib, ensure_ascii=False, indent=2))
+        else:
+            print(f"  Not found: {args.id}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.cmd == "accept":
+        result = accept_contribution(args.id, args.credits, args.note, args.reviewer)
+        if "error" in result:
+            print(f"  Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+        print(f"  Accepted: {result['id']}")
+        print(f"  User: {result['user']}")
+        print(f"  Credits granted: {result['credits_granted']}")
+        print(f"  Credits total: {result['credits_total']}")
+
+    elif args.cmd == "reject":
+        result = reject_contribution(args.id, args.reason, args.reviewer)
+        if "error" in result:
+            print(f"  Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+        print(f"  Rejected: {result['id']}")
+        if result["reason"]:
+            print(f"  Reason: {result['reason']}")
+
+    elif args.cmd == "summary":
+        summary = show_review_summary()
+        print(f"\n  Contribution Review Summary")
+        print(f"  Pending:  {summary['pending']}")
+        print(f"  Accepted: {summary['accepted']}")
+        print(f"  Rejected: {summary['rejected']}")
+        if summary["pending_items"]:
+            print(f"\n  Pending items:")
+            for item in summary["pending_items"]:
+                print(f"    {item['id']}  [{item['type']}]  {item['title']}")
+        print()
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_contribution_review.py
+++ b/tests/test_contribution_review.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Test contribution review CLI — accept, reject, credit grants.
+
+Covers v2.14 MVP PR 4: maintainer review and credit grant.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.contribution_queue import submit_contribution
+from scripts.contribution_review import (
+    accept_contribution,
+    reject_contribution,
+    show_review_summary,
+)
+from scripts.usage_meter import get_status
+
+
+@pytest.fixture(autouse=True)
+def temp_files(tmp_path):
+    """Use temporary queue and usage files."""
+    queue_file = tmp_path / "contribution_queue.jsonl"
+    usage_file = tmp_path / "usage_credits.jsonl"
+    with patch("scripts.contribution_queue.QUEUE_FILE", queue_file), \
+         patch("scripts.usage_meter.USAGE_FILE", usage_file), \
+         patch("scripts.contribution_review.grant_credits") as mock_grant:
+        # Make grant_credits actually work by importing the real function
+        from scripts.usage_meter import grant_credits as real_grant
+        mock_grant.side_effect = real_grant
+        yield queue_file
+
+
+# ── Accept ──
+
+class TestAccept:
+    def test_accept_grants_credits(self):
+        result = submit_contribution(contrib_type="intake", message="good fix", user="anon:test")
+        accepted = accept_contribution(result["id"], credits=20, note="verified")
+        assert accepted["accepted"] is True
+        assert accepted["credits_granted"] == 20
+
+    def test_accept_auto_credits_intake(self):
+        result = submit_contribution(contrib_type="intake", message="intake report")
+        accepted = accept_contribution(result["id"])
+        assert accepted["credits_granted"] == 5  # default for intake
+
+    def test_accept_auto_credits_lesson(self):
+        result = submit_contribution(contrib_type="lesson", title="lesson draft", problem="X", fix="Y")
+        accepted = accept_contribution(result["id"])
+        assert accepted["credits_granted"] == 20  # default for lesson
+
+    def test_accept_nonexistent(self):
+        result = accept_contribution("contrib_nonexistent")
+        assert "error" in result
+
+    def test_accept_already_accepted(self):
+        result = submit_contribution(contrib_type="intake", message="test")
+        accept_contribution(result["id"])
+        again = accept_contribution(result["id"])
+        assert "error" in again
+
+
+# ── Reject ──
+
+class TestReject:
+    def test_reject_no_credits(self):
+        result = submit_contribution(contrib_type="intake", message="bad")
+        rejected = reject_contribution(result["id"], reason="duplicate")
+        assert rejected["rejected"] is True
+
+    def test_reject_nonexistent(self):
+        result = reject_contribution("contrib_nonexistent")
+        assert "error" in result
+
+    def test_reject_already_accepted(self):
+        result = submit_contribution(contrib_type="intake", message="test")
+        accept_contribution(result["id"])
+        rejected = reject_contribution(result["id"])
+        assert "error" in rejected
+
+
+# ── Summary ──
+
+class TestSummary:
+    def test_summary_counts(self):
+        submit_contribution(contrib_type="intake", message="item 1")
+        r2 = submit_contribution(contrib_type="intake", message="item 2")
+        accept_contribution(r2["id"])
+        summary = show_review_summary()
+        assert summary["pending"] == 1
+        assert summary["accepted"] == 1
+        assert summary["rejected"] == 0
+
+
+# ── End-to-end: submit -> accept -> credits consumed ──
+
+class TestE2E:
+    def test_contribution_to_credits_flow(self):
+        """Submit -> accept -> credits available for lesson reads."""
+        from scripts.usage_meter import check_lesson, record_read, FREE_READ_LIMIT
+
+        user = "anon:e2e-test"
+
+        # Exhaust free reads
+        for i in range(FREE_READ_LIMIT):
+            record_read(user, f"free-{i}")
+
+        # Verify quota exceeded
+        result = check_lesson(user, "test-lesson")
+        assert result["allowed"] is False
+
+        # Submit contribution
+        contrib = submit_contribution(contrib_type="intake", message="e2e test", user=user)
+
+        # Accept it
+        accepted = accept_contribution(contrib["id"], credits=10)
+        assert accepted["credits_granted"] == 10
+
+        # Now can read again
+        result = check_lesson(user, "test-lesson")
+        assert result["allowed"] is True
+        assert result["reason"] == "credit"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
PR 4 of v2.14 MVP — closes the contribution→credits loop.

**New files:**
- `scripts/contribution_review.py` — accept/reject/grant/summary
- `tests/test_contribution_review.py` — 10 tests

**Commands:**
- `list` — show pending contributions
- `show <id>` — view contribution details
- `accept <id> --credits N` — accept and grant credits
- `reject <id> --reason` — reject (no credits)
- `summary` — pending/accepted/rejected counts

**Credit rules:**
- Credits ONLY granted on accept (no auto-grant)
- Default: intake=5, lesson=20 credits
- Override with `--credits N`

**E2E test:** submit → accept → credits available → lesson reads succeed