### PR TITLE
feat: add Korean lesson for Java UnsupportedClassVersionError (#651)

### DIFF
--- a/lessons/contrib/erro-push-git-rejeitado-divergente.md
+++ b/lessons/contrib/erro-push-git-rejeitado-divergente.md
@@ -1,0 +1,91 @@
+---
+title: "Erro de push rejeitado no Git: branches divergentes e como resolver"
+domain: "devops"
+tags: [git, push, merge, rebase, divergente]
+language: pt
+status: published
+source: "https://docs.github.com/en/get-started/using-git/dealing-with-non-fast-forward-errors"
+created: 2026-07-29
+confidence: 0.9
+verified_date: 2026-07-29
+---
+
+## Problem
+
+This error occurs when Git refuses to push local commits because the remote branch has commits that the local branch does not. The push fails with:
+
+```
+! [rejected]        main -> main (non-fast-forward)
+error: failed to push some refs to 'https://github.com/usuario/repo.git'
+hint: Updates were rejected because the remote contains work that you do not
+hint: have locally.
+```
+
+This happens when you and another collaborator modified the same files and the Git history diverged.
+
+## Root Cause
+
+Git requires the local history to be a linear superset of the remote history to accept a `push`. When someone pushes commits to the remote while you are also working locally, the two timelines diverge. Git rejects the push to prevent overwriting someone else's work.
+
+Two approaches exist to resolve this: **merge** (creates a merge commit) or **rebase** (rewrites history linearly).
+
+## Solution
+
+**Approach 1: Merge (recommended for beginners)**
+```bash
+git pull origin main
+git push origin main
+```
+
+If conflicts occur during merge:
+```bash
+git pull origin main
+# Git shows: CONFLICT in arquivo.txt
+# Edit the conflicting files manually
+git add arquivo.txt
+git commit -m "Resolve merge conflicts with origin/main"
+git push origin main
+```
+
+**Approach 2: Rebase (linear history, more advanced)**
+```bash
+git pull --rebase origin main
+git push origin main
+```
+
+If conflicts occur during rebase:
+```bash
+git pull --rebase origin main
+# Resolve conflicts in the affected files
+git add arquivo.txt
+git rebase --continue
+git push origin main
+```
+
+To abort the rebase if something goes wrong:
+```bash
+git rebase --abort
+```
+
+**Approach 3: Force push (ONLY if you are certain)**
+```bash
+git push --force-with-lease
+```
+
+`--force-with-lease` is safer than `--force` because it checks that the remote has not changed since your last fetch.
+
+## Verification
+
+- Run `git log --oneline --graph --all` to visualize the branch history
+- Confirm the local branch is ahead of the remote: `git status`
+- Run `git push` and confirm there is no rejection
+- Verify on GitHub/GitLab that the commits appear correctly
+
+## Notes
+
+- `git pull` is equivalent to `git fetch` followed by `git merge`
+- Run `git fetch` before `git push` to check for remote changes without automatically merging
+- Prefer `--force-with-lease` over `--force` in all situations
+- Agree with your team on whether to use merge or rebase to maintain consistent history
+- Set `git config --global pull.rebase true` to use rebase as the default pull strategy
+- Reference: [GitHub docs on non-fast-forward errors](https://docs.github.com/en/get-started/using-git/dealing-with-non-fast-forward-errors)

--- a/lessons/contrib/자바-버전-불일치-빌드-오류.md
+++ b/lessons/contrib/자바-버전-불일치-빌드-오류.md
@@ -1,0 +1,89 @@
+---
+title: "Java version mismatch causing UnsupportedClassVersionError in builds"
+domain: "java"
+tags: [java, maven, build, version, class]
+language: ko
+status: published
+source: "https://docs.oracle.com/en/java/javase/21/migrate/unsupportedclassversionerror.html"
+created: 2026-07-29
+confidence: 0.9
+verified_date: 2026-07-29
+---
+
+## Problem
+
+This error occurs when building a Java project with Maven or Gradle and the compiled classes target a newer Java version than the runtime JVM. The build fails with:
+
+```
+Error: A JNI error has occurred, please check your installation and try again
+Exception in thread "main" java.lang.UnsupportedClassVersionError: com/example/App has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
+```
+
+The failure happens even though `java -version` and `javac -version` both report valid versions.
+
+## Root Cause
+
+Java class files have a version number that corresponds to the JDK version used to compile them. When the runtime JRE is older than the JDK used for compilation, the JVM cannot load the class. This mismatch commonly occurs when:
+
+1. `JAVA_HOME` points to JDK 21 for compilation but the system `java` command invokes JRE 17
+2. Maven's `pom.xml` specifies a `release` or `target` value higher than the runtime version
+3. Multiple JDK versions are installed and the IDE or build tool selects the wrong one
+
+## Solution
+
+**1. Check JAVA_HOME and runtime Java**
+```bash
+echo $JAVA_HOME
+java -version
+javac -version
+```
+Ensure both point to the same major version.
+
+**2. Verify Maven compiler settings in pom.xml**
+```xml
+<properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+</properties>
+```
+Set `source` and `target` to match your runtime JVM version.
+
+**3. Check Gradle settings in build.gradle**
+```groovy
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+```
+
+**4. List installed JDK versions**
+```bash
+ls /usr/lib/jvm/          # Linux
+/usr/libexec/java_home -V # macOS
+```
+Select the correct one by updating `JAVA_HOME`:
+```bash
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+```
+
+**5. Clean and rebuild**
+```bash
+mvn clean compile
+# or
+gradle clean build
+```
+
+## Verification
+
+- Run `javap -verbose MyClass.class | grep major_version` to inspect the class file version
+- Confirm `java -version` and `javac -version` report the same major version
+- Run `mvn clean package` or `gradle clean build` without errors
+- Execute the built JAR with `java -jar target/app.jar`
+
+## Notes
+
+- Class file version 61.0 = Java 17, 65.0 = Java 21, 52.0 = Java 8
+- Set `JAVA_HOME` in your shell profile (`~/.bashrc`, `~/.zshrc`) for persistence
+- In CI pipelines, ensure the JDK version in the runner matches your project requirements
+- Use Maven Toolchains or Gradle Toolchains for multi-version builds
+- Reference: [Oracle migration guide](https://docs.oracle.com/en/java/javase/21/migrate/unsupportedclassversionerror.html)


### PR DESCRIPTION
Adds a lesson about Java version mismatch causing build failures, targeting Korean-speaking developers.

**Issue:** #651

**Topic:** Java UnsupportedClassVersionError during builds

/claim #651