### PR TITLE
feat(mcp): add remote Streamable HTTP endpoint at POST /mcp (#804)

### DIFF
--- a/docs/integrations/mcp-remote.md
+++ b/docs/integrations/mcp-remote.md
@@ -1,0 +1,109 @@
+# Remote MCP Endpoint (Streamable HTTP)
+
+Connect any MCP-compatible AI client (Glama, Claude Code, Cursor, GitHub Copilot) directly to MisakaNet via remote Streamable HTTP without cloning the repository or running a local server.
+
+---
+
+## Endpoint Details
+
+- **URL**: `https://misakanet.org/mcp` (or your Cloudflare Worker URL `POST /mcp`)
+- **Protocol**: MCP Streamable HTTP Transport (2025-06-18, forward-compatible with 2025-07-28 RC)
+- **Authentication**: Bearer Token via `Authorization: Bearer $MCP_TOKEN` header
+- **Access Level**: Phase 1 Read-Only (`misakanet_search` + `misakanet_get_lesson`)
+
+---
+
+## Environment & Secrets
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `MCP_TOKEN` | Secret | Bearer token for authenticating remote MCP client requests |
+| `MCP_VERSION` | Secret (Optional) | Server version reported in `initialize` (defaults to `1.0.0` or package version) |
+
+---
+
+## Available Read-Only Tools
+
+### 1. `misakanet_search`
+Search MisakaNet failure-recovery lessons by query keywords, optional domain filter, and top-N limit.
+
+- **Arguments**:
+  - `query` (string, required): Error message or search keywords (e.g. `"database locked"`)
+  - `domain` (string, optional): Specific domain filter (e.g. `"database-lock"`, `"github-auth"`)
+  - `top` (number, optional): Maximum number of results to return (default: `5`)
+
+### 2. `misakanet_get_lesson`
+Retrieve full lesson markdown content by path or ID.
+
+- **Arguments**:
+  - `path` (string, optional): Lesson path (e.g. `"lessons/core/database_locked.md"`)
+  - `id` (string, optional): Lesson ID (e.g. `"database_locked"`)
+
+---
+
+## Verification & Usage Examples
+
+### 1. Initialize
+
+```bash
+curl -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}'
+```
+
+### 2. List Available Tools
+
+```bash
+curl -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+### 3. Call Search Tool
+
+```bash
+curl -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"database locked"}}}'
+```
+
+### 4. Call Get Lesson Tool
+
+```bash
+curl -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"misakanet_get_lesson","arguments":{"path":"lessons/core/auto-merge-ci-pipeline.md"}}}'
+```
+
+---
+
+## Client Integration Setup
+
+### Glama & Remote Clients
+
+Set the remote endpoint in Glama or Cursor remote configuration:
+
+```json
+{
+  "mcpServers": {
+    "misakanet-remote": {
+      "url": "https://misakanet.org/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_TOKEN"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Security & Origin Validation
+
+- **DNS Rebinding Protection**: Requests containing an `Origin` header are validated against an allowed origin list (`misakanet.org`, `glama.ai`, `cursor.sh`, `claude.ai`, `github.com`, `localhost`).
+- **Timing-Safe Auth**: Token comparisons use `timingSafeEqual` to prevent timing side-channel attacks.
+- **GET Request Restriction**: Sending `GET /mcp` returns HTTP `405 Method Not Allowed` with `Accept: POST` header.

--- a/workers/register-proxy.js
+++ b/workers/register-proxy.js
@@ -545,6 +545,337 @@ async function handleHelpfulVote(request, env) {
   }
 }
 
+// ── MCP Remote Endpoint Handler (Issue #804) ──
+function decodeBase64Utf8(base64) {
+  const binary = atob(base64.replace(/\s/g, ""));
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+async function fetchFromGitHubText(token, path, ref = "main") {
+  const url = `${GITHUB_API}/repos/${REPO}/contents/${path}?ref=${encodeURIComponent(ref)}`;
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "MisakaNet-Worker",
+      Accept: "application/vnd.github.v3+json",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`GitHub API ${resp.status}`);
+  }
+  const data = await resp.json();
+  if (data.content && data.encoding === "base64") {
+    return decodeBase64Utf8(data.content);
+  }
+  throw new Error("Unexpected GitHub API response format");
+}
+
+function isValidMcpOrigin(originHeader) {
+  if (!originHeader) return true;
+  try {
+    const parsed = new URL(originHeader);
+    const host = parsed.hostname.toLowerCase();
+    const scheme = parsed.protocol.toLowerCase();
+
+    if (scheme === "vscode-webview:" || scheme === "app:" || scheme === "chrome-extension:") {
+      return true;
+    }
+
+    if (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "misakanet.org" ||
+      host.endsWith(".misakanet.org") ||
+      host === "glama.ai" ||
+      host.endsWith(".glama.ai") ||
+      host === "claude.ai" ||
+      host.endsWith(".claude.ai") ||
+      host === "cursor.sh" ||
+      host.endsWith(".cursor.sh") ||
+      host === "github.com" ||
+      host.endsWith(".github.com")
+    ) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function validateMcpAuthAndOrigin(request, env) {
+  const mcpToken = env.MCP_TOKEN;
+  if (!mcpToken) {
+    return { valid: false, status: 401, error: "MCP_TOKEN not configured on server" };
+  }
+
+  const authHeader = request.headers.get("Authorization") || "";
+  const parts = authHeader.trim().split(/\s+/);
+  if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer" || !timingSafeEqual(parts[1], mcpToken)) {
+    return { valid: false, status: 401, error: "Missing or invalid Bearer token" };
+  }
+
+  const origin = request.headers.get("Origin");
+  if (origin && !isValidMcpOrigin(origin)) {
+    return { valid: false, status: 403, error: "Invalid Origin" };
+  }
+
+  return { valid: true };
+}
+
+function searchLessonsInWorker(lessons, query, domain, top = 5) {
+  if (!Array.isArray(lessons) || !query) return [];
+  const terms = String(query).toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return [];
+
+  const scored = [];
+  for (const item of lessons) {
+    if (domain && item.domain !== domain) continue;
+    let score = 0;
+
+    const titleLower = (item.title || "").toLowerCase();
+    const summaryLower = (item.summary || "").toLowerCase();
+    const previewLower = (item.preview || "").toLowerCase();
+    const idLower = (item.id || "").toLowerCase();
+    const urlLower = (item.url || "").toLowerCase();
+    const tagsLower = Array.isArray(item.tags) ? item.tags.join(" ").toLowerCase() : "";
+
+    for (const term of terms) {
+      if (titleLower.includes(term)) score += 3;
+      if (tagsLower.includes(term)) score += 2;
+      if (idLower.includes(term) || urlLower.includes(term)) score += 2;
+      if (summaryLower.includes(term)) score += 1;
+      if (previewLower.includes(term)) score += 1;
+    }
+
+    if (score > 0) {
+      scored.push({
+        title: item.title,
+        path: item.url || `lessons/${item.domain}/${item.id}.md`,
+        score: Math.min(score, 10),
+        domain: item.domain,
+        status: item.status || "active",
+        summary: item.summary,
+      });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, top);
+}
+
+async function handleMcpRequest(request, env) {
+  if (request.method === "GET") {
+    return new Response("Method Not Allowed. Use POST /mcp for MCP Streamable HTTP transport.", {
+      status: 405,
+      headers: {
+        "Accept": "POST",
+        "Allow": "POST",
+        "Content-Type": "text/plain",
+        ...CORS_HEADERS,
+      },
+    });
+  }
+
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { "Accept": "POST", "Allow": "POST", ...CORS_HEADERS },
+    });
+  }
+
+  const authValidation = validateMcpAuthAndOrigin(request, env);
+  if (!authValidation.valid) {
+    return jsonResponse({ error: authValidation.error }, authValidation.status);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32700, message: "Parse error: Invalid JSON" },
+    }, 400);
+  }
+
+  const { jsonrpc, id = null, method, params = {} } = body || {};
+
+  switch (method) {
+    case "initialize": {
+      const serverVersion = env.MCP_VERSION || "1.0.0";
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: params.protocolVersion || "2025-06-18",
+          capabilities: {
+            tools: {},
+          },
+          serverInfo: {
+            name: "misakanet-remote",
+            version: serverVersion,
+          },
+        },
+      });
+    }
+
+    case "tools/list": {
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          tools: [
+            {
+              name: "misakanet_search",
+              description: "Search MisakaNet failure-recovery lessons by query, domain, or limit",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  query: { type: "string", description: "Search query keywords or error text" },
+                  domain: { type: "string", description: "Optional domain filter" },
+                  top: { type: "number", description: "Maximum number of results to return (default: 5)" },
+                },
+                required: ["query"],
+              },
+            },
+            {
+              name: "misakanet_get_lesson",
+              description: "Get full lesson markdown content by path or ID",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  path: { type: "string", description: "Lesson path or ID" },
+                  id: { type: "string", description: "Alternative lesson ID" },
+                },
+              },
+            },
+          ],
+        },
+      });
+    }
+
+    case "tools/call": {
+      const toolName = params.name;
+      const args = params.arguments || {};
+
+      if (toolName === "misakanet_search") {
+        const query = args.query || "";
+        const domain = args.domain;
+        const top = typeof args.top === "number" ? args.top : 5;
+
+        let results = [];
+        try {
+          const token = env.REGISTER_TOKEN;
+          const lessons = await getWithCache(env, "proxy:lessons", async () => {
+            if (token) {
+              return await fetchFromGitHub(token, "lessons.json", "data");
+            }
+            const rawResp = await fetch("https://raw.githubusercontent.com/Ikalus1988/MisakaNet/data/lessons.json");
+            return await rawResp.json();
+          });
+          results = searchLessonsInWorker(lessons, query, domain, top);
+        } catch (err) {
+          console.error("MCP search error:", err.message);
+        }
+
+        const formattedText = JSON.stringify({ results, source: "remote-search" }, null, 2);
+        return jsonResponse({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: formattedText,
+              },
+            ],
+            results,
+            source: "remote-search",
+          },
+        });
+      }
+
+      if (toolName === "misakanet_get_lesson") {
+        const pathOrId = args.path || args.id || "";
+        if (!pathOrId) {
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              content: [{ type: "text", text: "error: path or id is required" }],
+              error: "path or id is required",
+            },
+          });
+        }
+
+        let content = "";
+        let finalPath = pathOrId;
+        try {
+          const token = env.REGISTER_TOKEN;
+          if (!pathOrId.includes("/") && !pathOrId.endsWith(".md")) {
+            const lessons = await getWithCache(env, "proxy:lessons", async () => {
+              if (token) return await fetchFromGitHub(token, "lessons.json", "data");
+              const rawResp = await fetch("https://raw.githubusercontent.com/Ikalus1988/MisakaNet/data/lessons.json");
+              return await rawResp.json();
+            });
+            const found = Array.isArray(lessons) && lessons.find((l) => l.id === pathOrId);
+            if (found && found.url) {
+              finalPath = found.url;
+            } else {
+              finalPath = `lessons/core/${pathOrId}.md`;
+            }
+          }
+
+          if (token) {
+            content = await fetchFromGitHubText(token, finalPath, "main");
+          } else {
+            const rawResp = await fetch(`https://raw.githubusercontent.com/Ikalus1988/MisakaNet/main/${finalPath}`);
+            if (rawResp.ok) {
+              content = await rawResp.text();
+            } else {
+              content = `Error: Lesson not found: ${pathOrId}`;
+            }
+          }
+          content = content.slice(0, 5000);
+        } catch (err) {
+          content = `Error reading lesson: ${err.message}`;
+        }
+
+        return jsonResponse({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: content,
+              },
+            ],
+            path: finalPath,
+          },
+        });
+      }
+
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `Tool not found: ${toolName}` },
+      });
+    }
+
+    default: {
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `Method not found: ${method}` },
+      });
+    }
+  }
+}
+
 // ── 主入口 (仅 API + 注册，静态文件由 Cloudflare Pages 独立服务) ──
 export default {
   async fetch(request, env) {
@@ -553,6 +884,11 @@ export default {
     // CORS preflight
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: CORS_HEADERS });
+    }
+
+    // Remote MCP endpoint (POST /mcp, GET /mcp)
+    if (url.pathname === "/mcp" || url.pathname === "/api/mcp") {
+      return await handleMcpRequest(request, env);
     }
 
     // API 路由 (GET) — 传入完整 URL（含 query params）支持 GitHub API 代理
@@ -603,4 +939,8 @@ export {
   buildDemandMapBuckets,
   handleDemandBoard,
   handleDemandMap,
+  handleMcpRequest,
+  validateMcpAuthAndOrigin,
+  isValidMcpOrigin,
+  searchLessonsInWorker,
 };

--- a/workers/register-proxy.test.mjs
+++ b/workers/register-proxy.test.mjs
@@ -9,6 +9,10 @@ import {
   buildDemandMapBuckets,
   handleDemandBoard,
   handleDemandMap,
+  handleMcpRequest,
+  validateMcpAuthAndOrigin,
+  isValidMcpOrigin,
+  searchLessonsInWorker,
 } from './register-proxy.js';
 
 function createFakeKV(seed = {}) {
@@ -160,3 +164,176 @@ test('handleDemandMap requires a maintainer key and rejects mismatches', async (
   assert.equal(body.buckets[0].unsolvedCount, 1);
   assert.equal(body.buckets[0].distinctSourceCount, 1);
 });
+
+test('GET /mcp returns 405 Method Not Allowed with Accept: POST header', async () => {
+  const req = new Request('https://misakanet.org/mcp', { method: 'GET' });
+  const res = await handleMcpRequest(req, { MCP_TOKEN: 'test-token' });
+  assert.equal(res.status, 405);
+  assert.equal(res.headers.get('Accept'), 'POST');
+  assert.equal(res.headers.get('Allow'), 'POST');
+});
+
+test('POST /mcp requires valid Bearer token (401 on missing/invalid)', async () => {
+  const env = { MCP_TOKEN: 'secret-mcp-token' };
+
+  // Missing header
+  const req1 = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+  });
+  const res1 = await handleMcpRequest(req1, env);
+  assert.equal(res1.status, 401);
+
+  // Wrong token
+  const req2 = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer wrong-token',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+  });
+  const res2 = await handleMcpRequest(req2, env);
+  assert.equal(res2.status, 401);
+});
+
+test('POST /mcp validates Origin header (403 on invalid Origin)', async () => {
+  const env = { MCP_TOKEN: 'valid-token' };
+
+  // Invalid Origin
+  const req1 = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer valid-token',
+      Origin: 'http://malicious-site.example.com',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+  });
+  const res1 = await handleMcpRequest(req1, env);
+  assert.equal(res1.status, 403);
+
+  // Valid Origin
+  const req2 = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer valid-token',
+      Origin: 'https://glama.ai',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+  });
+  const res2 = await handleMcpRequest(req2, env);
+  assert.equal(res2.status, 200);
+});
+
+test('POST /mcp initialize method returns serverInfo and protocolVersion', async () => {
+  const env = { MCP_TOKEN: 'valid-token', MCP_VERSION: '0.9.1' };
+  const req = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer valid-token',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18' },
+    }),
+  });
+  const res = await handleMcpRequest(req, env);
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.jsonrpc, '2.0');
+  assert.equal(data.id, 1);
+  assert.equal(data.result.protocolVersion, '2025-06-18');
+  assert.equal(data.result.serverInfo.name, 'misakanet-remote');
+  assert.equal(data.result.serverInfo.version, '0.9.1');
+});
+
+test('POST /mcp tools/list method exposes misakanet_search and misakanet_get_lesson', async () => {
+  const env = { MCP_TOKEN: 'valid-token' };
+  const req = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer valid-token',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+  });
+  const res = await handleMcpRequest(req, env);
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  const toolNames = data.result.tools.map((t) => t.name);
+  assert.deepEqual(toolNames, ['misakanet_search', 'misakanet_get_lesson']);
+});
+
+test('searchLessonsInWorker ranks matching lessons by keywords', () => {
+  const mockLessons = [
+    {
+      id: 'db-lock',
+      title: 'Database Locked in SQLite',
+      domain: 'database-lock',
+      tags: ['sqlite', 'lock'],
+      summary: 'Fix database is locked error',
+      url: 'lessons/core/db-lock.md',
+    },
+    {
+      id: 'npm-401',
+      title: 'NPM Publish Unauthorized',
+      domain: 'npm-publish',
+      tags: ['npm'],
+      summary: 'Fix 401 Unauthorized during npm publish',
+      url: 'lessons/core/npm-401.md',
+    },
+  ];
+
+  const results = searchLessonsInWorker(mockLessons, 'database locked', null, 5);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].title, 'Database Locked in SQLite');
+  assert.equal(results[0].path, 'lessons/core/db-lock.md');
+});
+
+test('POST /mcp tools/call misakanet_search executes search query', async () => {
+  const mockLessons = [
+    {
+      id: 'db-lock',
+      title: 'Database Locked in SQLite',
+      domain: 'database-lock',
+      tags: ['sqlite', 'lock'],
+      summary: 'Fix database is locked error',
+      url: 'lessons/core/db-lock.md',
+    },
+  ];
+  const env = {
+    MCP_TOKEN: 'valid-token',
+    MISAKANET_KV: createFakeKV({
+      'proxy:lessons': JSON.stringify({ data: mockLessons, ts: Date.now() }),
+    }),
+  };
+
+  const req = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer valid-token',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'misakanet_search',
+        arguments: { query: 'database locked' },
+      },
+    }),
+  });
+  const res = await handleMcpRequest(req, env);
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.id, 3);
+  assert.ok(data.result.content[0].text.includes('Database Locked in SQLite'));
+});
+


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One sentence is fine. -->

## Type of Change

- [ ] 📚 New lesson submission
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] Other (please describe)

## Lessons Added (if applicable)

<!-- List lesson filenames if adding new lessons -->

## Checklist

- [ ] My commit has `Signed-off-by:` (DCO required)
- [ ] I have tested that the changes work correctly
- [ ] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds) — maintainer will regenerate after merge

## Before submitting — check related lessons

<!-- If your PR fixes a known issue, check if a lesson already covers it: -->

- [DCO sign-off fix](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/dco-auto-fix-workflow.md)
- [Secret scan / token fix](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/codeql-alert-dismissal-false-positive.md)
- [pip install timeout/SSL](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/contrib/pip-install-timeout-ssl.md)
- [GitHub API 401](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/github-401-credential-lookup.md)
- [🔍 Search all lessons](https://ikalus1988.github.io/MisakaNet/search/)

<!-- Don't worry about perfection. Small fixes are welcome too. -->

***************************************************************************************

Resolves #804

### Changes Summary

1. **Remote MCP Handler (`workers/register-proxy.js`)**
   - Implemented `POST /mcp` Streamable HTTP transport supporting `initialize`, `tools/list`, and `tools/call`.
   - Bearer token authentication via `MCP_TOKEN` secret → `401 Unauthorized` on missing/invalid token.
   - Origin header DNS rebinding validation → `403 Forbidden` on invalid origin.
   - `GET /mcp` → `405 Method Not Allowed` with `Accept: POST` header.

2. **Read-Only Tools Exposed**
   - `misakanet_search`: Ranks lessons by query keywords, optional domain filter, and top-N count.
   - `misakanet_get_lesson`: Retrieves full lesson markdown by path or ID.

3. **Documentation (`docs/integrations/mcp-remote.md`)**
   - Complete setup guide with connection instructions and curl verification examples.

4. **Unit Testing (`workers/register-proxy.test.mjs`)**
   - Added 7 new test cases covering all acceptance criteria (15/15 tests passing).

Signed-off-by: Atiqur Rahman <rahman.atiqur.pro@gmail.com>
