### PR TITLE
[Analytics] Add privacy-preserving unsolved failure map

### DIFF
--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -326,6 +326,39 @@ export default {
     }
 
     // GET /api/insights/demand-board — public aggregate view of intake clusters
+    
+    // GET /api/insights/unsolved-map - public map of unsolved failures
+    if (request.method === "GET" && url.pathname === "/api/insights/unsolved-map") {
+      if (!env.MISAKANET_KV) return jsonResponse({ success: true, available: false, unsolved: [] });
+      
+      const DEMAND_PREFIX = "demand:family:";
+      const families = [
+        "github-auth", "npm-publish", "cloudflare-worker", "mcp-registry",
+        "glama-release", "python-env", "database-lock", "crawler-block",
+        "agent-tooling", "lesson-feedback", "bug-report", "unclassified",
+      ];
+      
+      const unsolved = [];
+      for (const family of families) {
+        const record = await env.MISAKANET_KV.get(`${DEMAND_PREFIX}${family}`, "json");
+        if (!record || !record.days) continue;
+        
+        let unsolved_count = 0;
+        for (const bucket of Object.values(record.days)) {
+          unsolved_count += Object.values(bucket.reasons || {}).reduce((s, r) => s + (r.count || 0), 0);
+        }
+        
+        if (unsolved_count > 0) {
+          unsolved.push({
+            task_family: family,
+            unsolved_count: unsolved_count,
+            reason: "no match / low confidence"
+          });
+        }
+      }
+      return jsonResponse({ success: true, unsolved });
+    }
+
     if (request.method === "GET" && url.pathname === "/api/insights/demand-board") {
       if (!env.MISAKANET_KV) return jsonResponse({ success: true, available: false, summary: [] });
 

--- a/workers/register-proxy.js
+++ b/workers/register-proxy.js
@@ -246,6 +246,26 @@ async function getWithCache(env, cacheKey, fetchFn) {
   return data;
 }
 
+
+async function handleUnsolvedMap(env) {
+  if (!env.MISAKANET_KV) return jsonResponse({ success: true, available: false, unsolved: [] });
+  const DEMAND_PREFIX = "demand:family:";
+  const families = ["github-auth", "npm-publish", "cloudflare-worker", "mcp-registry", "glama-release", "python-env", "database-lock", "crawler-block", "agent-tooling", "lesson-feedback", "bug-report", "unclassified"];
+  const unsolved = [];
+  for (const family of families) {
+    const record = await env.MISAKANET_KV.get(`${DEMAND_PREFIX}${family}`, "json");
+    if (!record || !record.days) continue;
+    let unsolved_count = 0;
+    for (const bucket of Object.values(record.days)) {
+      unsolved_count += Object.values(bucket.reasons || {}).reduce((s, r) => s + (r.count || 0), 0);
+    }
+    if (unsolved_count > 0) {
+      unsolved.push({ task_family: family, unsolved_count: unsolved_count, reason: "no match / low confidence" });
+    }
+  }
+  return jsonResponse({ success: true, unsolved });
+}
+
 // ── API 路由处理 ──
 async function handleApiRequest(pathWithQuery, env, request) {
   // 分离路径与查询参数
@@ -257,6 +277,7 @@ async function handleApiRequest(pathWithQuery, env, request) {
   if (pathname === "/api/insights/demand-board") {
     return handleDemandBoard(env);
   }
+  if (pathname === "/api/insights/unsolved-map") { return handleUnsolvedMap(env); }
   if (pathname === "/api/insights/demand-map") {
     return handleDemandMap(request, env);
   }


### PR DESCRIPTION
Fixes #788

Adds `/api/insights/unsolved-map` to surface families with 0 results or low-confidence matches without exposing PII or raw queries.