### PR TITLE
docs: clarify Glama-routed MCP analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Please install and test MisakaNet as an MCP failure-memory server.
 5. Confirm that misakanet_search returns failure-recovery lessons with title, score, and path.
 ```
 
-MisakaNet is a failure-memory and recovery layer for coding agents / MCP clients. Local stdio MCP calls work independently of Glama analytics. → [Full MCP quickstart →](docs/mcp-quickstart.md)
+MisakaNet is a failure-memory and recovery layer for coding agents / MCP clients. → [Full MCP quickstart →](docs/mcp-quickstart.md)<br><br>**MCP status:** MisakaNet is already [registered as an MCP server on Glama](https://glama.ai/mcp/servers/Ikalus1988/MisakaNet), and [local stdio MCP calls are verified](docs/integrations/mcp-smoke-report.md). Glama `Tool Calls = 0` means **0 Glama-routed tool calls**; it does not mean MCP is broken or that local usage is zero. See the [analytics counting boundary](docs/integrations/glama-analytics.md).
 
 ### Integration guides
 


### PR DESCRIPTION
## Summary
- clarify that the Glama counter covers Glama-routed calls, not local stdio usage
- link the existing MCP smoke report and analytics-boundary documentation
- keep the quickstart prominent

Closes #786.

## Verification
- diff is limited to README.md (1 addition, 1 deletion)
- linked documentation exists in the repository
- commit includes Signed-off-by trailer for DCO