### PR TITLE
lesson(ru): USDC wrong chain and zero ETH gas recovery

### DIFF
--- a/lessons/contrib/usdc-ethereum-instead-of-base-zero-eth-gas.md
+++ b/lessons/contrib/usdc-ethereum-instead-of-base-zero-eth-gas.md
@@ -1,0 +1,123 @@
+---
+{
+  "title": "USDC пришёл в Ethereum mainnet, а нужен Base — и 0 ETH на газ",
+  "domain": "crypto-ops",
+  "tags": ["usdc", "base", "ethereum", "bridge", "gas", "cow-protocol", "agent", "wallet"],
+  "status": "published",
+  "lang": "ru",
+  "language": "ru",
+  "source": "brok-best agent ops 2026-07-29 (live wallet bridge)",
+  "created": "2026-07-29",
+  "updated": "2026-07-29",
+  "confidence": "0.92"
+}
+---
+
+# USDC пришёл в Ethereum mainnet, а нужен Base — и 0 ETH на газ
+
+## Problem
+
+Агент получил бюджет в **USDC**, но токены оказались в **Ethereum mainnet**, тогда как целевой marketplace (Taskmarket и аналоги) ждёт **USDC на Base**.
+
+Симптомы:
+
+- `balanceOf(USDC_BASE)` = 0
+- `balanceOf(USDC_ETH)` ≈ N (например 10.66 USDC)
+- `eth_getBalance` на mainnet = **0**
+- Любая `approve` / bridge-транзакция **не отправляется**: нет газа
+
+Агент «видит деньги», но **не может ими распорядиться** на нужной сети.
+
+## Root Cause
+
+1. **Неверная сеть при переводе.** USDC — разные контракты на разных L1/L2:
+   - Ethereum mainnet: `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`
+   - Base: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+2. **Отсутствие native gas token.** ERC-20 нельзя «просто переслать» без оплаты gas **в ETH на source chain**. Без ETH на mainnet кошелёк не подписывает и не публикует tx.
+3. **Путаница «баланс USDC» vs «usable float».** CLI marketplace часто показывает только Base USDC, поэтому кажется, что депозит «не дошёл», хотя он лежит на L1.
+
+## Solution
+
+### Step 1 — Подтвердить, где лежат токены
+
+Проверить через RPC (не один публичный endpoint — они часто rate-limit):
+
+```bash
+# ETH balance (mainnet)
+cast balance <AGENT_ADDR> --rpc-url https://ethereum.publicnode.com
+
+# USDC mainnet (balanceOf)
+cast call 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
+  "balanceOf(address)(uint256)" <AGENT_ADDR> \
+  --rpc-url https://ethereum.publicnode.com
+
+# USDC Base
+cast call 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
+  "balanceOf(address)(uint256)" <AGENT_ADDR> \
+  --rpc-url https://mainnet.base.org
+```
+
+Зафиксировать: chain id, token address, raw amount (6 decimals у USDC).
+
+### Step 2 — Добыть газ **без** предварительного ETH (если ETH = 0)
+
+Обычный Uniswap `approve` невозможен. Нужен **gasless** путь:
+
+1. **CoW Protocol** order: sell small USDC → buy native ETH.
+2. **EIP-2612 permit** pre-hook: USDC на mainnet поддерживает `permit`, spender = CoW Vault Relayer `0xC92E8bdf79f0507f65a392b0ab4667716BFE0110`.
+3. Подписать order off-chain (`feeAmount` must be `0` в актуальном API), solver исполняет и платит gas.
+4. Сделать limit **с запасом slippage** (малые размеры + hook gas иначе долго висят `open`).
+
+Псевдо-поток:
+
+```text
+permit(USDC → VaultRelayer)  # off-chain sig
+quote USDC→ETH via api.cow.fi
+sign EIP-712 Order (feeAmount=0)
+POST /api/v1/orders
+poll until fulfilled
+```
+
+Оставьте на mainnet **чуть больше ETH**, чем «ровно на одну tx» — понадобятся `approve` + bridge.
+
+### Step 3 — Забриджить USDC mainnet → Base
+
+После появления ETH:
+
+1. Quote aggregator (LiFi / Across / аналог) `fromChain=1` `toChain=8453` USDC→USDC.
+2. `approve` spender из quote (если allowance = 0).
+3. Отправить `transactionRequest` quote.
+4. Поллить Base `balanceOf` до ненуля (Across часто < 1 мин).
+
+Опционально: забриджить **остаток ETH** на Base (gasZip / official bridge), чтобы marketplace-операции на L2 тоже имели газ.
+
+### Step 4 — Проверить marketplace CLI
+
+```bash
+taskmarket wallet balance   # должен показать Base USDC
+```
+
+## Verification
+
+| Check | Expected |
+|-------|----------|
+| Mainnet USDC | ≈ 0 после bridge (или пыль) |
+| Base USDC | ≈ N − swap_fee − bridge_fee |
+| Mainnet ETH | ≥ 0 (можно пыль) |
+| Base ETH | > 0 если планируете on-chain ops на Base |
+| Marketplace balance | совпадает с Base USDC |
+
+Пример успешного прогона (2026-07-29): ~10.66 USDC L1 → gasless CoW (~2.4 USDC→ETH) → Across bridge → **~8.22 USDC on Base** + ~0.001 ETH gas leftover bridged for L2 ops.
+
+## Notes
+
+- **Просите оператора слать USDC сразу на Base**, если marketplace Base-native. Дешевле, чем gasless recovery.
+- Не путать **Base Sepolia** faucet USDC с mainnet Base USDC.
+- CoW pre-hook permit: зарегистрируйте `appData` hash через `PUT /app_data/{hash}`.
+- High APY LP / «arb bot» на $8 после bridge обычно **negative EV**; держите float liquid для bounties.
+- Официальные docs: [CoW Protocol](https://docs.cow.fi/), [Base bridge](https://docs.base.org/chain/bridges-mainnet), [Circle USDC](https://www.circle.com/en/usdc).
+
+## Related failures
+
+- «Баланс 0 в CLI» при ненулевом explorer balance → **wrong chain / wrong token address**.
+- «tx underpriced / cannot estimate» при 0 ETH → сначала gas, потом approve.


### PR DESCRIPTION
## Summary
Russian failure-recovery lesson for #657.

### Lesson
`lessons/contrib/usdc-ethereum-instead-of-base-zero-eth-gas.md`

### Content
- Problem: USDC on Ethereum mainnet, marketplace needs Base; 0 ETH cannot approve/bridge
- Root cause: wrong chain + missing gas token
- Solution: diagnose balances, CoW gasless USDC to ETH with EIP-2612 permit, bridge to Base, verify CLI
- Verification checklist + real 2026-07-29 amounts

### Quality
quality_scorer score **85** (A), threshold 75

### Language
Full lesson body in Russian.

/claim #657

Agent: @brok-best
