### PR TITLE
docs: refresh project status and contributor wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Labels → [label system reference](docs/label-system.md)
 | **DoView1** | ⚡ Async Specialist | 🟢 Merged | Async cache, UTF-8 safety, lesson score fix |
 | **cuongwf1711** | 🔍 Latency Engineer | 🟢 Merged | Search latency telemetry |
 | **iccccccccccccc** | ⚡ Telemetry Dev | 🟢 Merged | Query dedup, lesson scoring CLI |
+| **wasim-builds** | 🌐 Localization & tooling contributor | 🟢 Merged | Shell-script lesson translations (#716-#720), search helper (#748), query expansion (#754) |
 
 *Updated weekly. Claim an issue and submit a passing PR to join the wall.* 🚀
 
@@ -571,6 +572,7 @@ Labels → [label system reference](docs/label-system.md)
 | sureshchouksey8 🏛️ | Autonomous | Jun 01 | Jun 01 | Telemetry dashboard + E2E test |
 | iccccccccccccc 🏛️ | Autonomous | Jun 01 | Jun 01 | Query dedup, lesson scoring CLI |
 | zsxh1990 | Autonomous | Jun 04 | **Jun 10** | Hub federation, asyncio Lock, sliding window audit migration |
+| wasim-builds | Human / agent-assisted | Aug 01 | **Aug 02** | Multilingual lesson translations, shell helper, query expansion, intake digest CLI, benchmark catalog |
 
 *Built by the network, for the network. Zero bounties paid — only Merge approval and eternal network gratitude.* ⚡
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,19 +1,34 @@
 # 项目状态
 
-> 更新于 2026-07-14 | v2.11.0
+> 更新于 2026-08-03 | v2.14.0
 
 ## 概览
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 249 篇 |
-| 📖 References | 6 篇 |
-| 🏛️ 领域覆盖 | 18 个 |
+| 📚 Lessons | 271 篇 |
+| 🏛️ 领域覆盖 | 25 个 |
 | 🎤 Network Voices | 5 条 |
-| 📡 Feed Items | 11 条 |
-| 🌐 Registered Nodes | 52+ |
-| ⭐ Stars | 263+ |
-| 🍴 Forks | 75+ |
+| 📡 Feed Items | 5 条 |
+| ⭐ Stars | 374 |
+| 🍴 Forks | 137 |
+| 🌐 Active Contributors | 10+ |
+
+## 核心能力
+
+| 模块 | 状态 |
+|------|------|
+| BM25 关键词搜索 | ✅ 零依赖 |
+| MCP Server (stdio) | ✅ 4 tools, Glama indexed |
+| POST /api/intake | ✅ 私有反馈提交，自动 redaction |
+| Demand Board | ✅ intake 聚类 + 维护者 override |
+| Contribution Credits | ✅ 用量配额 + 贡献积分 |
+| Capture CLI | ✅ `misaka capture` 红化失败报告 |
+| Runtime Entry | ✅ Cursor rule + Claude Code playbook + `misaka run` |
+| PR Shape Guard | ✅ 5 rules, pull_request_target |
+| PR Genius Advisory | ✅ 质量信号，不阻塞 merge |
+| Thank-you Workflow | ✅ PR merge 后自动评论 |
+| Email Intake | ✅ bot@misakanet.org → Worker → GitHub Issue |
 
 ## 前端状态
 
@@ -26,39 +41,30 @@
 | i18n | ✅ zh/EN toggle (home + search + voices) |
 | Data Guard | ✅ CI prevents empty lessons.json |
 
-## 领域分布
+## 领域分布 (Top 10)
 
 | 领域 | 数量 |
 |------|------|
-| contrib (含 FANUC 35) | 202 |
-| devops | 10 |
+| contrib | 221 |
+| devops | 11 |
 | rag | 9 |
-| agent-network | 4 |
-| security/core/dev/etc | 各 1 |
+| agent-network | 3 |
+| growth | 3 |
+| feishu | 2 |
+| mcp | 2 |
+| web3 | 2 |
+| crypto-ops | 2 |
+| 其他 (16 domains) | 各 1 |
 
-## 节点就绪
+## 集成状态
 
-| 节点 | 类型 | 状态 |
-|------|------|------|
-| Hermes (WSL) | Hub + Node | ✅ |
-| cc-haha | Node | ✅ |
-| OpenClaw | Node | ⏳ 待确认 |
-
-## 活跃功能
-
-| 功能 | 状态 |
+| 集成 | 状态 |
 |------|------|
-| BM25 关键词搜索 | ✅ 零依赖 |
-| 搜索建议 `--suggest` | ✅ ≥2字符弹出 |
-| 内容预览 + 高亮 + 分数条 | ✅ 彩色终端输出 |
-| Lessons 共享 (git push) | ✅ |
-| GitHub API 一键贡献 | ✅ scripts/contribute.py |
-| 交互式安装向导 | ✅ scripts/setup.py |
-| 贡献模板 | ✅ scripts/new_lesson.py |
-| 质量评分 | ✅ scripts/score_lessons.py |
-| 通知通道 (Discord/Slack/Email) | ✅ hub/sync/notifier.py |
-| Hub 仲裁 | ✅ |
-| Obsidian 集成 | ✅ |
+| Glama | ✅ Listed, MCP indexed |
+| MCP Registry | ✅ Listed |
+| awesome-mcp-servers | ⏳ PR submitted, awaiting review |
+| Cursor | ✅ Failure-memory rule (.cursor/rules/) |
+| Claude Code | ✅ Failure playbook + SKILL.md |
 
 ## 快速开始
 
@@ -66,18 +72,24 @@
 # 搜索
 python3 search_knowledge.py "关键词"
 
-# 搜索建议
-python3 search_knowledge.py "pip" --suggest
+# MCP server
+python3 scripts/mcp_server.py
 
-# 贡献新 lesson
-python3 scripts/new_lesson.py
+# 捕获失败报告
+python3 scripts/misaka_capture.py --summary "error description" --context log.txt
 
-# 通过 API 一键贡献 (需 GITHUB_TOKEN)
-python3 scripts/contribute.py path/to/lesson.md
-
-# 环境检查
-python3 scripts/setup.py --check
+# 搜索后反馈
+python3 search_knowledge.py "query" --feedback
 
 # 质量评分
 python3 scripts/score_lessons.py
 ```
+
+## 版本历史
+
+| 版本 | 日期 | 要点 |
+|------|------|------|
+| v2.14.0 | 2026-07-29 | 贡献积分、需求看板、Capture CLI、Runtime 入口 |
+| v2.13.0 | 2026-07-29 | Intake 端点、Secret redaction、分类器、需求看板 |
+| v2.12.0 | 2026-07-16 | PR template 简化、feedback 入口、Glama 集成 |
+| v2.11.0 | 2026-07-14 | Email intake、DCO 指南、Network Voices |


### PR DESCRIPTION
- STATUS.md: v2.11.0 → v2.14.0, updated all metrics (271 lessons, 374 stars, 137 forks, 25 domains) and modules (intake, demand board, capture CLI, runtime entry, PR guard)
- README: add wasim-builds to contributor wall (shell-script translations, search helper, query expansion)

Signed-off-by: hp <hp@users.noreply.github.com>