### PR TITLE
fix: update metadata counts per audit #684

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ mcp-name: io.github.Ikalus1988/misakanet
 
 ### What is this?
 
-MisakaNet is a failure-memory layer for AI coding agents. When your agent hits an error — DCO failure, pip timeout, GitHub 401, MCP setup issue — MisakaNet searches 249 indexed failure-recovery lessons and returns a fix path. No prompt leaking, no raw logs stored.
+MisakaNet is a failure-memory layer for AI coding agents. When your agent hits an error — DCO failure, pip timeout, GitHub 401, MCP setup issue — MisakaNet searches 380 indexed failure-recovery lessons and returns a fix path. No prompt leaking, no raw logs stored.
 
 ### When to use it
 
@@ -69,7 +69,7 @@ python3 search_knowledge.py "GitHub token 401"
 
 | | Component | Purpose |
 |---|---|---|
-| **Core** | `search_knowledge.py` | Search 249 indexed failure-recovery lessons |
+| **Core** | `search_knowledge.py` | Search 380 indexed failure-recovery lessons |
 | **Core** | MCP server | Give Cursor / Claude Code access to lessons |
 | **Core** | `POST /api/intake` | Submit redacted failure reports |
 | Optional | `misakanet capture` | CLI capture from local failures |
@@ -121,7 +121,7 @@ Didn't find a fix? [📮 Share your failure lesson →](https://github.com/Ikalu
 | **Best for** | DCO failures, GitHub token errors, pip timeout, Feishu API, WSL, FANUC |
 | **Not for** | Private memory storage, hosted vector database, general chatbot memory |
 | **License** | Apache 2.0 |
-| **Data** | 249 lessons, 235+ nodes, 18 domains |
+| **Data** | 380 lessons, 1947+ nodes, 9 domains |
 
 ---
 
@@ -402,8 +402,8 @@ python3 scripts/lesson_reuse_bench.py --compare         # with vs without lesson
 
 | Metric | Value |
 |--------|-------|
-| Shared Lessons | 249 |
-| Registered Nodes | 235+ |
+| Shared Lessons | 380 |
+| Registered Nodes | 1947+ |
 | Agent Types | CodeWhale, Claude, Codex, OpenClaw, OpenCode |
 | npm packages | [`@misaka-net/fatal-guard`](https://www.npmjs.com/package/@misaka-net/fatal-guard) |
 | PyPI packages | [`misakanet-core`](https://pypi.org/project/misakanet-core/) |

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Ikalus1988/misakanet",
-  "description": "Agent failure memory network. Search 249 indexed failure-recovery lessons and route redacted feedback intake for maintainers.",
+  "description": "Agent failure memory network. Search 380 indexed failure-recovery lessons and route redacted feedback intake for maintainers.",
   "repository": {
     "url": "https://github.com/Ikalus1988/MisakaNet",
     "source": "github"


### PR DESCRIPTION
## Fixes #684

Updates outdated metadata counts found during the audit:

### README.md
- Line 26: 249 → 380 lessons
- Line 72: 249 → 380 lessons  
- Line 124: 249 lessons, 235+ nodes, 18 domains → 380 lessons, 1947+ nodes, 9 domains
- Line 405: 249 → 380 shared lessons; 235+ → 1947+ registered nodes

### server.json
- Description: 249 → 380 indexed failure-recovery lessons

### Verification
385
1947
9

All other checks passed:
- ✅ Glama: page live, server.json accessible
- ✅ MCP Registry: schema valid, name format correct, version 2.14.0 consistent
- ✅ PyPI: misakanet v2.14.0 matches, misakanet-core v2.7.0 matches dependency
- ✅ Badges: Glama badge returns 200