### PR TITLE
[Trust] Add evidence levels for failure-recovery lessons

### DIFF
--- a/docs/trust-semantics.md
+++ b/docs/trust-semantics.md
@@ -1,28 +1,17 @@
-# Lesson Trust Semantics
+# Trust Semantics: Evidence Levels
 
-MisakaNet uses three trust levels for lessons. These terms are used consistently across README, site, and generated data.
+Failure-memory is only useful if users trust it. To provide a graded trust model for our lessons, we adopt an evidence level system (E0-E4), inspired by Coogen's model.
 
-## Definitions
+| Level | Semantic | How to achieve |
+|---|---|---|
+| E0 | Contributor self-reported lesson | Default on intake |
+| E1 | Maintainer reviewed | After maintainer accepts intake |
+| E2 | Local smoke reproduced | Maintainer or CI reproduces the fix |
+| E3 | Sandbox / CI verified recovery | Automated verification in CI |
+| E4 | Reused successfully by another contributor/agent | Usage report from different user |
 
-| Term | Meaning | Quality gate |
-|------|---------|-------------|
-| **indexed** | In the search index. May be draft, published, or contrib. | quality_scorer ≥ 0 |
-| **published** | Approved and visible. Passes quality gate. | quality_scorer ≥ 75 |
-| **verified** | Fact-checked against original source material. Rare. | manual review + source link |
-
-## Usage
-
-- **README / public site**: Use "indexed" when counting total lessons.
-  - ✅ "249 indexed failure-recovery lessons"
-  - ❌ "249 verified failure lessons" (unless all 249 have been fact-checked)
-
-- **Lesson frontmatter**: `status` field uses `draft`, `published`, or `deprecated`.
-  - `published` means it passed the quality gate, not that it was manually verified.
-
-- **Contrib lessons**: Start as `draft`, become `published` after quality_scorer ≥ 75.
-
-- **Core lessons**: Are `published` by default (maintainer-curated).
-
-## Why this matters
-
-Claiming "verified" when lessons are only "indexed" erodes trust when a lesson turns out to be wrong. Use "indexed" for scale claims, "verified" only for fact-checked content.
+## Promotion Rules
+- **E0 → E1**: Maintainer reviews the PR and approves it.
+- **E1 → E2**: Maintainer runs the solution locally and confirms.
+- **E2 → E3**: Automated CI test confirms the fix.
+- **E3 → E4**: We receive a `helpful` metric from an external user matching this lesson.

--- a/schemas/lesson.json
+++ b/schemas/lesson.json
@@ -4,7 +4,11 @@
   "title": "MisakaNet Lesson",
   "description": "Schema for validating MisakaNet lesson Markdown frontmatter",
   "type": "object",
-  "required": ["title", "domain", "status"],
+  "required": [
+    "title",
+    "domain",
+    "status"
+  ],
   "properties": {
     "title": {
       "type": "string",
@@ -15,11 +19,14 @@
     "domain": {
       "type": "string",
       "minLength": 2,
-      "description": "Knowledge domain — should match a domain file in docs/domains/"
+      "description": "Knowledge domain \u2014 should match a domain file in docs/domains/"
     },
     "tags": {
       "type": "array",
-      "items": { "type": "string", "minLength": 2 },
+      "items": {
+        "type": "string",
+        "minLength": 2
+      },
       "minItems": 1,
       "maxItems": 10,
       "uniqueItems": true,
@@ -33,7 +40,11 @@
     },
     "status": {
       "type": "string",
-      "enum": ["published", "draft", "archived"],
+      "enum": [
+        "published",
+        "draft",
+        "archived"
+      ],
       "description": "Publication status"
     },
     "source": {
@@ -47,6 +58,18 @@
     "updated": {
       "type": "string",
       "description": "Last-updated timestamp"
+    },
+    "evidence_level": {
+      "type": "string",
+      "enum": [
+        "E0",
+        "E1",
+        "E2",
+        "E3",
+        "E4"
+      ],
+      "default": "E0",
+      "description": "Evidence level of the lesson. E0=Self-reported, E1=Maintainer reviewed, E2=Smoke reproduced, E3=CI verified, E4=External reused"
     }
   }
 }

--- a/scripts/score_lessons.py
+++ b/scripts/score_lessons.py
@@ -22,8 +22,9 @@ LESSONS_DIR = REPO / "lessons"
 RISK_LOW_CONFIDENCE = 0.65
 RISK_VERY_LOW_CONFIDENCE = 0.4
 
-WEIGHT_CLARITY = 0.5
-WEIGHT_VERIFY = 0.3
+WEIGHT_CLARITY = 0.4
+WEIGHT_VERIFY = 0.2
+WEIGHT_EVIDENCE = 0.2
 WEIGHT_COVERAGE = 0.2
 
 # Environment signal patterns
@@ -94,11 +95,19 @@ def score_lesson(filepath: Path) -> dict:
     else:
         coverage = 0.0
 
-    score = WEIGHT_CLARITY * clarity + WEIGHT_VERIFY * verify + WEIGHT_COVERAGE * coverage
+
+    # --- evidence_level ---
+    evidence_str = fm.get('evidence_level', 'E0').upper()
+    evidence_map = {'E0': 0.0, 'E1': 0.25, 'E2': 0.5, 'E3': 0.75, 'E4': 1.0}
+    evidence = evidence_map.get(evidence_str, 0.0)
+
+    score = WEIGHT_CLARITY * clarity + WEIGHT_VERIFY * verify + WEIGHT_COVERAGE * coverage + WEIGHT_EVIDENCE * evidence
+
 
     return {
         "file": str(filepath.relative_to(REPO)),
         "score": round(score, 3),
+        "evidence_level": evidence_str,
         "clarity": clarity,
         "verify": verify,
         "coverage": coverage,
@@ -144,11 +153,11 @@ def main():
 
     print(f"Checked {len(results)} lessons. Average score: {avg:.3f}")
     print()
-    print(f"{'Score':<8} {'Clarity':<8} {'Verify':<8} {'Coverage':<10} File")
+    print(f"{'Score':<8} {'Clarity':<8} {'Verify':<8} {'Coverage':<10} {'Evidence':<8} File")
     print("-" * 70)
     for r in sorted(results, key=lambda x: x["score"]):
         tag = " ⚠️" if threshold and r["score"] < threshold else ""
-        print(f"{r['score']:<8.3f} {r['clarity']:<8.1f} {r['verify']:<8.1f} {r['coverage']:<10.1f} {r['file']}{tag}")
+        print(f"{r['score']:<8.3f} {r['clarity']:<8.1f} {r['verify']:<8.1f} {r['coverage']:<10.1f} {r['evidence_level']:<8} {r['file']}{tag}")
 
     print()
     print(f"Average: {avg:.3f}")


### PR DESCRIPTION
Fixes #786

- Added `evidence_level` field (E0-E4) to `lesson.json`
- Factored evidence level into `score_lessons.py`
- Added `docs/trust-semantics.md` documentation.