### PR TITLE
chore: reject generated cache files in PRs (Closes #746)

### DIFF
--- a/.github/workflows/pr-shape-guard.yml
+++ b/.github/workflows/pr-shape-guard.yml
@@ -78,9 +78,15 @@ jobs:
               if (name === 'search_knowledge.py' && f.deletions > 100) {
                 failures.push(`**核心文件高风险删除**: \`search_knowledge.py\` 删除了 ${f.deletions} 行，需要人工 review。`);
               }
+
+              // Rule 5: generated cache / build artifacts
+              const cachePatterns = [/__pycache__\//, /\.pyc$/, /\.pytest_cache\//, /\.egg-info\//];
+              if (cachePatterns.some(p => p.test(name))) {
+                failures.push(`**缓存/构建产物泄露**: \`${name}\` 是自动生成的缓存文件，提交前请清理。`);
+              }
             }
 
-            // Rule 5: docs-only title but code changed
+            // Rule 6: docs-only title but code changed
             const titleBody = `${pr.title}\n${pr.body || ''}`.toLowerCase();
             const claimsDocsOnly = titleBody.includes('docs:') || titleBody.includes('docs-only') || titleBody.includes('[docs]');
             const codeChanged = files.some(f => /\.(py|js|ts|go)$/.test(f.filename));

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python
 __pycache__/
 *.pyc
+.pytest_cache/
 .cache/
 node_modules/
 misakanet/profile.json


### PR DESCRIPTION
## Summary

Add Rule 5 to PR Shape Guard to reject PRs containing generated cache/build artifact files, as described in #746.

## Changes

### `.github/workflows/pr-shape-guard.yml`
- **New Rule 5**: Detects and rejects PRs that include generated cache/build files:
  - `__pycache__/` directories
  - `*.pyc` bytecode files
  - `.pytest_cache/` directories
  - `*.egg-info/` directories
- Clear error message in Chinese: \"缓存/构建产物泄露\"
- Renamed old Rule 5 → Rule 6

### `.gitignore`
- Added `.pytest_cache/` entry

## Acceptance Criteria
- ✅ Shape guard detects `__pycache__/` files
- ✅ Clear error message: \"缓存/构建产物泄露\"
- ✅ Does NOT affect normal docs-only PRs (only triggers when generated files are in the diff)
- ✅ Test: PR with pycache/ is rejected (shape guard fails)

Closes #746