### PR TITLE
docs: add Glama-first quickstart block to README [Fix #762]

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ mcp-name: io.github.Ikalus1988/misakanet
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/github/license/Ikalus1988/MisakaNet?style=flat&color=blueviolet)](https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE)
 [![Glama score](https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badges/score.svg)](https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/score)
+[![MCP quickstart](https://img.shields.io/badge/MCP-quickstart-blue)](docs/quickstart.md)
 [![Stars](https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social)](https://github.com/Ikalus1988/MisakaNet/stargazers)
 [![MCP Toplist: Top 1% of 81,852](https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg)](https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet)
 
@@ -46,7 +47,9 @@ MisakaNet is a failure-memory layer for AI coding agents. When your agent hits a
 }
 ```
 
-Then ask: *"Search MisakaNet for DCO sign-off failure"*
+Then ask your MCP client: *"Search MisakaNet for database locked"*
+
+**Expected output:** a list of matching failure-recovery lessons with title, score, and fix path — e.g. `[{"title": "sqlite3.OperationalError: database locked", "score": 0.92, "path": "lessons/core/sqlite-locked-fix.md"}]`
 
 **Option B: CLI**
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Ikalus1988/misakanet",
-  "description": "Agent failure memory network. Search 249 indexed failure-recovery lessons and route redacted feedback intake for maintainers.",
+  "description": "Agent failure memory network — search real failure-recovery lessons when your coding agent hits an error. Start with: 'Search MisakaNet for database locked'",
   "repository": {
     "url": "https://github.com/Ikalus1988/MisakaNet",
     "source": "github"


### PR DESCRIPTION
## Fix #762 — Add Glama-first quickstart block

### Changes

1. **README.md**: Replace MCP example query from "DCO sign-off failure" to "database locked" (guaranteed-success test query from acceptance criteria)
2. **README.md**: Add expected output format showing title, score, and fix path
3. **server.json**: Update description to emphasize first use case ("Start with: 'Search MisakaNet for database locked'")
4. **README.md**: Add MCP quickstart badge linked to docs/quickstart.md

### Acceptance criteria met

- [x] README MCP section has: "Ask your MCP client: Search MisakaNet for database locked"
- [x] Expected output described (failure-recovery lessons with title, score, path)
- [x] server.json description emphasizes first use case
- [x] Glama badge area has MCP quickstart link
- [x] No false claims added

/claim #762
