### PR TITLE
fix(mcp): use correct BM25 search API in MCP server

### DIFF
--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -59,7 +59,11 @@ except ImportError:
 
 # Import BM25 search fallback
 try:
-    from misakanet.search.engine import MisakaNetSearchEngine
+    from misakanet.search.engine import (
+        LESSONS,
+        _load_docs_cached,
+        _search_cached,
+    )
     HAS_BM25 = True
 except ImportError:
     HAS_BM25 = False
@@ -78,8 +82,17 @@ def handle_search(args: dict) -> dict:
         results = sag_search(SAG_DB, query, domain=domain, top=top)
         return {"results": results, "source": "sag-lite"}
     elif HAS_BM25:
-        engine = MisakaNetSearchEngine()
-        results = engine.search(query, top=top)
+        docs = _load_docs_cached(LESSONS, is_lesson=True)
+        scored = _search_cached(query, docs)
+        results = []
+        for score, doc in scored[:top]:
+            results.append({
+                "title": doc.title,
+                "path": str(doc.filepath),
+                "score": round(score, 3),
+                "domain": doc.domain,
+                "status": doc.status,
+            })
         return {"results": results, "source": "bm25"}
     else:
         return {"error": "No search engine available. Run: python3 scripts/build_sag_index.py"}


### PR DESCRIPTION
## Problem

`scripts/mcp_server.py` imports `MisakaNetSearchEngine` from `misakanet.search.engine`, but that class doesn't exist. The BM25 fallback is silently disabled by the `ImportError` catch, so `misakanet.search` always returns "No search engine available" unless SAG is built.

## Root Cause

The search engine module (`misakanet/search/engine.py`) exposes:
- `_load_docs_cached(directory, is_lesson=True)` — loads lesson docs
- `_search_cached(query, docs)` — BM25 search

Not a `MisakaNetSearchEngine` class with a `.search()` method.

## Fix

1. Import `_load_docs_cached`, `_search_cached`, `LESSONS` from the engine
2. Call them directly in `handle_search`
3. Use `doc.filepath` instead of `doc.path` (`CachedDoc` has no `path` attribute)

## Verification

```python
from scripts.mcp_server import handle_search
result = handle_search({'query': 'github api', 'top': 3})
# Returns: {'results': [...], 'source': 'bm25'}
```