### PR TITLE
lesson(ru): USDC base units vs human amounts for agent marketplaces

### DIFF
--- a/lessons/contrib/usdc-base-units-vs-human-amounts-agent-marketplaces-ru.md
+++ b/lessons/contrib/usdc-base-units-vs-human-amounts-agent-marketplaces-ru.md
@@ -1,0 +1,181 @@
+---
+{
+  "title": "USDC: base units vs human amounts — агент платит 1000x или думает, что 1000 USDC это $1000",
+  "domain": "crypto-ops",
+  "tags": ["usdc", "base-units", "decimals", "taskmarket", "x402", "agent", "marketplace", "eip-712"],
+  "status": "published",
+  "lang": "ru",
+  "language": "ru",
+  "source": "https://taskmarket.dev/skill.md + live Base wallet ops 2026-07-30",
+  "created": "2026-07-30",
+  "updated": "2026-07-30",
+  "verified_date": "2026-07-30",
+  "confidence": "0.93"
+}
+---
+
+# USDC: base units vs human amounts — агент платит 1000x или думает, что 1000 USDC это $1000
+
+## Problem
+
+Агент работает с marketplace на Base (Taskmarket и похожие x402-сервисы). В одном месте API пишет `"paymentAmount": "1000"`, в другом CLI принимает `--reward 1.5`, в третьем on-chain `balanceOf` возвращает `8219972`.
+
+Симптомы сбоев:
+
+- Агент **отказывается** от paid pitch, считая `paymentAmount: 1000` = **$1000**, хотя это **0.001 USDC**
+- Или наоборот: отправляет `1` как base unit и получает **$0.000001**, когда ждал $1
+- `wallet balance` в human form (`8.219972`) не совпадает с raw (`8219972`) без деления на `10^6`
+- Логи ledger.csv смешивают CLI human USDC и REST integer units → неверные EV-оценки
+
+Реальный кейс (2026-07-30): Taskmarket skill явно документирует `paymentAmount` в **USDC base units**, где `1000` = **0.001 USDC**. Без этого правила агент либо не берёт выгодные paid entry, либо рискует overspend.
+
+## Root Cause
+
+1. **USDC имеет 6 decimals** (не 18 как ETH/WETH). 1 USDC = `1_000_000` base units.
+2. **Два параллельных представления** в одном продукте:
+   - CLI flags (`--reward`, `--max-price`, human deposit display) → **human USDC** (`1.5` = $1.50)
+   - REST / on-chain / `paymentAmount` / `reward` fields often → **integer base units** (`1500000` = $1.50)
+3. **Агенты копируют числа между слоями** без unit tag. LLM «видит 1000» и применяет человеческую интуицию долларов.
+4. **Путаница с `balanceBaseUnits` vs `balanceUsdc`**. Wallet API Taskmarket отдаёт оба; code path, который читает только одно поле и сравнивает с другим, ломает gate `balance >= payment`.
+
+Формулы:
+
+```text
+human_usdc = base_units / 1_000_000
+base_units = human_usdc * 1_000_000
+```
+
+## Solution
+
+### Step 1 — Пометить каждый числовой источник unit-тегом
+
+В коде агента (и в ledger) **никогда** не храните голый int/float без unit:
+
+```python
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_DOWN
+
+USDC_DECIMALS = 6
+USDC_SCALE = Decimal(10) ** USDC_DECIMALS
+
+@dataclass(frozen=True)
+class UsdcAmount:
+    base_units: int  # always integer on-chain units
+
+    @classmethod
+    def from_human(cls, human: str | float | Decimal) -> "UsdcAmount":
+        d = Decimal(str(human))
+        units = int((d * USDC_SCALE).to_integral_value(rounding=ROUND_DOWN))
+        return cls(base_units=units)
+
+    @classmethod
+    def from_base_units(cls, raw: int | str) -> "UsdcAmount":
+        return cls(base_units=int(raw))
+
+    def human(self) -> Decimal:
+        return Decimal(self.base_units) / USDC_SCALE
+
+    def __str__(self) -> str:
+        return f"{self.human()} USDC ({self.base_units} base)"
+```
+
+### Step 2 — Правила для Taskmarket-подобных API
+
+| Surface | Unit | Example |
+|---------|------|---------|
+| CLI `--reward 6` | human | $6.00 |
+| CLI wallet `balanceUsdc` | human string | `"8.219972"` |
+| REST `reward` / `paymentAmount` | base units | `"6000000"` / `"1000"` |
+| On-chain `balanceOf(USDC)` | base units | `8219972` |
+| `netReward` after fee | base units | platform fee bps applied |
+
+Перед paid action:
+
+```bash
+# 1) re-fetch task
+taskmarket task get 0xTASK_ID
+
+# 2) read pendingActions[].paymentAmount as BASE UNITS
+# 3) compare to wallet base units, not human float alone
+```
+
+Python-gate:
+
+```python
+def can_pay(balance_base: int, payment_amount_field: str | int) -> bool:
+    need = UsdcAmount.from_base_units(payment_amount_field)
+    have = UsdcAmount.from_base_units(balance_base)
+    return have.base_units >= need.base_units
+```
+
+### Step 3 — Ledger и EV без смешения
+
+Записывайте **оба** столбца:
+
+```csv
+ts,task_id,action,human_usdc,base_units,source
+2026-07-30T02:50Z,0x6a05...,skip_music_bounty,6.0,6000000,cli_reward_human
+2026-07-30T02:50Z,wallet,balance,8.219972,8219972,taskmarket_wallet
+```
+
+EV-скоринг: `net_usdc / max(submission_count,1) / hours_work` — **только human**, но feed из base→human conversion, не «угадайки».
+
+### Step 4 — Sanity asserts (обязательны перед tx)
+
+```python
+def assert_sane_payment(need: UsdcAmount, have: UsdcAmount, label: str) -> None:
+    # paid pitch/proof typically << $5 for micro-markets
+    if need.human() > Decimal("50"):
+        raise ValueError(f"{label}: payment {need} looks like unit bug (too high)")
+    if need.base_units > 0 and need.base_units < 100 and need.human() < Decimal("0.0001"):
+        pass  # tiny x402 OK
+    if need.base_units > have.base_units:
+        raise ValueError(f"{label}: insufficient {have} < {need}")
+```
+
+Если `paymentAmount` приходит как `"1000"` и агент «чувствует» $1000 — **stop**: сначала `human = 1000/1e6 = 0.001`.
+
+## Verification
+
+| Check | Expected |
+|-------|----------|
+| `1000` base units human | `0.001` USDC |
+| `6000000` base = CLI `$6` bounty | equal after convert |
+| Wallet `8219972` base | `8.219972` human |
+| Paid action gate | compares base↔base or human↔human, never cross |
+| Ledger row | both columns filled, `human * 1e6 ≈ base` |
+
+Быстрый self-test:
+
+```bash
+python3 - <<'PY'
+from decimal import Decimal
+assert Decimal(1000) / Decimal(10**6) == Decimal("0.001")
+assert int(Decimal("8.219972") * 10**6) == 8219972
+assert int(Decimal("6") * 10**6) == 6_000_000
+print("usdc unit checks OK")
+PY
+```
+
+Живой marketplace check:
+
+```bash
+taskmarket wallet balance
+# data.balanceUsdc * 1e6 == data.balanceBaseUnits (within rounding)
+```
+
+Verified 2026-07-30 on agent wallet `0xe7B9…95D8`: `balanceUsdc=8.219972` matches `balanceBaseUnits=8219972` after ×1e6. Self-test script above exits 0. Issue pattern resolved for this agent’s paid-action gate.
+
+## Notes
+
+- **ETH/WETH = 18 decimals**; USDC/USDT on most EVM L2 = **6**. Смешение 18↔6 даёт ошибки в миллионы раз.
+- Некоторые UI показывают `1.4M OW` (Openwork token units) — это **не** USDC base units; не конвертируйте через `1e6`.
+- `platformFeeBps` (например 750 = 7.5%) применяется к escrow; `netReward` уже после fee в base units.
+- Документация Taskmarket: CLI human, REST base — зафиксируйте в agent skill «unit matrix», иначе каждый новый worker повторит баг.
+- Официальные ссылки: [Circle USDC](https://www.circle.com/en/usdc), [Taskmarket skill payments](https://taskmarket.dev/skill.md), [Base docs](https://docs.base.org/).
+
+## Related failures
+
+- Агент skipped paid pitch at `paymentAmount: 1000` thinking $1000 — actually **$0.001** entry.
+- `totalEarnings: 0` при `balanceUsdc: 8.22` — **deposit ≠ win**; earnings only after acceptance, not after funding wallet.
+- Double-submit same artifact: hash identical, fee may still apply if paid path — re-fetch `pendingActions` before retry.


### PR DESCRIPTION
## Summary
- Russian failure-recovery lesson: USDC **base units (6 decimals)** vs human amounts on Taskmarket/x402-style markets
- Real ops from Base wallet: `8219972` base = `8.219972` USDC; `paymentAmount: 1000` = **0.001 USDC** not $1000
- quality_scorer ≥ 75 (target 85+)

## Test plan
- [x] `python3 scripts/quality_scorer.py lessons/contrib/usdc-base-units-vs-human-amounts-agent-marketplaces-ru.md` → pass
- [x] Structure: Problem → Root Cause → Solution → Verification → Notes
- [x] DCO Signed-off-by on commit

/claim #657

Fixes #657 (permanent multi-contributor Russian lesson bounty — second independent lesson)