### PR TITLE
feat(worker): add remote MCP endpoint at POST /mcp (#804)

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -6,6 +6,7 @@ Connect MisakaNet to your AI coding tool. Search 271+ failure-recovery lessons d
 
 | Tool | Status | Setup |
 |------|--------|-------|
+| **Remote MCP (any client)** | ✅ Ready | [`POST /mcp` setup](mcp-remote.md) — no clone required |
 | **Cursor** | ✅ Ready | [Failure-memory rule](cursor-failure-memory.md) |
 | **Claude Code** | ✅ Ready | [Failure playbook](claude-code-failure-memory.md) |
 | **Continue.dev** | ✅ Ready | [Setup Guide](continue/README.md) |
@@ -14,6 +15,24 @@ Connect MisakaNet to your AI coding tool. Search 271+ failure-recovery lessons d
 | **Aider** | Planned | — |
 | **VS Code** | Planned | — |
 | **Cline** | Planned | — |
+
+## Quick: Remote MCP
+
+No clone, no Python — point any MCP client at the hosted endpoint:
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "type": "http",
+      "url": "https://misakanet.org/mcp",
+      "headers": { "Authorization": "Bearer YOUR_MCP_TOKEN" }
+    }
+  }
+}
+```
+
+Full instructions, tool reference, and curl verification: [mcp-remote.md](mcp-remote.md).
 
 ## Public smoke evidence
 

--- a/docs/integrations/mcp-remote.md
+++ b/docs/integrations/mcp-remote.md
@@ -1,0 +1,191 @@
+# Remote MCP endpoint (`POST /mcp`)
+
+Connect any MCP-compatible client to MisakaNet **without cloning the repo**. The
+endpoint runs on the existing Cloudflare Worker (`misakanet-register-proxy`) and
+speaks [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)
+(protocol `2025-06-18`, forward-compatible with the `2026-07-28` RC).
+
+- **Endpoint**: `https://misakanet.org/mcp`
+- **Transport**: Streamable HTTP (single `POST`, JSON responses, stateless — no session ID)
+- **Auth**: `Authorization: Bearer <MCP_TOKEN>`
+- **Phase 1 scope**: read-only — `misakanet_search`, `misakanet_get_lesson`
+
+> Prefer running locally? The stdio server (`scripts/mcp_server.py`) is still
+> supported and exposes the same two read tools plus resources and prompts —
+> see [mcp-quickstart.md](../mcp-quickstart.md).
+
+## Tools
+
+| Tool | Input | Returns |
+|------|-------|---------|
+| `misakanet_search` | `query` (required), `domain`, `top` (default 5, max 20) | Ranked lesson summaries: `id`, `title`, `domain`, `tags`, `status`, `path`, `score` |
+| `misakanet_get_lesson` | `path` **or** `id` | Lesson markdown (`content`, truncated at 5000 chars, plus `length` and `truncated`) |
+
+Both tools are read-only: no writes, no issue creation, no telemetry beyond the
+Worker's request log. `misakanet_submit_usage` / `misakanet_usage_status` remain
+Phase 2 and are intentionally absent.
+
+## Client configuration
+
+### Claude Code
+
+```bash
+claude mcp add --transport http misakanet https://misakanet.org/mcp \
+  --header "Authorization: Bearer $MCP_TOKEN"
+```
+
+### Claude Desktop / Cursor / Copilot (`mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "type": "http",
+      "url": "https://misakanet.org/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_TOKEN"
+      }
+    }
+  }
+}
+```
+
+- **Cursor**: `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project)
+- **Claude Desktop**: `claude_desktop_config.json`
+- **Copilot (VS Code)**: `.vscode/mcp.json`, under `"servers"` instead of `"mcpServers"`
+
+### Clients without native HTTP transport
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://misakanet.org/mcp",
+               "--header", "Authorization: Bearer YOUR_MCP_TOKEN"]
+    }
+  }
+}
+```
+
+### First call to try
+
+> Search MisakaNet for lessons about "database is locked", then open the top result.
+
+## Verify with curl
+
+```bash
+export MCP_TOKEN=...   # ask a maintainer, or use your own deployment's secret
+
+# 1. initialize — negotiates the protocol version, returns serverInfo
+curl -sS -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}'
+
+# 2. tools/list — the two read-only tools
+curl -sS -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+# 3. tools/call — ranked search results
+curl -sS -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"database locked"}}}'
+
+# 4. tools/call — full lesson markdown
+curl -sS -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"misakanet_get_lesson","arguments":{"id":"auto-merge-ci-pipeline"}}}'
+```
+
+Negative checks:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://misakanet.org/mcp \
+  -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'      # 401
+
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://misakanet.org/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" -H "Origin: https://evil.example" \
+  -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'      # 403
+
+curl -s -o /dev/null -w '%{http_code}\n' https://misakanet.org/mcp                             # 405 (Accept-Post: application/json)
+```
+
+## Status codes
+
+| Situation | Status | Body |
+|-----------|--------|------|
+| Valid request | `200` | JSON-RPC result |
+| Notification (`notifications/*`) | `202` | empty |
+| Missing / invalid Bearer token | `401` | JSON-RPC error `-32001`, `WWW-Authenticate: Bearer` |
+| Origin present but not allowlisted | `403` | JSON-RPC error `-32000` |
+| `GET` / `DELETE /mcp` | `405` | `Accept-Post: application/json`, `Allow: POST, OPTIONS` |
+| Body over 64 KB | `413` | JSON-RPC error `-32600` |
+| Malformed JSON | `400` | JSON-RPC error `-32700` |
+| JSON-RPC batch array | `400` | `-32600` (batching was removed in `2025-06-18`) |
+| Unknown method / unknown tool | `200` | `-32601` / `-32602` |
+| `MCP_TOKEN` not configured on the Worker | `503` | JSON-RPC error `-32000` |
+
+Tool-level problems (missing `query`, lesson not found, GitHub upstream failure)
+come back as a normal `200` result with `isError: true`, per the MCP spec.
+
+## Security model
+
+- **Bearer token** — compared in constant time against the `MCP_TOKEN` secret.
+- **Origin allowlist** — DNS rebinding protection. Requests with *no* `Origin`
+  header (curl, native MCP hosts) are allowed; a request carrying an unknown
+  `Origin` is rejected with `403`. Defaults: `misakanet.org`, `www.misakanet.org`,
+  `ikalus1988.github.io`, `glama.ai`, `claude.ai`, `cursor.com`. Add more with the
+  optional `MCP_ALLOWED_ORIGINS` variable (comma-separated).
+- **Path confinement** — `misakanet_get_lesson` only serves `lessons/**/*.md`;
+  traversal (`..`) and any other path are rejected before a GitHub request is made.
+- **Read-only** — no endpoint in this phase mutates repository or KV state.
+
+## Operating the endpoint
+
+Secrets on the `misakanet-register-proxy` Worker:
+
+| Name | Required | Purpose |
+|------|----------|---------|
+| `MCP_TOKEN` | yes | Bearer token clients must present. Without it, `/mcp` returns `503`. |
+| `REGISTER_TOKEN` | yes (already set) | GitHub PAT used to read `lessons.json` and lesson markdown. |
+| `MCP_VERSION` | no | Reported as `serverInfo.version`; defaults to the packaged `pyproject.toml` version. |
+| `MCP_ALLOWED_ORIGINS` | no | Extra allowlisted origins, comma-separated. |
+
+```bash
+npx wrangler secret put MCP_TOKEN --name misakanet-register-proxy
+```
+
+Deploy: pushing `workers/register-proxy-sw.js` to `main` triggers
+[`deploy-worker.yml`](../../.github/workflows/deploy-worker.yml).
+
+Lesson data is read through the existing GitHub proxy with the same 30-second KV
+cache as `GET /api/lessons` (`lessons.json` from the `data` branch, lesson markdown
+from `main`), so MCP traffic adds no extra GitHub API load in the common case.
+
+## Tests
+
+```bash
+node --test workers/mcp-remote.test.mjs     # transport, auth, tools, ranking
+pytest tests/test_mcp_remote_worker.py      # route/contract checks + the node suite
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---------|-------|
+| `401` with a token you believe is right | Token mismatch — the comparison is exact, including whitespace. Re-set the secret. |
+| `403` from a browser-based client | The client's `Origin` is not allowlisted; add it to `MCP_ALLOWED_ORIGINS`. |
+| `503` | `MCP_TOKEN` is not set on the Worker. |
+| Empty `results` | No lesson matched. Try fewer / more specific keywords, or drop the `domain` filter. |
+| `Upstream failure: GitHub API 4xx` | `REGISTER_TOKEN` expired or lost read access. |
+
+## Related
+
+- [Glama Analytics counting boundary](glama-analytics.md) — why "0 routed tool calls" is a measurement gap, and what this endpoint changes
+- [MCP smoke report](mcp-smoke-report.md) — local stdio evidence
+- [Integrations index](README.md)

--- a/tests/test_mcp_remote_worker.py
+++ b/tests/test_mcp_remote_worker.py
@@ -1,0 +1,107 @@
+"""Tests for the remote MCP endpoint on the Cloudflare Worker (Issue #804).
+
+Real request/response behaviour is exercised by workers/mcp-remote.test.mjs
+(`node --test`), which this module runs when Node is available. The remaining
+tests pin the contract that must not silently drift: route wiring, the Phase 1
+read-only tool set, the auth/Origin gates, and the version fallback.
+"""
+
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKER = REPO_ROOT / "workers" / "register-proxy-sw.js"
+NODE_TESTS = REPO_ROOT / "workers" / "mcp-remote.test.mjs"
+
+
+class TestMcpWorkerContract(unittest.TestCase):
+    def setUp(self):
+        self.js = WORKER.read_text(encoding="utf-8")
+
+    def test_mcp_route_is_wired_for_post_options_and_405(self):
+        self.assertIn('const MCP_PATH = "/mcp"', self.js)
+        self.assertIn("return handleMcpRequest(request, env)", self.js)
+        self.assertIn("return mcpMethodNotAllowed(request, env)", self.js)
+        self.assertIn('"Accept-Post": "application/json"', self.js)
+
+    def test_mcp_route_precedes_the_catch_all_get_landing_page(self):
+        """GET /mcp must 405 rather than fall through to the HTML page."""
+        self.assertLess(
+            self.js.index("url.pathname === MCP_PATH"),
+            self.js.index("// Catch-all GET — landing page"),
+        )
+
+    def test_bearer_auth_uses_a_timing_safe_comparison(self):
+        self.assertIn("function mcpTimingSafeEqual(", self.js)
+        self.assertIn("mcpTimingSafeEqual(mcpBearerToken(request), String(env.MCP_TOKEN))", self.js)
+        self.assertIn("401", self.js)
+
+    def test_origin_allowlist_blocks_dns_rebinding(self):
+        self.assertIn("MCP_ALLOWED_ORIGINS", self.js)
+        self.assertIn("Forbidden origin", self.js)
+        for origin in ("https://misakanet.org", "https://claude.ai", "https://glama.ai"):
+            self.assertIn(f'"{origin}"', self.js)
+
+    def test_phase_one_is_read_only(self):
+        self.assertIn('name: "misakanet_search"', self.js)
+        self.assertIn('name: "misakanet_get_lesson"', self.js)
+        # Write tools are Phase 2 — they must not be reachable yet.
+        self.assertNotIn("misakanet_submit_usage", self.js)
+        self.assertNotIn("misakanet_usage_status", self.js)
+
+    def test_protocol_versions_cover_the_spec_and_the_rc(self):
+        self.assertIn('"2025-06-18"', self.js)
+        self.assertIn('"2026-07-28"', self.js)
+        self.assertIn("MCP_DEFAULT_PROTOCOL", self.js)
+
+    def test_lesson_paths_are_restricted_to_lesson_markdown(self):
+        self.assertIn("function mcpSafeLessonPath(", self.js)
+        self.assertIn('if (path.includes("..")) return null;', self.js)
+        self.assertIn(r"^lessons\/[A-Za-z0-9._/-]+\.md$", self.js)
+
+    def test_no_hardcoded_mcp_token(self):
+        """The token only ever comes from env."""
+        for match in re.finditer(r"MCP_TOKEN\s*[:=]\s*(.+)", self.js):
+            tail = match.group(1).strip()
+            self.assertFalse(
+                tail.startswith(('"', "'")),
+                f"MCP_TOKEN must be read from env, found literal: {tail[:40]}",
+            )
+
+    def test_version_fallback_matches_pyproject(self):
+        """MCP_VERSION defaults to the packaged version (issue #804 spec)."""
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        version = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', pyproject, re.MULTILINE).group(1)
+        self.assertIn(f'const MCP_FALLBACK_VERSION = "{version}"', self.js)
+        self.assertIn("env.MCP_VERSION || MCP_FALLBACK_VERSION", self.js)
+
+
+class TestMcpWorkerDocs(unittest.TestCase):
+    def test_connection_doc_exists_and_documents_the_endpoint(self):
+        doc = REPO_ROOT / "docs" / "integrations" / "mcp-remote.md"
+        self.assertTrue(doc.exists(), "docs/integrations/mcp-remote.md is required by #804")
+        text = doc.read_text(encoding="utf-8")
+        self.assertIn("https://misakanet.org/mcp", text)
+        self.assertIn("Authorization: Bearer", text)
+        self.assertIn("misakanet_search", text)
+        self.assertIn("misakanet_get_lesson", text)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class TestMcpWorkerBehaviour(unittest.TestCase):
+    def test_node_unit_tests_pass(self):
+        result = subprocess.run(
+            ["node", "--test", str(NODE_TESTS)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout[-4000:] + result.stderr[-2000:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workers/README.md
+++ b/workers/README.md
@@ -85,6 +85,27 @@ jobs:
 | GET | `/api/health` | 健康检查，返回 Token / KV 配置状态 |
 | GET | `/api/helpful?lesson_id=<id>` | 返回该 lesson 的 "helped me" 投票数 |
 | POST | `/` | 节点注册（IP 限流 1 次/30s） |
+| POST | `/mcp` | 远程 MCP 端点（Streamable HTTP，需 Bearer `MCP_TOKEN`） |
+| GET | `/mcp` | 405 + `Accept-Post: application/json`（不提供 SSE 流） |
+
+### Remote MCP endpoint (Issue #804)
+
+`POST /mcp` 暴露只读 MCP 工具 `misakanet_search` 与 `misakanet_get_lesson`，任何 MCP 客户端
+（Claude / Cursor / Copilot / Glama）无需 clone 仓库即可连接。协议版本 `2025-06-18`（兼容
+`2026-07-28` RC），无状态、不返回 session ID。
+
+| 变量名 | 必需 | 说明 |
+|--------|------|------|
+| `MCP_TOKEN` | 是 | Bearer 令牌；未配置时 `/mcp` 返回 503 |
+| `MCP_VERSION` | 否 | `serverInfo.version`，默认取 `pyproject.toml` 版本 |
+| `MCP_ALLOWED_ORIGINS` | 否 | 额外允许的 Origin（逗号分隔），用于 DNS rebinding 防护白名单 |
+
+```bash
+npx wrangler secret put MCP_TOKEN --name misakanet-register-proxy
+node --test workers/mcp-remote.test.mjs   # 传输层 / 鉴权 / 工具 / 排序单测
+```
+
+连接方式与 curl 验证：[docs/integrations/mcp-remote.md](../docs/integrations/mcp-remote.md)。
 
 ### Insights endpoints (Issue #591)
 

--- a/workers/mcp-remote.test.mjs
+++ b/workers/mcp-remote.test.mjs
@@ -1,0 +1,370 @@
+// Unit tests for the remote MCP endpoint (Issue #804).
+// Run: node --test workers/mcp-remote.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import worker, {
+  MCP_FALLBACK_VERSION,
+  MCP_TOOLS,
+  handleMcpRequest,
+  mcpMethodNotAllowed,
+  mcpOriginAllowed,
+  mcpRankLessons,
+  mcpSafeLessonPath,
+  mcpTimingSafeEqual,
+  mcpTokenize,
+} from './register-proxy-sw.js';
+
+const TOKEN = 'test-mcp-token';
+const ENV = { MCP_TOKEN: TOKEN, REGISTER_TOKEN: 'gh-token' };
+
+const LESSONS = [
+  {
+    id: 'sqlite-database-locked',
+    title: 'SQLite database is locked under concurrent writers',
+    domain: 'python',
+    tags: ['sqlite', 'database', 'locking'],
+    summary: 'Concurrent writers hit "database is locked"; fix with WAL mode and a busy timeout.',
+    preview: '# database locked\n\nUse WAL.',
+    url: 'lessons/core/sqlite-database-locked.md',
+    status: 'active',
+    verified: true,
+    confidence: 0.9,
+  },
+  {
+    id: 'npm-publish-otp',
+    title: 'npm publish fails with EOTP',
+    domain: 'devops',
+    tags: ['npm', 'publish'],
+    summary: 'npm publish needs a one-time password when 2FA is enabled.',
+    preview: 'Pass --otp=<code>.',
+    url: 'lessons/contrib/npm-publish-otp.md',
+    status: 'active',
+    verified: false,
+    confidence: 0.6,
+  },
+  {
+    id: 'zh-locked-db',
+    title: '数据库锁定导致写入失败',
+    domain: 'python',
+    tags: ['数据库'],
+    summary: '并发写入时数据库锁定，需要开启 WAL 模式。',
+    preview: '数据库锁定的排查步骤。',
+    url: 'lessons/core/zh-locked-db.md',
+    status: 'active',
+    verified: false,
+    confidence: 0.5,
+  },
+];
+
+const MARKDOWN = {
+  'lessons/core/sqlite-database-locked.md': '# SQLite database is locked\n\nEnable WAL mode.\n',
+  'lessons/core/zh-locked-db.md': '# 数据库锁定\n\n开启 WAL 模式并设置 busy_timeout。\n',
+};
+
+// Stub the GitHub contents API the worker reads through.
+function installFakeGitHub() {
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    const parsed = new URL(String(url));
+    const path = decodeURIComponent(parsed.pathname.split('/contents/')[1] || '');
+    const ref = parsed.searchParams.get('ref');
+
+    let text = null;
+    if (path === 'lessons.json' && ref === 'data') text = JSON.stringify(LESSONS);
+    else if (ref === 'main' && MARKDOWN[path] !== undefined) text = MARKDOWN[path];
+
+    if (text === null) return new Response('{"message":"Not Found"}', { status: 404 });
+    return new Response(
+      JSON.stringify({ content: Buffer.from(text, 'utf8').toString('base64'), encoding: 'base64' }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  };
+  return calls;
+}
+
+function mcpRequest(body, { token = TOKEN, origin, headers = {}, method = 'POST' } = {}) {
+  const requestHeaders = { 'Content-Type': 'application/json', ...headers };
+  if (token !== null) requestHeaders.Authorization = `Bearer ${token}`;
+  if (origin) requestHeaders.Origin = origin;
+  return new Request('https://misakanet.org/mcp', {
+    method,
+    headers: requestHeaders,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const rpc = (method, params, id = 1) => ({ jsonrpc: '2.0', id, method, params });
+
+async function callMcp(body, options) {
+  installFakeGitHub();
+  const resp = await handleMcpRequest(mcpRequest(body, options), options?.env || ENV);
+  return resp;
+}
+
+// ── Auth + Origin ──────────────────────────────────────────────────────────
+
+test('missing bearer token returns 401', async () => {
+  const resp = await callMcp(rpc('tools/list', {}), { token: null });
+  assert.equal(resp.status, 401);
+  assert.match(resp.headers.get('WWW-Authenticate') || '', /Bearer/);
+  assert.equal((await resp.json()).error.message, 'Unauthorized');
+});
+
+test('invalid bearer token returns 401', async () => {
+  const resp = await callMcp(rpc('tools/list', {}), { token: 'wrong-token-value' });
+  assert.equal(resp.status, 401);
+});
+
+test('unknown Origin returns 403 even with a valid token', async () => {
+  const resp = await callMcp(rpc('tools/list', {}), { origin: 'https://evil.example' });
+  assert.equal(resp.status, 403);
+  assert.equal((await resp.json()).error.message, 'Forbidden origin');
+});
+
+test('allowlisted Origin is accepted and echoed back', async () => {
+  const resp = await callMcp(rpc('tools/list', {}), { origin: 'https://misakanet.org' });
+  assert.equal(resp.status, 200);
+  assert.equal(resp.headers.get('Access-Control-Allow-Origin'), 'https://misakanet.org');
+});
+
+test('MCP_ALLOWED_ORIGINS extends the allowlist', () => {
+  assert.equal(mcpOriginAllowed('https://extra.example', { MCP_ALLOWED_ORIGINS: 'https://extra.example' }), true);
+  assert.equal(mcpOriginAllowed('https://extra.example', {}), false);
+  assert.equal(mcpOriginAllowed(null, {}), true, 'non-browser clients send no Origin');
+});
+
+test('unconfigured MCP_TOKEN returns 503, not a bypass', async () => {
+  const resp = await callMcp(rpc('tools/list', {}), { env: { REGISTER_TOKEN: 'gh-token' } });
+  assert.equal(resp.status, 503);
+});
+
+test('timing-safe compare rejects mismatched and empty tokens', () => {
+  assert.equal(mcpTimingSafeEqual(TOKEN, TOKEN), true);
+  assert.equal(mcpTimingSafeEqual(TOKEN, 'test-mcp-tokeN'), false);
+  assert.equal(mcpTimingSafeEqual('', ''), false);
+});
+
+// ── Protocol surface ───────────────────────────────────────────────────────
+
+test('initialize returns serverInfo and negotiates the protocol version', async () => {
+  const resp = await callMcp(rpc('initialize', { protocolVersion: '2025-06-18' }));
+  assert.equal(resp.status, 200);
+  const { result } = await resp.json();
+  assert.equal(result.protocolVersion, '2025-06-18');
+  assert.equal(result.serverInfo.name, 'misakanet');
+  assert.equal(result.serverInfo.version, MCP_FALLBACK_VERSION);
+  assert.ok(result.capabilities.tools);
+});
+
+test('initialize echoes the 2026-07-28 RC and falls back for unknown versions', async () => {
+  const rc = await (await callMcp(rpc('initialize', { protocolVersion: '2026-07-28' }))).json();
+  assert.equal(rc.result.protocolVersion, '2026-07-28');
+  const unknown = await (await callMcp(rpc('initialize', { protocolVersion: '1999-01-01' }))).json();
+  assert.equal(unknown.result.protocolVersion, '2025-06-18');
+});
+
+test('MCP_VERSION secret overrides the fallback version', async () => {
+  const resp = await callMcp(rpc('initialize', {}), { env: { ...ENV, MCP_VERSION: '9.9.9' } });
+  assert.equal((await resp.json()).result.serverInfo.version, '9.9.9');
+});
+
+test('tools/list exposes exactly the two read-only tools', async () => {
+  const { result } = await (await callMcp(rpc('tools/list', {}))).json();
+  assert.deepEqual(result.tools.map((t) => t.name), ['misakanet_search', 'misakanet_get_lesson']);
+  for (const tool of result.tools) {
+    assert.equal(tool.inputSchema.type, 'object');
+    assert.ok(tool.description.length > 50);
+  }
+});
+
+test('no write tools leak into Phase 1', () => {
+  const names = MCP_TOOLS.map((t) => t.name);
+  assert.ok(!names.includes('misakanet_submit_usage'));
+  assert.ok(!names.includes('misakanet_usage_status'));
+});
+
+test('unsupported MCP-Protocol-Version header returns 400', async () => {
+  const resp = await callMcp(rpc('tools/list', {}), { headers: { 'MCP-Protocol-Version': '2001-01-01' } });
+  assert.equal(resp.status, 400);
+});
+
+test('notifications get 202 with no body', async () => {
+  const resp = await callMcp({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  assert.equal(resp.status, 202);
+  assert.equal(await resp.text(), '');
+});
+
+test('unknown method returns JSON-RPC -32601', async () => {
+  const { error } = await (await callMcp(rpc('resources/list', {}))).json();
+  assert.equal(error.code, -32601);
+});
+
+test('malformed JSON returns -32700 and batches are rejected', async () => {
+  installFakeGitHub();
+  const bad = new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+    body: '{not json',
+  });
+  const parseResp = await handleMcpRequest(bad, ENV);
+  assert.equal(parseResp.status, 400);
+  assert.equal((await parseResp.json()).error.code, -32700);
+
+  const batchResp = await callMcp([rpc('tools/list', {})]);
+  assert.equal(batchResp.status, 400);
+  assert.equal((await batchResp.json()).error.code, -32600);
+});
+
+test('GET /mcp returns 405 with Accept-Post', () => {
+  const resp = mcpMethodNotAllowed(new Request('https://misakanet.org/mcp'), ENV);
+  assert.equal(resp.status, 405);
+  assert.equal(resp.headers.get('Accept-Post'), 'application/json');
+  assert.equal(resp.headers.get('Allow'), 'POST, OPTIONS');
+});
+
+// ── Routing through the worker entrypoint ──────────────────────────────────
+
+test('worker routes /mcp before the landing page and CORS catch-alls', async () => {
+  installFakeGitHub();
+
+  const get = await worker.fetch(new Request('https://misakanet.org/mcp'), ENV);
+  assert.equal(get.status, 405, 'GET /mcp must not fall through to the HTML landing page');
+  assert.equal(get.headers.get('Accept-Post'), 'application/json');
+
+  const preflight = await worker.fetch(
+    new Request('https://misakanet.org/mcp', { method: 'OPTIONS', headers: { Origin: 'https://claude.ai' } }),
+    ENV,
+  );
+  assert.equal(preflight.status, 204);
+  assert.equal(preflight.headers.get('Access-Control-Allow-Origin'), 'https://claude.ai');
+  assert.match(preflight.headers.get('Access-Control-Allow-Headers') || '', /Authorization/);
+
+  const post = await worker.fetch(mcpRequest(rpc('tools/list', {})), ENV);
+  assert.equal(post.status, 200);
+  assert.equal((await post.json()).result.tools.length, 2);
+
+  const trailingSlash = await worker.fetch(
+    new Request('https://misakanet.org/mcp/', { method: 'POST', headers: { Authorization: `Bearer ${TOKEN}` }, body: '{}' }),
+    ENV,
+  );
+  assert.equal(trailingSlash.status, 400, '/mcp/ is handled by the MCP route, not the 404 catch-all');
+});
+
+test('other routes still work after the MCP route is added', async () => {
+  installFakeGitHub();
+  const health = await worker.fetch(new Request('https://misakanet.org/api/health'), ENV);
+  assert.equal(health.status, 200);
+  assert.equal((await health.json()).status, 'ok');
+
+  const lessons = await worker.fetch(new Request('https://misakanet.org/api/lessons'), ENV);
+  assert.equal(lessons.status, 200);
+  assert.equal((await lessons.json()).length, LESSONS.length);
+});
+
+// ── tools/call ─────────────────────────────────────────────────────────────
+
+test('misakanet_search returns ranked lesson results', async () => {
+  const resp = await callMcp(rpc('tools/call', { name: 'misakanet_search', arguments: { query: 'database locked' } }));
+  const { result } = await resp.json();
+  assert.equal(result.isError, false);
+  const payload = JSON.parse(result.content[0].text);
+  assert.equal(payload.results[0].id, 'sqlite-database-locked');
+  assert.equal(payload.results[0].path, 'lessons/core/sqlite-database-locked.md');
+  assert.ok(payload.results[0].score > 0);
+  assert.equal(payload.count, payload.results.length);
+});
+
+test('misakanet_search validates query and honours domain/top', async () => {
+  const missing = await (await callMcp(rpc('tools/call', { name: 'misakanet_search', arguments: {} }))).json();
+  assert.equal(missing.result.isError, true);
+  assert.match(missing.result.content[0].text, /query is required/);
+
+  const filtered = mcpRankLessons(LESSONS, { query: 'publish', domain: 'python', top: 5 });
+  assert.deepEqual(filtered, [], 'domain filter excludes non-matching domains');
+
+  const capped = mcpRankLessons(LESSONS, { query: 'database', top: 1 });
+  assert.equal(capped.length, 1);
+});
+
+test('CJK queries tokenize into bigrams and match Chinese lessons', () => {
+  assert.ok(mcpTokenize('数据库锁定').includes('数据'));
+  const results = mcpRankLessons(LESSONS, { query: '数据库锁定', top: 5 });
+  assert.equal(results[0].id, 'zh-locked-db');
+});
+
+test('misakanet_get_lesson returns lesson markdown by path and by id', async () => {
+  const byPath = await (await callMcp(rpc('tools/call', {
+    name: 'misakanet_get_lesson',
+    arguments: { path: 'lessons/core/sqlite-database-locked.md' },
+  }))).json();
+  const payload = JSON.parse(byPath.result.content[0].text);
+  assert.match(payload.content, /Enable WAL mode/);
+  assert.equal(payload.truncated, false);
+
+  const byId = await (await callMcp(rpc('tools/call', {
+    name: 'misakanet_get_lesson',
+    arguments: { id: 'sqlite-database-locked' },
+  }))).json();
+  assert.equal(JSON.parse(byId.result.content[0].text).path, 'lessons/core/sqlite-database-locked.md');
+});
+
+test('lesson markdown survives UTF-8 round-trip', async () => {
+  const resp = await callMcp(rpc('tools/call', {
+    name: 'misakanet_get_lesson',
+    arguments: { id: 'zh-locked-db' },
+  }));
+  const payload = JSON.parse((await resp.json()).result.content[0].text);
+  assert.match(payload.content, /数据库锁定/);
+});
+
+test('missing lesson and missing arguments are tool errors, not crashes', async () => {
+  const notFound = await (await callMcp(rpc('tools/call', {
+    name: 'misakanet_get_lesson',
+    arguments: { id: 'does-not-exist' },
+  }))).json();
+  assert.equal(notFound.result.isError, true);
+  assert.match(notFound.result.content[0].text, /Lesson not found/);
+
+  const noArgs = await (await callMcp(rpc('tools/call', { name: 'misakanet_get_lesson', arguments: {} }))).json();
+  assert.match(noArgs.result.content[0].text, /path or id is required/);
+});
+
+test('lesson paths are confined to lessons/*.md', () => {
+  assert.equal(mcpSafeLessonPath('lessons/core/a.md'), 'lessons/core/a.md');
+  assert.equal(mcpSafeLessonPath('lessons/../.github/workflows/deploy-worker.yml'), null);
+  assert.equal(mcpSafeLessonPath('../../etc/passwd'), null);
+  assert.equal(mcpSafeLessonPath('scripts/mcp_server.py'), null);
+  assert.equal(mcpSafeLessonPath('lessons/core/a.txt'), null);
+});
+
+test('traversal attempts never reach GitHub', async () => {
+  const calls = installFakeGitHub();
+  const resp = await handleMcpRequest(
+    mcpRequest(rpc('tools/call', {
+      name: 'misakanet_get_lesson',
+      arguments: { path: 'lessons/../../../etc/passwd' },
+    })),
+    ENV,
+  );
+  const payload = JSON.parse((await resp.json()).result.content[0].text);
+  assert.match(payload.error, /Lesson not found/);
+  assert.ok(!calls.some((c) => c.includes('etc/passwd')));
+});
+
+test('unknown tool returns JSON-RPC -32602', async () => {
+  const { error } = await (await callMcp(rpc('tools/call', { name: 'misakanet_delete_everything', arguments: {} }))).json();
+  assert.equal(error.code, -32602);
+});
+
+test('upstream GitHub failure surfaces as a tool error, not a 500', async () => {
+  globalThis.fetch = async () => new Response('nope', { status: 502 });
+  const resp = await handleMcpRequest(mcpRequest(rpc('tools/call', {
+    name: 'misakanet_search',
+    arguments: { query: 'database locked' },
+  })), ENV);
+  assert.equal(resp.status, 200);
+  const { result } = await resp.json();
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /Upstream failure/);
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -47,8 +47,17 @@ function jsonResponse(body, status = 200) {
   });
 }
 
+// atob() yields one char per byte, so multi-byte UTF-8 (the Chinese lessons)
+// would come back as mojibake without decoding the bytes explicitly.
+function decodeBase64Utf8(b64) {
+  const binary = atob(String(b64).replace(/\s/g, ""));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
 // ── GitHub API fetch with token ──
-async function fetchFromGitHub(token, path, ref = "data") {
+async function fetchTextFromGitHub(token, path, ref = "data") {
   const url = `${GITHUB_API}/repos/${REPO}/contents/${path}?ref=${encodeURIComponent(ref)}`;
   const resp = await fetch(url, {
     headers: { Authorization: `Bearer ${token}`, "User-Agent": "MisakaNet-Worker", Accept: "application/vnd.github.v3+json" },
@@ -56,7 +65,11 @@ async function fetchFromGitHub(token, path, ref = "data") {
   if (!resp.ok) throw new Error(`GitHub API ${resp.status}`);
   const data = await resp.json();
   if (!data.content || data.encoding !== "base64") throw new Error("Unexpected GitHub response");
-  return JSON.parse(atob(data.content));
+  return decodeBase64Utf8(data.content);
+}
+
+async function fetchFromGitHub(token, path, ref = "data") {
+  return JSON.parse(await fetchTextFromGitHub(token, path, ref));
 }
 
 // ── KV cache wrapper ──
@@ -79,6 +92,421 @@ function sanitizeIdentifier(val, maxLen) {
   if (val.length > maxLen) val = val.slice(0, maxLen);
   // 只允许字母、数字、下划线、连字符、中文
   return val.replace(/[^\w\u4e00-\u9fa5\-]/g, "");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Remote MCP endpoint — POST /mcp (Issue #804)
+//
+// Streamable HTTP transport, Phase 1 = read-only: misakanet_search and
+// misakanet_get_lesson. Any MCP client (Claude, Cursor, Copilot, Glama) can
+// connect without cloning the repo. Writes (submit_usage, usage_status) are
+// deliberately out of scope here.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const MCP_PATH = "/mcp";
+const MCP_DEFAULT_PROTOCOL = "2025-06-18";
+// Newest first — 2026-07-28 is the forward-compat RC, 2025-03-26 the legacy fallback.
+const MCP_SUPPORTED_PROTOCOLS = ["2026-07-28", "2025-06-18", "2025-03-26"];
+// Used when the MCP_VERSION secret is unset. Kept in sync with pyproject.toml
+// by tests/test_mcp_remote_worker.py.
+const MCP_FALLBACK_VERSION = "2.15.0";
+const MCP_LESSON_REF = "main";
+const MCP_INDEX_PATH = "lessons.json";
+const MCP_INDEX_REF = "data";
+const MCP_MAX_BODY = 65_536;
+const MCP_MAX_RESULTS = 20;
+const MCP_LESSON_MAX_CHARS = 5000;
+
+// Origin allowlist (DNS rebinding protection). Non-browser MCP clients send no
+// Origin header at all; only a *present and unknown* Origin is rejected.
+const MCP_ALLOWED_ORIGINS = [
+  "https://misakanet.org",
+  "https://www.misakanet.org",
+  "https://ikalus1988.github.io",
+  "https://glama.ai",
+  "https://claude.ai",
+  "https://cursor.com",
+];
+
+const MCP_TOOLS = [
+  {
+    name: "misakanet_search",
+    description:
+      "Search MisakaNet's public failure-lesson index by error text, keyword, or topic. " +
+      "Use when you need to discover relevant lessons and do not already know a lesson ID. " +
+      "Input: query is required; domain optionally filters by lesson domain; top limits ranked " +
+      "results (default 5, max 20). Output: JSON with results[] of ranked lesson summaries " +
+      "(id, title, domain, tags, status, path, score) plus count and source. Error cases: missing " +
+      "query, or upstream index unavailable. Side effects: none — read-only. Do not send private " +
+      "logs or prompts; search with redacted snippets only. Use misakanet_get_lesson for full content.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Required redacted error message, keyword, or topic (for example: 'database is locked')." },
+        domain: { type: "string", description: "Optional domain filter such as devops, python, network, rag, or mcp." },
+        top: { type: "integer", description: "Maximum ranked results to return. Defaults to 5, capped at 20." },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "misakanet_get_lesson",
+    description:
+      "Fetch one public MisakaNet lesson as markdown, by repository path or lesson ID. Use after " +
+      "misakanet_search returns a promising result, or when a lesson is explicitly referenced; not " +
+      "for broad discovery. Input: provide either path (lessons/<dir>/<id>.md) or id. Output: JSON " +
+      "with path, content (truncated to 5000 characters), length, and truncated flag. Error cases: " +
+      "missing path/id, or lesson not found. Side effects: none — read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "Lesson path relative to the repository, for example lessons/core/auto-merge-ci-pipeline.md." },
+        id: { type: "string", description: "Lesson ID, usually the filename without .md, for example auto-merge-ci-pipeline." },
+      },
+    },
+  },
+];
+
+function mcpTimingSafeEqual(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length || a.length === 0) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return mismatch === 0;
+}
+
+function mcpBearerToken(request) {
+  const header = (request.headers.get("Authorization") || "").trim();
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1].trim() : "";
+}
+
+function mcpOriginAllowed(origin, env = {}) {
+  if (!origin) return true; // curl / native MCP hosts never send Origin
+  const extra = String(env.MCP_ALLOWED_ORIGINS || "").split(",").map((o) => o.trim()).filter(Boolean);
+  return MCP_ALLOWED_ORIGINS.includes(origin) || extra.includes(origin);
+}
+
+function mcpCorsHeaders(origin, env) {
+  const headers = {
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, MCP-Protocol-Version, Mcp-Session-Id",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+  // Only echo an Origin that already passed the allowlist above.
+  if (origin && mcpOriginAllowed(origin, env)) headers["Access-Control-Allow-Origin"] = origin;
+  return headers;
+}
+
+function mcpJson(body, status, origin, env, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "Cache-Control": "no-store",
+      ...mcpCorsHeaders(origin, env),
+      ...extraHeaders,
+    },
+  });
+}
+
+function mcpErrorBody(id, code, message) {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+function mcpServerVersion(env) {
+  return String(env.MCP_VERSION || MCP_FALLBACK_VERSION);
+}
+
+// ── Ranking ──
+// Lightweight keyword scoring over the lessons.json index. CJK queries have no
+// whitespace, so CJK tokens also contribute their character bigrams.
+function mcpTokenize(text) {
+  const tokens = [];
+  for (const raw of String(text).toLowerCase().split(/[^\p{L}\p{N}_]+/u)) {
+    if (!raw) continue;
+    const isCjk = /[\u3400-\u9fff\u3040-\u30ff]/.test(raw); // CJK ideographs + kana
+    if (raw.length >= 2 || isCjk) tokens.push(raw);
+    if (isCjk && raw.length > 2) {
+      for (let i = 0; i < raw.length - 1; i++) tokens.push(raw.slice(i, i + 2));
+    }
+  }
+  return [...new Set(tokens)];
+}
+
+const MCP_FIELD_WEIGHTS = [
+  ["title", 5],
+  ["tags", 4],
+  ["id", 3],
+  ["domain", 3],
+  ["summary", 2],
+  ["preview", 1],
+];
+
+function mcpScoreLesson(lesson, tokens, phrase) {
+  const fields = {
+    title: String(lesson.title || ""),
+    tags: Array.isArray(lesson.tags) ? lesson.tags.join(" ") : String(lesson.tags || ""),
+    id: String(lesson.id || ""),
+    domain: String(lesson.domain || ""),
+    summary: String(lesson.summary || ""),
+    preview: String(lesson.preview || ""),
+  };
+
+  let score = 0;
+  for (const [field, weight] of MCP_FIELD_WEIGHTS) {
+    const hay = fields[field].toLowerCase();
+    if (!hay) continue;
+    for (const token of tokens) if (hay.includes(token)) score += weight;
+    if (phrase.length >= 3 && hay.includes(phrase)) score += weight * 2;
+  }
+  if (score === 0) return 0;
+
+  if (lesson.verified) score += 1;
+  if (lesson.status && lesson.status !== "active") score -= 1;
+  const confidence = typeof lesson.confidence === "number" ? lesson.confidence : 0.5;
+  return Math.round((score + confidence) * 1000) / 1000;
+}
+
+function mcpRankLessons(lessons, { query, domain, top = 5 } = {}) {
+  const tokens = mcpTokenize(query);
+  const phrase = String(query).toLowerCase().trim();
+  const wantedDomain = domain ? String(domain).toLowerCase() : null;
+
+  const scored = [];
+  for (const lesson of Array.isArray(lessons) ? lessons : []) {
+    if (!lesson || typeof lesson !== "object") continue;
+    if (wantedDomain && String(lesson.domain || "").toLowerCase() !== wantedDomain) continue;
+    const score = mcpScoreLesson(lesson, tokens, phrase);
+    if (score > 0) scored.push({ lesson, score });
+  }
+
+  scored.sort((a, b) => b.score - a.score || String(a.lesson.id || "").localeCompare(String(b.lesson.id || "")));
+  return scored.slice(0, top).map(({ lesson, score }) => ({
+    id: lesson.id || null,
+    title: lesson.title || null,
+    domain: lesson.domain || null,
+    tags: Array.isArray(lesson.tags) ? lesson.tags : [],
+    status: lesson.status || null,
+    verified: !!lesson.verified,
+    path: lesson.url || null,
+    score,
+  }));
+}
+
+// Only repository lesson markdown is reachable — no traversal, no other paths.
+function mcpSafeLessonPath(candidate) {
+  const path = String(candidate || "").replace(/^\.\//, "").trim();
+  if (path.includes("..")) return null;
+  if (!/^lessons\/[A-Za-z0-9._/-]+\.md$/.test(path)) return null;
+  return path;
+}
+
+async function mcpLoadLessons(env) {
+  const token = env.REGISTER_TOKEN;
+  if (!token) throw new Error("REGISTER_TOKEN not configured");
+  // Same cache key as GET /api/lessons — one index fetch serves both.
+  return getWithCache(env, "proxy:lessons", () => fetchFromGitHub(token, MCP_INDEX_PATH, MCP_INDEX_REF));
+}
+
+async function mcpToolSearch(args, env) {
+  const query = typeof args.query === "string" ? args.query.trim() : "";
+  if (!query) return { error: "query is required" };
+
+  const requestedTop = parseInt(args.top, 10);
+  const top = Math.min(Math.max(Number.isFinite(requestedTop) ? requestedTop : 5, 1), MCP_MAX_RESULTS);
+  const lessons = await mcpLoadLessons(env);
+  const results = mcpRankLessons(lessons, { query, domain: args.domain, top });
+
+  return { query, count: results.length, results, source: "misakanet-worker" };
+}
+
+// path wins when given; otherwise resolve the ID through the index, falling
+// back to the two conventional lesson directories.
+async function mcpLessonCandidates(args, env) {
+  const explicit = mcpSafeLessonPath(args.path);
+  if (explicit) return [explicit];
+
+  const raw = typeof args.id === "string" && args.id ? args.id : args.path;
+  const id = sanitizeIdentifier(String(raw || "").replace(/\.md$/, ""), 120);
+  if (!id) return [];
+
+  const candidates = [];
+  try {
+    const lessons = await mcpLoadLessons(env);
+    const hit = (Array.isArray(lessons) ? lessons : []).find(
+      (lesson) => lesson && String(lesson.id || "").toLowerCase() === id.toLowerCase(),
+    );
+    const indexed = hit && mcpSafeLessonPath(hit.url);
+    if (indexed) candidates.push(indexed);
+  } catch { /* index unavailable — fall through to the conventional paths */ }
+
+  for (const dir of ["core", "contrib"]) {
+    const guess = mcpSafeLessonPath(`lessons/${dir}/${id}.md`);
+    if (guess && !candidates.includes(guess)) candidates.push(guess);
+  }
+  return candidates;
+}
+
+async function mcpToolGetLesson(args, env) {
+  if (!args.path && !args.id) return { error: "path or id is required" };
+
+  const token = env.REGISTER_TOKEN;
+  if (!token) throw new Error("REGISTER_TOKEN not configured");
+
+  const candidates = await mcpLessonCandidates(args, env);
+  if (!candidates.length) return { error: `Lesson not found: ${String(args.path || args.id).slice(0, 120)}` };
+
+  for (const path of candidates) {
+    let markdown;
+    try {
+      markdown = await fetchTextFromGitHub(token, path, MCP_LESSON_REF);
+    } catch {
+      continue;
+    }
+    const truncated = markdown.length > MCP_LESSON_MAX_CHARS;
+    return {
+      path,
+      length: markdown.length,
+      truncated,
+      content: truncated ? markdown.slice(0, MCP_LESSON_MAX_CHARS) : markdown,
+    };
+  }
+
+  return { error: `Lesson not found: ${String(args.path || args.id).slice(0, 120)}` };
+}
+
+async function mcpCallTool(name, args, env) {
+  const handlers = {
+    misakanet_search: mcpToolSearch,
+    misakanet_get_lesson: mcpToolGetLesson,
+  };
+  const handler = handlers[name];
+  if (!handler) return null;
+
+  let payload;
+  try {
+    payload = await handler(args && typeof args === "object" ? args : {}, env);
+  } catch (err) {
+    payload = { error: `Upstream failure: ${err.message}` };
+  }
+
+  // Tool-level failures stay inside the result with isError, per MCP spec —
+  // only protocol failures become JSON-RPC errors.
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    isError: !!payload.error,
+  };
+}
+
+// Returns a JSON-RPC response object, or null for notifications (nothing to send back).
+async function mcpDispatch(message, env) {
+  const id = message.id ?? null;
+  const method = String(message.method || "");
+  const params = message.params && typeof message.params === "object" ? message.params : {};
+
+  if (method.startsWith("notifications/")) return null;
+
+  switch (method) {
+    case "initialize": {
+      const requested = String(params.protocolVersion || "");
+      const negotiated = MCP_SUPPORTED_PROTOCOLS.includes(requested) ? requested : MCP_DEFAULT_PROTOCOL;
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: negotiated,
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: { name: "misakanet", title: "MisakaNet", version: mcpServerVersion(env) },
+          instructions:
+            "MisakaNet is a cross-agent index of failure lessons. Search it with misakanet_search " +
+            "before debugging a recurring error, then read the full lesson with misakanet_get_lesson. " +
+            "Read-only: never send private logs, prompts, or secrets.",
+        },
+      };
+    }
+
+    case "ping":
+      return { jsonrpc: "2.0", id, result: {} };
+
+    case "tools/list":
+      return { jsonrpc: "2.0", id, result: { tools: MCP_TOOLS } };
+
+    case "tools/call": {
+      const name = String(params.name || "");
+      const result = await mcpCallTool(name, params.arguments, env);
+      if (!result) return mcpErrorBody(id, -32602, `Unknown tool: ${name}`);
+      console.log(`[mcp] tools/call ${name}`);
+      return { jsonrpc: "2.0", id, result };
+    }
+
+    default:
+      return mcpErrorBody(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+async function handleMcpRequest(request, env) {
+  const origin = request.headers.get("Origin");
+
+  // 1. Origin allowlist — DNS rebinding protection, checked before auth.
+  if (!mcpOriginAllowed(origin, env)) {
+    return mcpJson(mcpErrorBody(null, -32000, "Forbidden origin"), 403, null, env);
+  }
+
+  // 2. Bearer auth.
+  if (!env.MCP_TOKEN) {
+    return mcpJson(mcpErrorBody(null, -32000, "MCP endpoint not configured (MCP_TOKEN missing)"), 503, origin, env);
+  }
+  if (!mcpTimingSafeEqual(mcpBearerToken(request), String(env.MCP_TOKEN))) {
+    return mcpJson(mcpErrorBody(null, -32001, "Unauthorized"), 401, origin, env, {
+      "WWW-Authenticate": 'Bearer realm="misakanet-mcp"',
+    });
+  }
+
+  // 3. Transport-level validation.
+  const headerVersion = request.headers.get("MCP-Protocol-Version");
+  if (headerVersion && !MCP_SUPPORTED_PROTOCOLS.includes(headerVersion)) {
+    return mcpJson(mcpErrorBody(null, -32000, `Unsupported MCP-Protocol-Version: ${headerVersion}`), 400, origin, env);
+  }
+  if (parseInt(request.headers.get("content-length") || "0", 10) > MCP_MAX_BODY) {
+    return mcpJson(mcpErrorBody(null, -32600, "Request too large"), 413, origin, env);
+  }
+
+  let message;
+  try {
+    message = await request.json();
+  } catch {
+    return mcpJson(mcpErrorBody(null, -32700, "Parse error"), 400, origin, env);
+  }
+  if (Array.isArray(message)) {
+    return mcpJson(mcpErrorBody(null, -32600, "JSON-RPC batching is not supported (removed in MCP 2025-06-18)"), 400, origin, env);
+  }
+  if (!message || typeof message !== "object" || message.jsonrpc !== "2.0" || typeof message.method !== "string") {
+    return mcpJson(mcpErrorBody(message && message.id, -32600, "Invalid Request"), 400, origin, env);
+  }
+
+  const responseHeaders = { "MCP-Protocol-Version": headerVersion || MCP_DEFAULT_PROTOCOL };
+
+  let response;
+  try {
+    response = await mcpDispatch(message, env);
+  } catch (err) {
+    console.error("[mcp] internal error", err.message);
+    return mcpJson(mcpErrorBody(message.id, -32603, `Internal error: ${err.message}`), 500, origin, env, responseHeaders);
+  }
+
+  // Notifications carry no response body.
+  if (!response) return new Response(null, { status: 202, headers: { ...mcpCorsHeaders(origin, env), ...responseHeaders } });
+  return mcpJson(response, 200, origin, env, responseHeaders);
+}
+
+// GET/DELETE /mcp — no server-initiated SSE stream is offered, so the spec
+// requires 405 plus Accept-Post advertising the POST content type.
+function mcpMethodNotAllowed(request, env) {
+  return mcpJson(mcpErrorBody(null, -32000, "Method not allowed. Use POST /mcp (Streamable HTTP)."), 405, request.headers.get("Origin"), env, {
+    "Accept-Post": "application/json",
+    Allow: "POST, OPTIONS",
+  });
 }
 
 async function probeKeepaliveEndpoint(endpoint) {
@@ -127,6 +555,18 @@ async function runKeepaliveSweep(cron = "manual") {
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+
+    // Remote MCP endpoint (#804) — own auth/CORS rules, so it goes before the
+    // generic OPTIONS handler and every /api route.
+    if (url.pathname === MCP_PATH || url.pathname === `${MCP_PATH}/`) {
+      if (request.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: mcpCorsHeaders(request.headers.get("Origin"), env) });
+      }
+      if (request.method === "POST") {
+        return handleMcpRequest(request, env);
+      }
+      return mcpMethodNotAllowed(request, env);
+    }
 
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: CORS_HEADERS });
@@ -528,4 +968,22 @@ export default {
   async scheduled(controller, env, ctx) {
     ctx.waitUntil(runKeepaliveSweep(controller.cron));
   },
+};
+
+// Named exports for unit tests only (workers/mcp-remote.test.mjs). Wrangler
+// deploys this file for its default export; the extra exports are inert there.
+export {
+  MCP_PATH,
+  MCP_TOOLS,
+  MCP_DEFAULT_PROTOCOL,
+  MCP_SUPPORTED_PROTOCOLS,
+  MCP_FALLBACK_VERSION,
+  decodeBase64Utf8,
+  handleMcpRequest,
+  mcpMethodNotAllowed,
+  mcpOriginAllowed,
+  mcpRankLessons,
+  mcpSafeLessonPath,
+  mcpTimingSafeEqual,
+  mcpTokenize,
 };


### PR DESCRIPTION
## Summary

Adds the remote MCP endpoint from #804: `POST /mcp` on the existing `misakanet-register-proxy` Worker, so any MCP client (Claude, Cursor, Copilot, Glama) can use MisakaNet without cloning the repo. Phase 1 is read-only — `misakanet_search` + `misakanet_get_lesson` only.

/claim #804

## Type of Change

- [x] ✨ New feature
- [ ] 📚 New lesson submission
- [ ] 🐛 Bug fix
- [x] 📝 Documentation update
- [x] 🧪 Test improvement

## What changed

| File | Change |
|------|--------|
| `workers/register-proxy-sw.js` | MCP handler: transport, auth, Origin gate, 2 read-only tools, ranking (+~460 lines) |
| `workers/mcp-remote.test.mjs` | 29 `node --test` cases covering transport, auth, tools, ranking, routing |
| `tests/test_mcp_remote_worker.py` | Contract tests + runs the node suite, so CI covers it |
| `docs/integrations/mcp-remote.md` | Connection instructions, curl verification, status codes, ops |
| `docs/integrations/README.md`, `workers/README.md` | Endpoint + secret documentation |

Implementation notes:

- **Transport** — Streamable HTTP, protocol `2025-06-18`; `initialize` negotiates and echoes `2026-07-28` (RC) and `2025-03-26` when a client asks for them. Stateless (no session ID), so no SSE stream is offered.
- **Auth** — Bearer token compared in constant time against the `MCP_TOKEN` secret. Origin is checked *before* auth (DNS rebinding protection); requests with no `Origin` (curl, native MCP hosts) pass, an unknown `Origin` gets `403`. Extra origins via optional `MCP_ALLOWED_ORIGINS`.
- **Tools** — `misakanet_search` ranks `lessons.json` by weighted keyword hits (title/tags/id/domain/summary/preview), supports `domain` and `top` (default 5, capped at 20), and tokenizes CJK into bigrams so Chinese queries match. `misakanet_get_lesson` resolves a path or ID, confined to `lessons/**/*.md` — traversal is rejected before any GitHub request — and truncates at 5000 chars like the stdio server.
- **Errors** — protocol failures are JSON-RPC errors; tool failures return `200` with `isError: true`, per spec. Batches (`-32600`), oversize bodies (`413`), unsupported `MCP-Protocol-Version` (`400`) and unset `MCP_TOKEN` (`503`) are all handled.
- **Data path** — reuses the existing GitHub proxy and the same 30s KV cache key as `GET /api/lessons`, so MCP traffic adds no extra GitHub API load in the common case. While wiring this up I made the shared base64 decode UTF-8 aware (`atob` alone mangles the Chinese lessons into mojibake); that also fixes `GET /api/lessons` for non-ASCII content.
- **Version** — `serverInfo.version` comes from `MCP_VERSION`, defaulting to the `pyproject.toml` version (2.15.0); a test pins the two together so they can't drift.

## Acceptance criteria

- [x] `POST /mcp` with valid Bearer token returns `initialize`, `tools/list`, `tools/call` responses
- [x] Missing/invalid token → 401
- [x] Invalid Origin → 403
- [x] `tools/call` for `misakanet_search` returns ranked lesson results
- [x] `tools/call` for `misakanet_get_lesson` returns lesson markdown
- [x] `GET /mcp` → 405 with `Accept-Post` header
- [x] `docs/integrations/mcp-remote.md` exists with connection instructions
- [ ] Glama analytics shows > 0 routed tool calls after endpoint is live — **not verifiable from a PR**: it needs the `MCP_TOKEN` secret set on the Worker and a deploy to main first. See "Deploy checklist" below.

## Deploy checklist (maintainer)

1. `npx wrangler secret put MCP_TOKEN --name misakanet-register-proxy` (until this is set, `/mcp` returns `503` and nothing else changes).
2. Merge → `deploy-worker.yml` deploys on push to `main` (it already watches `workers/register-proxy-sw.js`).
3. Run the curl block in `docs/integrations/mcp-remote.md` against `https://misakanet.org/mcp`.
4. Point a Glama-routed client at the endpoint and re-check analytics for the last AC.

## Testing

```
node --test workers/mcp-remote.test.mjs   # 29 pass
node --test workers/register-proxy.test.mjs  # 8 pass (existing suite, unaffected)
python3 -m unittest tests.test_mcp_remote_worker  # 11 pass
python3 scripts/check_worker_secrets.py   # 0 errors
```

The node suite stubs the GitHub contents API, so it exercises real request → response behaviour (auth, 403/401/405/202/413, ranking, UTF-8 round-trip, traversal rejection) without network access.

## Checklist

- [x] My commit has `Signed-off-by:` (DCO required)
- [x] I have tested that the changes work correctly
- [x] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds)
