### PR TITLE
docs: establish minimum growth funnel dashboard

### DIFF
--- a/docs/maintainer/growth-funnel.md
+++ b/docs/maintainer/growth-funnel.md
@@ -1,0 +1,65 @@
+# Growth Funnel Dashboard
+
+This document tracks weekly growth metrics for the project across discovery (Glama), GitHub, and distribution channels (PyPI, GHCR). It gives maintainers a lightweight, at-a-glance view of where users are dropping off in the funnel — from seeing the profile, to clicking through, to actually using the tool.
+
+## How to update this weekly
+
+1. Copy the **Weekly Template** section below.
+2. Paste it at the top of the **Update Log**, filling in this week's date and numbers.
+3. Pull numbers from:
+   - **Glama**: project dashboard → Analytics tab (views, impressions, clicks, CTR, tool calls)
+   - **GitHub**: repo → Insights → Traffic (unique visitors)
+   - **PyPI**: [pypistats.org](https://pypistats.org) or `pip download` stats for the package name
+   - **GHCR**: package page → Insights (pulls), if published
+4. Commit the update — no code changes or release needed, this is doc-only.
+
+---
+
+## Baseline (established this week)
+
+| Metric                 | Current |
+| ---------------------- | ------- |
+| Glama profile views    | 1,433   |
+| Glama impressions      | 80      |
+| Glama clicks           | 8       |
+| Glama CTR              | 10%     |
+| Glama tool calls       | 0       |
+| GitHub unique visitors | ~176    |
+| PyPI downloads         | TBD     |
+| GHCR pulls             | TBD     |
+
+**Notes on baseline:**
+
+- Glama CTR (10%) is healthy relative to impressions, but _tool calls = 0_ is the key funnel gap right now — people are viewing and clicking but not invoking the tool. Worth flagging as the metric to watch closest.
+- PyPI downloads and GHCR pulls are not yet instrumented/tracked — first priority for next update is filling these in so the full funnel (view → click → install → use) is visible.
+
+---
+
+## Weekly Template
+
+Copy this block for each new entry in the Update Log below.
+
+```markdown
+### Week of YYYY-MM-DD
+
+| Metric                 | This Week | Last Week | Δ   |
+| ---------------------- | --------- | --------- | --- |
+| Glama profile views    |           |           |     |
+| Glama impressions      |           |           |     |
+| Glama clicks           |           |           |     |
+| Glama CTR              |           |           |     |
+| Glama tool calls       |           |           |     |
+| GitHub unique visitors |           |           |     |
+| PyPI downloads         |           |           |     |
+| GHCR pulls             |           |           |     |
+
+## **Observations:**
+
+## **Actions for next week:**
+```
+
+---
+
+## Update Log
+
+_(Add new weekly entries above this line, most recent first.)_


### PR DESCRIPTION
## Summary
Adds a growth funnel dashboard doc (`docs/maintainer/growth-funnel.md`) with the current baseline metrics and a reusable template for weekly updates, per the issue.

## Type of Change
- [ ] 📚 New lesson submission
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] Other (please describe)

## Lessons Added (if applicable)
N/A — no lesson files added, this is a maintainer-facing dashboard doc.

## Checklist
- [ ] My commit has `Signed-off-by:` (DCO required)
- [x] I have tested that the changes work correctly (doc renders correctly, no code paths touched)
- [x] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds) — maintainer will regenerate after merge

## Before submitting — check related lessons
N/A — this PR doesn't fix a bug or known issue, it's a new baseline doc.

## Notes for reviewer
- Doc-only change — no code changes, no release needed.
- Baseline captured: Glama profile views (1,433), impressions (80), clicks (8), CTR (10%), tool calls (0), GitHub unique visitors (~176). PyPI/GHCR pull counts marked TBD since they aren't instrumented yet.
- Flagging one thing worth a look: 8 Glama clicks but 0 tool calls — that gap (click-through without actual usage) seems like the metric to watch closest going forward.