### PR TITLE
ci: add PR Genius GitHub Action for automated PR analysis

### DIFF
--- a/.github/workflows/pr-genius-check.yml
+++ b/.github/workflows/pr-genius-check.yml
@@ -1,0 +1,50 @@
+name: PR Genius Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-genius:
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'docs-only')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: zsxh1990/pr-genius/.github/actions/pr-genius-check@v1.0.0
+        id: pr-genius
+        with:
+          title: ${{ github.event.pull_request.title }}
+          repo: ${{ github.repository }}
+          body: ${{ github.event.pull_request.body }}
+
+      - name: Output PR Genius result
+        if: always()
+        shell: bash
+        env:
+          TIER: ${{ steps.pr-genius.outputs.tier }}
+          RESULT: ${{ steps.pr-genius.outputs.result }}
+        run: |
+          echo "=========================================="
+          echo "PR Genius Analysis"
+          echo "=========================================="
+          echo "Risk Level: $TIER"
+          echo ""
+          echo "$RESULT" | python3 -c "
+          import json, sys
+          try:
+              d = json.load(sys.stdin)
+              checklist = d.get('checklist', [])
+              if checklist:
+                  print('Checklist:')
+                  for c in checklist:
+                      print(f\"  [{c.get('priority','')}] {c.get('action','')}: {c.get('hint','')}\")
+          except:
+              pass
+          " 2>/dev/null
+          echo "=========================================="


### PR DESCRIPTION
## Summary
Add [PR Genius](https://github.com/zsxh1990/pr-genius) GitHub Action to automatically analyze every PR.

### What it does
- Runs on every PR open/sync (skips draft and docs-only)
- Analyzes PR title, body, and repo context
- Outputs risk level (🟢/🟡/🔴) to console

### Security
- Pinned to @v1.0.0 (not @main)
- Permissions: contents: read only
- No PR comments (console output only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)