### PR TITLE
feat: define deterministic Agent Self-Healing task catalog

### DIFF
--- a/data/benchmark_tasks.json
+++ b/data/benchmark_tasks.json
@@ -1,0 +1,82 @@
+[
+  {
+    "task_id": "self-heal-dco-signoff",
+    "title": "DCO sign-off failure — commit missing Signed-off-by",
+    "failure": "PR fails DCO check because one or more commits lack a Signed-off-by trailer.",
+    "expected_action": "Run git rebase --signoff (or git commit --amend --signoff) to add the trailer to every commit, then force-push.",
+    "lesson_ref": "lessons/core/dco-auto-fix-workflow.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-pip-timeout",
+    "title": "pip install timeout — network stalls on PyPI",
+    "failure": "pip install times out after 15 s with ConnectionError or SSLError.",
+    "expected_action": "Switch to a mirror index-url (e.g. tsinghua), increase --default-timeout, or add --trusted-host as a temporary bypass.",
+    "lesson_ref": "lessons/contrib/pip-install-timeout-ssl.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-github-401",
+    "title": "GitHub API 401 — local credential lookup before asking for a new token",
+    "failure": "GitHub API returns HTTP 401 Bad credentials. The agent asks the user for a new PAT without checking local stores.",
+    "expected_action": "Inspect ~/.git-credentials, ~/.netrc, gh auth status, $GITHUB_TOKEN, and git credential.helper config in that order; only then request a new token.",
+    "lesson_ref": "lessons/contrib/github-401-credential-lookup.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-mcp-path-error",
+    "title": "MCP server path error — module not found at runtime",
+    "failure": "MCP server fails to start with ModuleNotFoundError because PYTHONPATH or the working directory is wrong.",
+    "expected_action": "Set PYTHONPATH to the project root or install the package in editable mode (pip install -e .) before launching the server.",
+    "lesson_ref": "lessons/contrib/python-sandbox-path-isolation.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-windows-gbk",
+    "title": "Windows GBK encoding error — subprocess output crashes on decode",
+    "failure": "Python subprocess on Windows raises UnicodeDecodeError because stdout uses GBK instead of UTF-8.",
+    "expected_action": "Set PYTHONIOENCODING=utf-8, use errors='replace' in open/read calls, or switch the console code page to UTF-8 (chcp 65001).",
+    "lesson_ref": "lessons/contrib/python-gbk-encoding-error.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-pytest-importerror",
+    "title": "pytest ImportError — stale __pycache__ after a module rename",
+    "failure": "pytest crashes with ImportError after renaming a module because .pyc cache still exports the old symbol.",
+    "expected_action": "Remove __pycache__ and .pytest_cache, then re-run pytest.",
+    "lesson_ref": "lessons/contrib/python-pycache-stale.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-cloudflare-deploy",
+    "title": "Cloudflare Worker deploy failure — wrangler.toml missing or misconfigured",
+    "failure": "npx wrangler deploy exits non-zero because the Worker is not bound to the correct account_id or route.",
+    "expected_action": "Verify wrangler.toml has the right account_id, route, and zone_id; run wrangler whoami to confirm the logged-in account.",
+    "lesson_ref": "lessons/contrib/cloudflare-email-worker-registration-trap.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-json-schema-error",
+    "title": "JSON schema validation error — input missing required fields",
+    "failure": "Downstream tool rejects a JSON payload because required keys are absent or the type is wrong.",
+    "expected_action": "Validate the payload against the JSON schema before sending; fix missing or mistyped fields.",
+    "lesson_ref": "lessons/contrib/json-parse-failure-handling.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-npm-publish-403",
+    "title": "npm publish 403 — scope not owned or token lacks privilege",
+    "failure": "npm publish returns HTTP 403 because the auth token does not have publish rights for the scope.",
+    "expected_action": "Check npm auth token (npm whoami), ensure 2FA is enabled, and verify the scope is owned; regenerate the token if needed.",
+    "lesson_ref": "lessons/contrib/npm-eacces-permission-error-linux.md",
+    "verifier_type": "command_exit"
+  },
+  {
+    "task_id": "self-heal-stale-generated-data",
+    "title": "Stale generated data cleanup — lessons.json or index.md out of sync",
+    "failure": "Generated artifacts (data/lessons.json, lessons/index.md) are stale after adding/removing lesson files.",
+    "expected_action": "Run the regeneration script (python3 scripts/update_lessons_json.py and/or python3 scripts/build_lesson_pages.py) and verify the generated file checksum changed.",
+    "lesson_ref": "lessons/contrib/shared-json-needs-atomic-write.md",
+    "verifier_type": "command_exit"
+  }
+]

--- a/tests/test_benchmark_tasks.py
+++ b/tests/test_benchmark_tasks.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Tests for benchmark task catalog schema and references."""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from misakanet.search.engine import REPO
+
+TASKS_FILE = REPO / "data" / "benchmark_tasks.json"
+REQUIRED_FIELDS = {"task_id", "title", "failure", "expected_action", "lesson_ref", "verifier_type"}
+VALID_VERIFIERS = {"command_exit", "http_status", "file_content", "log_pattern", "process_alive"}
+
+
+def _load_tasks():
+    with open(TASKS_FILE, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestBenchmarkTasks:
+    def test_file_exists(self):
+        assert TASKS_FILE.exists(), f"{TASKS_FILE} not found"
+
+    def test_minimum_count(self):
+        tasks = _load_tasks()
+        assert len(tasks) >= 10, f"Expected >= 10 tasks, got {len(tasks)}"
+
+    def test_unique_ids(self):
+        tasks = _load_tasks()
+        ids = [t["task_id"] for t in tasks]
+        assert len(ids) == len(set(ids)), "Duplicate task_id found"
+
+    def test_schema_fields(self):
+        tasks = _load_tasks()
+        for task in tasks:
+            missing = REQUIRED_FIELDS - set(task.keys())
+            assert not missing, f"Task {task.get('task_id')} missing fields: {missing}"
+
+    def test_verifier_type_valid(self):
+        tasks = _load_tasks()
+        for task in tasks:
+            vtype = task.get("verifier_type")
+            assert vtype in VALID_VERIFIERS, (
+                f"Invalid verifier_type '{vtype}' in {task.get('task_id')}"
+            )
+
+    def test_no_random_simulated_results(self):
+        tasks = _load_tasks()
+        for task in tasks:
+            assert "random" not in task["failure"].lower()
+            assert "simulated" not in task["failure"].lower()
+            assert "fake" not in task["failure"].lower()
+            assert "random" not in task["expected_action"].lower()
+
+    def test_lesson_refs_exist(self):
+        tasks = _load_tasks()
+        for task in tasks:
+            ref = Path(task["lesson_ref"])
+            assert ref.exists(), f"lesson_ref not found: {ref}"
+
+    def test_expected_action_present(self):
+        tasks = _load_tasks()
+        for task in tasks:
+            action = task.get("expected_action", "")
+            assert len(action) >= 10, (
+                f"expected_action too short in {task.get('task_id')}"
+            )


### PR DESCRIPTION
Closes #742

- Add data/benchmark_tasks.json with 10 deterministic tasks
- Each task includes id, failure, expected_action, lesson_ref, verifier_type
- Add schema validation test (JSON structure, unique IDs, valid verifier_types)
- Add test for lesson_ref existence and no random/simulated results
- Covers DCO, pip, GitHub auth, MCP, encoding, pytest, Cloudflare, JSON, npm, and stale data

Signed-off-by: wasim-builds <wasim@example.com>