### PR TITLE
docs: clarify Glama-routed MCP analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Please install and test MisakaNet as an MCP failure-memory server.
 5. Confirm that misakanet_search returns failure-recovery lessons with title, score, and path.
 ```
 
-MisakaNet is a failure-memory and recovery layer for coding agents / MCP clients. Local stdio MCP calls work independently of Glama analytics. → [Full MCP quickstart →](docs/mcp-quickstart.md)
+MisakaNet is a failure-memory and recovery layer for coding agents / MCP clients. → [Full MCP quickstart →](docs/mcp-quickstart.md)  > **MCP status:** MisakaNet is already [registered as an MCP server on Glama](https://glama.ai/mcp/servers/Ikalus1988/MisakaNet), and [local stdio MCP calls are verified](docs/integrations/mcp-smoke-report.md). Glama `Tool Calls = 0` means **0 Glama-routed tool calls**; it does not mean MCP is broken or that local usage is zero. See the [analytics counting boundary](docs/integrations/glama-analytics.md).
 
 ### Integration guides
 


### PR DESCRIPTION
## Summary
- expose the existing MCP registration status from the main README
- distinguish Glama-routed tool-call analytics from verified local stdio MCP use
- link the Glama listing, local smoke report, and detailed counting-boundary note

## Verification
- local acceptance/link self-check: `DOC ACCEPTANCE SELFCHECK OK`
- `git diff --check` passed
- all linked repository documents exist

Closes #779

/opire claim #779