### PR TITLE
feat(insights): add privacy-preserving unsolved failure map (#788)

### DIFF
--- a/docs/insights/unsolved-map.html
+++ b/docs/insights/unsolved-map.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MisakaNet — Unsolved Failure Map</title>
+<meta name="description" content="Which failure families MisakaNet has no effective lesson for. Aggregate counts only — no raw queries, prompts, logs, or identifiers.">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; min-height: 100vh;
+    display: flex; flex-direction: column; align-items: center; padding: 2rem 1rem;
+  }
+  .container { max-width: 820px; width: 100%; }
+  h1 { font-size: 1.5rem; font-weight: 600; color: #58a6ff; margin-bottom: 0.25rem; }
+  h2 { font-size: 1.05rem; font-weight: 600; color: #e6edf3; margin: 2rem 0 0.75rem; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 1.5rem; line-height: 1.6; }
+  .privacy {
+    border: 1px solid #30363d; border-left: 3px solid #3fb950; border-radius: 8px;
+    background: #161b22; padding: 0.9rem 1rem; font-size: 0.85rem; color: #8b949e; line-height: 1.7;
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.6rem 0.75rem; border-bottom: 1px solid #21262d; }
+  th { color: #8b949e; font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  tbody tr:hover { background: #161b22; }
+  .family { color: #e6edf3; font-weight: 600; }
+  .reasons { color: #8b949e; font-size: 0.8rem; }
+  .bar { height: 4px; background: #1f6feb; border-radius: 2px; margin-top: 4px; }
+  .state { color: #8b949e; font-size: 0.9rem; padding: 1.25rem 0; }
+  .state.error { color: #f85149; }
+  .table-wrap { overflow-x: auto; }
+  a { color: #58a6ff; }
+  footer { margin-top: 2.5rem; font-size: 0.8rem; color: #6e7681; line-height: 1.8; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>⚡ Unsolved Failure Map</h1>
+  <p class="subtitle">
+    Where MisakaNet's lesson coverage has gaps: failure families whose searches found nothing,
+    found only low-confidence matches, or whose lessons were reported as not helpful.
+    Rolling 30-day window.
+  </p>
+
+  <div class="privacy">
+    <strong>Privacy:</strong> aggregate counts only. Task-family labels are derived from query
+    clustering on the server and the query text is discarded immediately — no raw queries, prompts,
+    logs, file paths, session data, or user identifiers are stored or shown here.
+  </div>
+
+  <h2>Top unsolved families</h2>
+  <div class="table-wrap">
+    <table id="families-table" hidden>
+      <thead>
+        <tr><th>Task family</th><th class="num">7d</th><th class="num">30d</th><th>Reasons</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div class="state" id="families-state">Loading…</div>
+
+  <h2>Lessons reported as not helpful</h2>
+  <div class="table-wrap">
+    <table id="stale-table" hidden>
+      <thead>
+        <tr><th>Lesson</th><th class="num">Not-helpful (30d)</th><th>Last seen</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div class="state" id="stale-state">Loading…</div>
+
+  <footer>
+    Source: <code>GET /api/insights/unsolved-map</code> ·
+    <a href="https://github.com/Ikalus1988/MisakaNet/issues/788">issue #788</a> ·
+    A family with a high count is an invitation:
+    <a href="https://github.com/Ikalus1988/MisakaNet/issues/new?template=lesson-feedback.yml">share a lesson</a>
+    that closes the gap.
+  </footer>
+</div>
+
+<script>
+const API = window.location.origin + '/api/insights/unsolved-map';
+
+function escapeHTML(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function renderFamilies(families) {
+  const table = document.getElementById('families-table');
+  const state = document.getElementById('families-state');
+  if (!families.length) {
+    state.textContent = 'No unsolved searches recorded in the last 30 days.';
+    return;
+  }
+  const max = Math.max(...families.map(f => f.unsolved30d));
+  table.querySelector('tbody').innerHTML = families.map(f => {
+    const reasons = Object.entries(f.reasons || {})
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => escapeHTML(reason.replace(/_/g, ' ')) + ' ×' + count)
+      .join(', ');
+    const width = Math.round((f.unsolved30d / max) * 100);
+    return '<tr>' +
+      '<td><span class="family">' + escapeHTML(f.taskFamily) + '</span>' +
+        '<div class="bar" style="width:' + width + '%"></div></td>' +
+      '<td class="num">' + f.unsolved7d + '</td>' +
+      '<td class="num">' + f.unsolved30d + '</td>' +
+      '<td class="reasons">' + (reasons || '—') + '</td>' +
+    '</tr>';
+  }).join('');
+  table.hidden = false;
+  state.hidden = true;
+}
+
+function renderStale(lessons) {
+  const table = document.getElementById('stale-table');
+  const state = document.getElementById('stale-state');
+  if (!lessons.length) {
+    state.textContent = 'No lessons flagged as not helpful in the last 30 days.';
+    return;
+  }
+  table.querySelector('tbody').innerHTML = lessons.map(l =>
+    '<tr>' +
+      '<td><a href="/search/?q=' + encodeURIComponent(l.lessonId) + '">' + escapeHTML(l.lessonId) + '</a></td>' +
+      '<td class="num">' + l.notHelpful30d + '</td>' +
+      '<td class="reasons">' + escapeHTML(l.lastSeen || '—') + '</td>' +
+    '</tr>').join('');
+  table.hidden = false;
+  state.hidden = true;
+}
+
+fetch(API)
+  .then(r => r.json())
+  .then(data => {
+    if (!data.available) {
+      document.getElementById('families-state').textContent = 'Insights storage is not configured on this deployment.';
+      document.getElementById('stale-state').hidden = true;
+      return;
+    }
+    renderFamilies(data.families || []);
+    renderStale(data.staleLessons || []);
+  })
+  .catch(() => {
+    for (const id of ['families-state', 'stale-state']) {
+      const el = document.getElementById(id);
+      el.textContent = 'Could not load the map. Try again later.';
+      el.className = 'state error';
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -368,6 +368,27 @@ function getFeedbackForLesson(lessonId, query) {
 }
 
 const FEEDBACK_API = window.location.origin + '/api/feedback';
+const SEARCH_SIGNAL_API = window.location.origin + '/api/search-signal';
+
+// Unsolved failure map (#788). Only searches that found nothing useful are
+// reported; the backend derives a task-family label and drops the query, so no
+// raw query text is ever stored. Fire-and-forget, deduped per query per session.
+const _signalledQueries = new Set();
+
+function reportUnsolvedSearch(q, results) {
+  if (!q) return;
+  const topScore = results.length ? (results[0].score || 0) : 0;
+  if (results.length && topScore >= 0.35) return; // solved — nothing to report
+  const key = q.toLowerCase().trim();
+  if (_signalledQueries.has(key)) return;
+  _signalledQueries.add(key);
+
+  fetch(SEARCH_SIGNAL_API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: q, result_count: results.length, top_score: topScore }),
+  }).catch(() => {}); // silent fail — insights are best-effort
+}
 
 function submitFeedback(lessonId, query, feedback) {
   const existing = getFeedbackForLesson(lessonId, query);
@@ -450,6 +471,7 @@ function openFeedbackIssue() {
 function render(results, q) {
   const el = document.getElementById('results');
   _lastResults = results;
+  reportUnsolvedSearch(q, results);
   if (!results.length) {
     el.innerHTML = '<div class="fallback">' +
       '<div style="margin-bottom:12px;">' + t('noMatchPrefix') + ' "' + escapeHTML(q) + '". ' + t('noMatchSuffix') + '</div>' +

--- a/tests/test_unsolved_map.py
+++ b/tests/test_unsolved_map.py
@@ -1,0 +1,104 @@
+"""Tests for the privacy-preserving unsolved failure map (Issue #788).
+
+Behaviour is exercised by workers/unsolved-map.test.mjs (`node --test`), which
+this module runs when Node is available. The rest pins the privacy contract:
+only derived family labels and enum reasons may be stored or emitted.
+"""
+
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKER = REPO_ROOT / "workers" / "register-proxy-sw.js"
+NODE_TESTS = REPO_ROOT / "workers" / "unsolved-map.test.mjs"
+SEARCH_PAGE = REPO_ROOT / "docs" / "search" / "index.html"
+MAP_PAGE = REPO_ROOT / "docs" / "insights" / "unsolved-map.html"
+
+
+class TestUnsolvedMapWorker(unittest.TestCase):
+    def setUp(self):
+        self.js = WORKER.read_text(encoding="utf-8")
+        start = self.js.index("Unsolved failure map (Issue #788)")
+        end = self.js.index("async function probeKeepaliveEndpoint")
+        self.section = self.js[start:end]
+
+    def test_endpoints_exist(self):
+        self.assertIn('url.pathname === "/api/insights/unsolved-map"', self.js)
+        self.assertIn('url.pathname === "/api/search-signal"', self.js)
+
+    def test_reason_enum_matches_the_issue(self):
+        for reason in ("no_match", "low_confidence", "not_helpful"):
+            self.assertIn(f'"{reason}"', self.section)
+        self.assertIn("function normalizeUnsolvedReason(", self.section)
+
+    def test_family_labels_are_derived_not_user_supplied(self):
+        """Labels come from the keyword table, never from request fields."""
+        self.assertIn("function classifyTaskFamily(", self.section)
+        self.assertIn("classifyTaskFamily(query)", self.js)
+        self.assertNotIn("body.task_family", self.js)
+        self.assertNotIn("body.taskFamily", self.js)
+
+    def test_query_is_never_persisted_by_the_signal_endpoint(self):
+        """The KV writes in the signal path must not carry the query."""
+        handler = self.section[self.section.index("async function handleSearchSignal("):]
+        kv_writes = re.findall(r"MISAKANET_KV\.put\(([^;]+)\)", handler)
+        for write in kv_writes:
+            self.assertNotIn("query", write, f"query must not be written to KV: {write}")
+
+    def test_output_declares_the_privacy_contract(self):
+        self.assertIn('privacy: "aggregate-only"', self.section)
+        for field in ("raw_query: false", "prompts: false", "logs: false", "paths: false", "pii: false"):
+            self.assertIn(field, self.section)
+
+    def test_window_and_pruning(self):
+        self.assertIn("const UNSOLVED_WINDOW_DAYS = 30", self.section)
+        self.assertIn("function pruneUnsolvedDays(", self.section)
+
+    def test_signal_endpoint_is_rate_limited_and_size_capped(self):
+        handler = self.section[self.section.index("async function handleSearchSignal("):]
+        self.assertIn("rate:signal:", handler)
+        self.assertIn("429", handler)
+        self.assertIn("413", handler)
+
+    def test_logging_never_includes_the_query(self):
+        for line in re.findall(r"console\.log\(`\[unsolved\][^`]*`\)", self.section):
+            self.assertNotIn("query", line)
+
+
+class TestUnsolvedMapFrontend(unittest.TestCase):
+    def test_search_page_reports_only_unsolved_searches(self):
+        html = SEARCH_PAGE.read_text(encoding="utf-8")
+        self.assertIn("/api/search-signal", html)
+        self.assertIn("function reportUnsolvedSearch(", html)
+        # Solved searches return before the fetch.
+        body = html[html.index("function reportUnsolvedSearch("):]
+        self.assertIn("return; // solved", body)
+
+    def test_public_page_exists_and_states_the_privacy_rules(self):
+        self.assertTrue(MAP_PAGE.exists(), "docs/insights/unsolved-map.html is the public view for #788")
+        html = MAP_PAGE.read_text(encoding="utf-8")
+        self.assertIn("/api/insights/unsolved-map", html)
+        self.assertIn("aggregate counts only", html.lower())
+        self.assertIn("escapeHTML", html, "rendered values must be escaped")
+
+    def test_public_page_has_no_external_dependencies(self):
+        html = MAP_PAGE.read_text(encoding="utf-8")
+        self.assertNotIn("<script src=", html)
+        self.assertNotIn("cdn.", html)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class TestUnsolvedMapBehaviour(unittest.TestCase):
+    def test_node_unit_tests_pass(self):
+        result = subprocess.run(
+            ["node", "--test", str(NODE_TESTS)],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=300,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout[-4000:] + result.stderr[-2000:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workers/README.md
+++ b/workers/README.md
@@ -93,6 +93,21 @@ jobs:
 | GET | `/api/insights/demand-board` | 公开、仅聚合的需求看板：按 task family 统计 7d/30d 未解决次数，不含原始查询/日志/个人信息 |
 | GET | `/api/insights/demand-map` | 维护者视图：按 `taskFamily` × `bucketDay` × `unsolvedReason` 展开的桶，需 `X-Maintainer-Key` 头匹配 `MAINTAINER_KEY` |
 
+### Unsolved failure map (Issue #788)
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/insights/unsolved-map` | 公开、仅聚合：30 天窗口内各 task family 的未解决次数（`no_match` / `low_confidence` / `not_helpful`）+ 被标记为无用的 lesson |
+| POST | `/api/search-signal` | 前端在搜索无结果 / 低置信度时上报；Worker 在内存中把 query 归类到 task family 后**立即丢弃原文**，只写入聚合计数（IP 限流 30 次/分钟，body 上限 4KB） |
+
+隐私约束：只存储派生的 family 标签与固定枚举 reason，绝不写入原始 query、prompt、日志、路径或任何身份标识。
+`/api/feedback` 收到 `irrelevant` / `too_basic` 时同样只写入聚合信号 + 公开 lesson ID。
+公开页面：[`docs/insights/unsolved-map.html`](../docs/insights/unsolved-map.html) → https://misakanet.org/insights/unsolved-map.html
+
+```bash
+node --test workers/unsolved-map.test.mjs   # 分类 / 聚合 / 隐私 / 限流单测
+```
+
 两个端点都不依赖 `REGISTER_TOKEN`，只依赖 `MISAKANET_KV`（数据源）与可选的 `MAINTAINER_KEY`（保护 demand-map）。数据来自 `recordUnsolvedSignal()`，供 intake 端点（#589）与分类器（#575）在报告/反馈/MCP 搜索未命中时调用写入；在这两个上游合并之前，看板会返回 `available: true, summary: []`（KV 已配置但暂无数据）。
 
 ### Testing

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -81,6 +81,224 @@ function sanitizeIdentifier(val, maxLen) {
   return val.replace(/[^\w\u4e00-\u9fa5\-]/g, "");
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Unsolved failure map (Issue #788)
+//
+// Shows which failure families have no effective lesson. Aggregate-only by
+// construction: a query is classified into a task family in memory and then
+// discarded — no raw query, prompt, log, path, or identifier is ever written.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const UNSOLVED_KV_PREFIX = "unsolved:family:";
+const UNSOLVED_STALE_PREFIX = "unsolved:lesson:";
+const UNSOLVED_WINDOW_DAYS = 30;
+const UNSOLVED_MAX_STALE_LESSONS = 20;
+const UNSOLVED_LOW_SCORE = 0.35; // matches the frontend's "low confidence" band
+
+// Reason enum — the only values that may ever reach storage or output.
+const UNSOLVED_REASONS = ["no_match", "low_confidence", "not_helpful", "outdated_lesson", "missing_runtime_path"];
+
+// Task families and the keyword clusters that derive them. Labels come from
+// this table, never from user input.
+const UNSOLVED_FAMILIES = [
+  ["github-auth", ["github", "gh auth", "401", "403", "permission denied", "pat", "token expired", "dco", "sign-off", "signoff"]],
+  ["npm-publish", ["npm", "yarn", "pnpm", "eotp", "publish", "registry", "package.json"]],
+  ["cloudflare-worker", ["cloudflare", "worker", "wrangler", "kv namespace", "durable object", "pages"]],
+  ["mcp-registry", ["mcp", "model context protocol", "stdio", "tools/list", "tools/call", "mcp server"]],
+  ["glama-release", ["glama", "listing", "release", "changelog", "tag"]],
+  ["python-env", ["pip", "venv", "virtualenv", "conda", "poetry", "modulenotfounderror", "importerror", "pytest", "python"]],
+  ["database-lock", ["database is locked", "database locked", "sqlite", "deadlock", "lock timeout", "busy timeout", "postgres", "mysql"]],
+  ["crawler-block", ["crawler", "scrape", "robots.txt", "cloudflare challenge", "captcha", "rate limit", "429", "blocked"]],
+  ["agent-tooling", ["agent", "claude", "cursor", "copilot", "codex", "aider", "prompt", "context window", "tool call"]],
+  ["ci-pipeline", ["ci", "github actions", "workflow", "runner", "pipeline", "build failed", "job failed"]],
+  ["encoding-locale", ["gbk", "utf-8", "unicodedecodeerror", "encoding", "locale", "mojibake", "codec"]],
+  ["container-deploy", ["docker", "container", "ghcr", "image", "kubernetes", "k8s", "crashloopbackoff", "compose"]],
+];
+const UNSOLVED_FALLBACK_FAMILY = "unclassified";
+const UNSOLVED_FAMILY_WHITELIST = [...UNSOLVED_FAMILIES.map(([family]) => family), UNSOLVED_FALLBACK_FAMILY];
+
+// Derives a family label from query text. The text is never returned or stored:
+// only the label leaves this function.
+function classifyTaskFamily(text) {
+  const haystack = String(text || "").toLowerCase();
+  if (!haystack.trim()) return UNSOLVED_FALLBACK_FAMILY;
+
+  let best = UNSOLVED_FALLBACK_FAMILY;
+  let bestScore = 0;
+  for (const [family, keywords] of UNSOLVED_FAMILIES) {
+    let score = 0;
+    for (const keyword of keywords) {
+      // Multi-word keywords are stronger evidence than single tokens.
+      if (haystack.includes(keyword)) score += keyword.includes(" ") ? 2 : 1;
+    }
+    if (score > bestScore) {
+      best = family;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+function normalizeUnsolvedReason(reason) {
+  return UNSOLVED_REASONS.includes(reason) ? reason : "no_match";
+}
+
+function unsolvedDay(date = new Date()) {
+  return date.toISOString().slice(0, 10);
+}
+
+function pruneUnsolvedDays(days, windowDays = UNSOLVED_WINDOW_DAYS) {
+  const cutoff = Date.now() - windowDays * 86_400_000;
+  for (const day of Object.keys(days)) {
+    if (new Date(`${day}T00:00:00Z`).getTime() < cutoff) delete days[day];
+  }
+  return days;
+}
+
+// Writes one aggregate signal. Callers must pass a derived family and an enum
+// reason — never raw text.
+async function recordUnsolvedSearch(env, { taskFamily, reason, day } = {}) {
+  if (!env.MISAKANET_KV) return null;
+  const family = UNSOLVED_FAMILY_WHITELIST.includes(taskFamily) ? taskFamily : UNSOLVED_FALLBACK_FAMILY;
+  const normalizedReason = normalizeUnsolvedReason(reason);
+  const bucketDay = day || unsolvedDay();
+  const kvKey = `${UNSOLVED_KV_PREFIX}${family}`;
+
+  const stored = await env.MISAKANET_KV.get(kvKey, "json");
+  const record = stored && typeof stored === "object" && stored.days ? stored : { days: {} };
+  pruneUnsolvedDays(record.days);
+
+  const dayBucket = record.days[bucketDay] || (record.days[bucketDay] = { reasons: {} });
+  dayBucket.reasons[normalizedReason] = (dayBucket.reasons[normalizedReason] || 0) + 1;
+
+  await env.MISAKANET_KV.put(kvKey, JSON.stringify(record), { expirationTtl: (UNSOLVED_WINDOW_DAYS + 7) * 86_400 });
+  return { taskFamily: family, reason: normalizedReason, day: bucketDay };
+}
+
+// Tracks lessons that keep drawing not-helpful feedback. Lesson IDs are public
+// repository identifiers, not user data.
+async function recordStaleLesson(env, lessonId, day) {
+  if (!env.MISAKANET_KV || !lessonId) return;
+  const kvKey = `${UNSOLVED_STALE_PREFIX}${lessonId}`;
+  const stored = await env.MISAKANET_KV.get(kvKey, "json");
+  const record = stored && typeof stored === "object" && stored.days ? stored : { days: {} };
+  pruneUnsolvedDays(record.days);
+  const bucketDay = day || unsolvedDay();
+  record.days[bucketDay] = (record.days[bucketDay] || 0) + 1;
+  await env.MISAKANET_KV.put(kvKey, JSON.stringify(record), { expirationTtl: (UNSOLVED_WINDOW_DAYS + 7) * 86_400 });
+}
+
+function sumUnsolvedDays(days, windowDays) {
+  const cutoff = Date.now() - windowDays * 86_400_000;
+  let total = 0;
+  const reasons = {};
+  let lastSeen = null;
+
+  for (const [day, bucket] of Object.entries(days || {})) {
+    const dayTime = new Date(`${day}T00:00:00Z`).getTime();
+    const entries = typeof bucket === "number" ? { total: bucket } : (bucket.reasons || {});
+    const dayCount = Object.values(entries).reduce((sum, n) => sum + (n || 0), 0);
+    if (dayCount > 0 && (!lastSeen || day > lastSeen)) lastSeen = day;
+    if (dayTime < cutoff) continue;
+    total += dayCount;
+    for (const [reason, count] of Object.entries(entries)) {
+      reasons[reason] = (reasons[reason] || 0) + count;
+    }
+  }
+  return { total, reasons, lastSeen };
+}
+
+async function buildUnsolvedMap(env) {
+  const families = [];
+  for (const family of UNSOLVED_FAMILY_WHITELIST) {
+    const record = await env.MISAKANET_KV.get(`${UNSOLVED_KV_PREFIX}${family}`, "json");
+    if (!record || !record.days) continue;
+    const { total: unsolved30d, reasons, lastSeen } = sumUnsolvedDays(record.days, UNSOLVED_WINDOW_DAYS);
+    if (unsolved30d <= 0) continue;
+    const { total: unsolved7d } = sumUnsolvedDays(record.days, 7);
+    families.push({ taskFamily: family, unsolved7d, unsolved30d, reasons, lastSeen });
+  }
+  families.sort((a, b) => b.unsolved30d - a.unsolved30d || a.taskFamily.localeCompare(b.taskFamily));
+
+  const staleLessons = [];
+  let cursor;
+  do {
+    const listed = await env.MISAKANET_KV.list({ prefix: UNSOLVED_STALE_PREFIX, cursor });
+    for (const key of listed.keys || []) {
+      const record = await env.MISAKANET_KV.get(key.name, "json");
+      if (!record || !record.days) continue;
+      const { total: notHelpful30d, lastSeen } = sumUnsolvedDays(record.days, UNSOLVED_WINDOW_DAYS);
+      if (notHelpful30d <= 0) continue;
+      staleLessons.push({ lessonId: key.name.slice(UNSOLVED_STALE_PREFIX.length), notHelpful30d, lastSeen });
+    }
+    cursor = listed.list_complete ? null : listed.cursor;
+  } while (cursor);
+  staleLessons.sort((a, b) => b.notHelpful30d - a.notHelpful30d || a.lessonId.localeCompare(b.lessonId));
+
+  return { families, staleLessons: staleLessons.slice(0, UNSOLVED_MAX_STALE_LESSONS) };
+}
+
+// GET /api/insights/unsolved-map — public, aggregate-only.
+async function handleUnsolvedMap(env) {
+  const available = !!env.MISAKANET_KV;
+  const data = available ? await buildUnsolvedMap(env) : { families: [], staleLessons: [] };
+  return jsonResponse({
+    success: true,
+    available,
+    windowDays: UNSOLVED_WINDOW_DAYS,
+    taskFamilies: UNSOLVED_FAMILY_WHITELIST,
+    reasons: UNSOLVED_REASONS,
+    families: data.families,
+    staleLessons: data.staleLessons,
+    meta: { privacy: "aggregate-only", raw_query: false, prompts: false, logs: false, paths: false, pii: false },
+  });
+}
+
+// POST /api/search-signal — records that a search went unsolved. The query is
+// classified here and dropped; only the derived family + reason are persisted.
+async function handleSearchSignal(request, env) {
+  if (!env.MISAKANET_KV) return jsonResponse({ error: "KV not configured" }, 503);
+
+  if (parseInt(request.headers.get("content-length") || "0", 10) > 4096) {
+    return jsonResponse({ error: "Request too large" }, 413);
+  }
+
+  // IP rate limit: 30 signals per IP per minute.
+  const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+  const rateKey = `rate:signal:${ip}`;
+  const rateCount = parseInt((await env.MISAKANET_KV.get(rateKey, "text")) || "0", 10) || 0;
+  if (rateCount >= 30) return jsonResponse({ error: "Rate limited. Try again later." }, 429);
+  await env.MISAKANET_KV.put(rateKey, String(rateCount + 1), { expirationTtl: 60 });
+
+  let body;
+  try { body = await request.json(); } catch { return jsonResponse({ error: "Invalid JSON" }, 400); }
+
+  const { query, result_count: resultCount, top_score: topScore, reason, lesson_id: lessonId } = body || {};
+  if (typeof query !== "string" || !query.trim()) return jsonResponse({ error: "Missing 'query'" }, 400);
+
+  // Solved searches are not recorded at all — the map only tracks gaps.
+  const count = Number.isFinite(Number(resultCount)) ? Number(resultCount) : 0;
+  const score = Number.isFinite(Number(topScore)) ? Number(topScore) : 0;
+  let derivedReason = reason;
+  if (!UNSOLVED_REASONS.includes(derivedReason)) {
+    if (count <= 0) derivedReason = "no_match";
+    else if (score < UNSOLVED_LOW_SCORE) derivedReason = "low_confidence";
+    else return jsonResponse({ recorded: false, reason: "search_was_solved" });
+  }
+
+  const recorded = await recordUnsolvedSearch(env, {
+    taskFamily: classifyTaskFamily(query),
+    reason: derivedReason,
+  });
+  if (derivedReason === "not_helpful" && lessonId) {
+    await recordStaleLesson(env, sanitizeIdentifier(lessonId, 200));
+  }
+
+  // Log the derived label only — never the query itself.
+  console.log(`[unsolved] ${recorded.taskFamily} ${recorded.reason}`);
+  return jsonResponse({ recorded: true, taskFamily: recorded.taskFamily, reason: recorded.reason });
+}
+
 async function probeKeepaliveEndpoint(endpoint) {
   const resp = await fetch(endpoint.url, {
     headers: { "User-Agent": "MisakaNet-Register-Proxy-Keepalive/1.0" },
@@ -238,9 +456,22 @@ export default {
         );
         accepted.push(feedbackId);
         console.log(`Feedback ${feedbackId}: ${feedback} on ${lesson_id} for "${query}"`);
+
+        // Unsolved failure map (#788): a not-helpful verdict means the lesson
+        // did not close the gap. Aggregate-only — the query is classified and
+        // dropped, and only the public lesson ID is counted.
+        if (feedback === "irrelevant" || feedback === "too_basic") {
+          await recordUnsolvedSearch(env, { taskFamily: classifyTaskFamily(query), reason: "not_helpful" });
+          await recordStaleLesson(env, sanitizeIdentifier(record.lesson_id, 200));
+        }
       }
 
       return jsonResponse({ accepted: accepted.length });
+    }
+
+    // POST /api/search-signal — unsolved-search intake for the failure map (#788)
+    if (request.method === "POST" && url.pathname === "/api/search-signal") {
+      return handleSearchSignal(request, env);
     }
 
     // POST /api/intake — general-purpose intake for MCP, agents, sandbox (#589)
@@ -323,6 +554,11 @@ export default {
 
       console.log(`Intake ${intakeId}: type=${type} source=${source} family=${family}`);
       return jsonResponse({ accepted: true, intake_id: intakeId, consent: record.consent });
+    }
+
+    // GET /api/insights/unsolved-map — public aggregate failure map (#788)
+    if (request.method === "GET" && url.pathname === "/api/insights/unsolved-map") {
+      return handleUnsolvedMap(env);
     }
 
     // GET /api/insights/demand-board — public aggregate view of intake clusters
@@ -528,4 +764,18 @@ export default {
   async scheduled(controller, env, ctx) {
     ctx.waitUntil(runKeepaliveSweep(controller.cron));
   },
+};
+
+// Named exports for unit tests only (workers/unsolved-map.test.mjs). Wrangler
+// deploys this file for its default export; the extra exports are inert there.
+export {
+  UNSOLVED_FAMILY_WHITELIST,
+  UNSOLVED_REASONS,
+  UNSOLVED_WINDOW_DAYS,
+  buildUnsolvedMap,
+  classifyTaskFamily,
+  handleSearchSignal,
+  handleUnsolvedMap,
+  recordStaleLesson,
+  recordUnsolvedSearch,
 };

--- a/workers/unsolved-map.test.mjs
+++ b/workers/unsolved-map.test.mjs
@@ -1,0 +1,260 @@
+// Unit tests for the privacy-preserving unsolved failure map (Issue #788).
+// Run: node --test workers/unsolved-map.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import worker, {
+  UNSOLVED_FAMILY_WHITELIST,
+  UNSOLVED_REASONS,
+  buildUnsolvedMap,
+  classifyTaskFamily,
+  handleSearchSignal,
+  handleUnsolvedMap,
+  recordStaleLesson,
+  recordUnsolvedSearch,
+} from './register-proxy-sw.js';
+
+function createFakeKV(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    async get(key, type) {
+      if (!store.has(key)) return null;
+      const raw = store.get(key);
+      return type === 'json' ? JSON.parse(raw) : raw;
+    },
+    async put(key, value) { store.set(key, value); },
+    async delete(key) { store.delete(key); },
+    async list({ prefix = '', cursor } = {}) {
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name }));
+      return { keys, list_complete: true, cursor: cursor ?? null };
+    },
+    _store: store,
+  };
+}
+
+const envWithKV = (seed) => ({ MISAKANET_KV: createFakeKV(seed) });
+
+function signalRequest(body, headers = {}) {
+  return new Request('https://misakanet.org/api/search-signal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const daysAgo = (n) => new Date(Date.now() - n * 86_400_000).toISOString().slice(0, 10);
+
+// ── Classification ─────────────────────────────────────────────────────────
+
+test('queries are clustered into whitelisted task families', () => {
+  assert.equal(classifyTaskFamily('sqlite database is locked on concurrent write'), 'database-lock');
+  assert.equal(classifyTaskFamily('pip install ModuleNotFoundError'), 'python-env');
+  assert.equal(classifyTaskFamily('npm publish EOTP one time password'), 'npm-publish');
+  assert.equal(classifyTaskFamily('wrangler deploy failed on cloudflare'), 'cloudflare-worker');
+  assert.equal(classifyTaskFamily('DCO sign-off missing'), 'github-auth');
+  assert.equal(classifyTaskFamily('mcp server tools/list empty'), 'mcp-registry');
+  assert.equal(classifyTaskFamily('UnicodeDecodeError gbk codec'), 'encoding-locale');
+  assert.equal(classifyTaskFamily('kubernetes crashloopbackoff'), 'container-deploy');
+});
+
+test('unrecognised and empty queries fall back to unclassified', () => {
+  assert.equal(classifyTaskFamily('why is the sky blue'), 'unclassified');
+  assert.equal(classifyTaskFamily(''), 'unclassified');
+  assert.equal(classifyTaskFamily(undefined), 'unclassified');
+});
+
+test('every derived family is on the published whitelist', () => {
+  const queries = ['database locked', 'pip timeout', 'docker image', 'random words here'];
+  for (const q of queries) assert.ok(UNSOLVED_FAMILY_WHITELIST.includes(classifyTaskFamily(q)));
+});
+
+// ── Aggregation ────────────────────────────────────────────────────────────
+
+test('signals bucket by family, day and reason', async () => {
+  const env = envWithKV();
+  await recordUnsolvedSearch(env, { taskFamily: 'database-lock', reason: 'no_match' });
+  await recordUnsolvedSearch(env, { taskFamily: 'database-lock', reason: 'no_match' });
+  await recordUnsolvedSearch(env, { taskFamily: 'database-lock', reason: 'low_confidence' });
+  await recordUnsolvedSearch(env, { taskFamily: 'python-env', reason: 'no_match' });
+
+  const { families } = await buildUnsolvedMap(env);
+  assert.deepEqual(families.map((f) => f.taskFamily), ['database-lock', 'python-env']);
+  assert.equal(families[0].unsolved30d, 3);
+  assert.deepEqual(families[0].reasons, { no_match: 2, low_confidence: 1 });
+});
+
+test('unknown families and reasons are normalised, never stored raw', async () => {
+  const env = envWithKV();
+  const recorded = await recordUnsolvedSearch(env, { taskFamily: 'made-up-family', reason: 'user typed this' });
+  assert.equal(recorded.taskFamily, 'unclassified');
+  assert.equal(recorded.reason, 'no_match');
+  assert.ok(!JSON.stringify([...env.MISAKANET_KV._store.values()]).includes('user typed this'));
+});
+
+test('buckets older than the 30-day window are pruned and excluded', async () => {
+  const env = envWithKV({
+    'unsolved:family:python-env': JSON.stringify({
+      days: { '2000-01-01': { reasons: { no_match: 99 } }, [daysAgo(2)]: { reasons: { no_match: 2 } } },
+    }),
+  });
+  await recordUnsolvedSearch(env, { taskFamily: 'python-env', reason: 'no_match' });
+
+  const { families } = await buildUnsolvedMap(env);
+  assert.equal(families[0].unsolved30d, 3, 'ancient bucket must not count');
+  assert.ok(!env.MISAKANET_KV._store.get('unsolved:family:python-env').includes('2000-01-01'));
+});
+
+test('7-day and 30-day windows are counted separately', async () => {
+  const env = envWithKV({
+    'unsolved:family:github-auth': JSON.stringify({
+      days: { [daysAgo(20)]: { reasons: { no_match: 5 } }, [daysAgo(1)]: { reasons: { no_match: 2 } } },
+    }),
+  });
+  const { families } = await buildUnsolvedMap(env);
+  assert.equal(families[0].unsolved30d, 7);
+  assert.equal(families[0].unsolved7d, 2);
+  assert.equal(families[0].lastSeen, daysAgo(1));
+});
+
+test('stale lessons are ranked by not-helpful reports', async () => {
+  const env = envWithKV();
+  await recordStaleLesson(env, 'outdated-lesson');
+  await recordStaleLesson(env, 'outdated-lesson');
+  await recordStaleLesson(env, 'slightly-stale-lesson');
+
+  const { staleLessons } = await buildUnsolvedMap(env);
+  assert.deepEqual(staleLessons.map((l) => l.lessonId), ['outdated-lesson', 'slightly-stale-lesson']);
+  assert.equal(staleLessons[0].notHelpful30d, 2);
+});
+
+// ── POST /api/search-signal ────────────────────────────────────────────────
+
+test('zero-result searches are recorded as no_match', async () => {
+  const env = envWithKV();
+  const resp = await handleSearchSignal(signalRequest({ query: 'database is locked', result_count: 0 }), env);
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.deepEqual(body, { recorded: true, taskFamily: 'database-lock', reason: 'no_match' });
+});
+
+test('low-confidence results are recorded as low_confidence', async () => {
+  const env = envWithKV();
+  const body = await (await handleSearchSignal(
+    signalRequest({ query: 'pip install timeout', result_count: 3, top_score: 0.2 }), env)).json();
+  assert.equal(body.reason, 'low_confidence');
+});
+
+test('solved searches are not recorded at all', async () => {
+  const env = envWithKV();
+  const body = await (await handleSearchSignal(
+    signalRequest({ query: 'pip install timeout', result_count: 3, top_score: 0.9 }), env)).json();
+  assert.deepEqual(body, { recorded: false, reason: 'search_was_solved' });
+  assert.equal(env.MISAKANET_KV._store.size, 1, 'only the rate-limit key exists');
+});
+
+test('the raw query never reaches KV', async () => {
+  const env = envWithKV();
+  const secretish = 'ghp_pretend_token_in_a_query database locked /home/me/app.log';
+  await handleSearchSignal(signalRequest({ query: secretish, result_count: 0 }), env);
+
+  const dump = JSON.stringify([...env.MISAKANET_KV._store.entries()]);
+  assert.ok(!dump.includes('ghp_pretend_token_in_a_query'));
+  assert.ok(!dump.includes('/home/me/app.log'));
+  assert.ok(dump.includes('unsolved:family:database-lock'));
+});
+
+test('missing query and malformed JSON are rejected', async () => {
+  const env = envWithKV();
+  assert.equal((await handleSearchSignal(signalRequest({ result_count: 0 }), env)).status, 400);
+
+  const bad = new Request('https://misakanet.org/api/search-signal', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{oops',
+  });
+  assert.equal((await handleSearchSignal(bad, env)).status, 400);
+});
+
+test('signals are rate limited per IP and oversize bodies rejected', async () => {
+  const env = envWithKV();
+  const headers = { 'CF-Connecting-IP': '203.0.113.9' };
+  for (let i = 0; i < 30; i++) {
+    await handleSearchSignal(signalRequest({ query: `database locked ${i}`, result_count: 0 }, headers), env);
+  }
+  const limited = await handleSearchSignal(signalRequest({ query: 'database locked', result_count: 0 }, headers), env);
+  assert.equal(limited.status, 429);
+
+  const big = await handleSearchSignal(
+    signalRequest({ query: 'x', result_count: 0 }, { 'content-length': '99999' }), env);
+  assert.equal(big.status, 413);
+});
+
+test('without KV the endpoint degrades to 503 instead of crashing', async () => {
+  assert.equal((await handleSearchSignal(signalRequest({ query: 'x', result_count: 0 }), {})).status, 503);
+});
+
+// ── GET /api/insights/unsolved-map ─────────────────────────────────────────
+
+test('the map response is aggregate-only and declares it', async () => {
+  const env = envWithKV();
+  await recordUnsolvedSearch(env, { taskFamily: 'database-lock', reason: 'no_match' });
+  await recordStaleLesson(env, 'stale-lesson');
+
+  const body = await (await handleUnsolvedMap(env)).json();
+  assert.equal(body.success, true);
+  assert.equal(body.available, true);
+  assert.equal(body.windowDays, 30);
+  assert.deepEqual(body.reasons, UNSOLVED_REASONS);
+  assert.equal(body.families[0].taskFamily, 'database-lock');
+  assert.equal(body.staleLessons[0].lessonId, 'stale-lesson');
+  assert.deepEqual(body.meta, {
+    privacy: 'aggregate-only', raw_query: false, prompts: false, logs: false, paths: false, pii: false,
+  });
+
+  const emitted = Object.keys(body.families[0]).concat(Object.keys(body.staleLessons[0]));
+  for (const field of ['query', 'text', 'ip', 'path', 'prompt', 'user']) {
+    assert.ok(!emitted.includes(field), `${field} must never be emitted`);
+  }
+});
+
+test('without KV the map reports unavailable rather than failing', async () => {
+  const body = await (await handleUnsolvedMap({})).json();
+  assert.deepEqual(body.families, []);
+  assert.equal(body.available, false);
+  assert.equal(body.success, true);
+});
+
+// ── Routing + feedback integration ─────────────────────────────────────────
+
+test('worker routes the map and the signal endpoint', async () => {
+  const env = envWithKV();
+  const posted = await worker.fetch(signalRequest({ query: 'sqlite database is locked', result_count: 0 }), env);
+  assert.equal(posted.status, 200);
+
+  const map = await worker.fetch(new Request('https://misakanet.org/api/insights/unsolved-map'), env);
+  assert.equal(map.status, 200);
+  assert.equal((await map.json()).families[0].taskFamily, 'database-lock');
+});
+
+test('not-helpful feedback feeds the map and the stale-lesson list', async () => {
+  const env = envWithKV();
+  const feedback = new Request('https://misakanet.org/api/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: 'npm publish 403', lesson_id: 'npm-publish-otp', feedback: 'irrelevant' }),
+  });
+  assert.equal((await worker.fetch(feedback, env)).status, 200);
+
+  const body = await (await handleUnsolvedMap(env)).json();
+  assert.equal(body.families[0].taskFamily, 'npm-publish');
+  assert.deepEqual(body.families[0].reasons, { not_helpful: 1 });
+  assert.equal(body.staleLessons[0].lessonId, 'npm-publish-otp');
+});
+
+test('helpful feedback does not pollute the unsolved map', async () => {
+  const env = envWithKV();
+  const feedback = new Request('https://misakanet.org/api/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: 'npm publish 403', lesson_id: 'npm-publish-otp', feedback: 'helpful' }),
+  });
+  await worker.fetch(feedback, env);
+  assert.deepEqual((await (await handleUnsolvedMap(env)).json()).families, []);
+});


### PR DESCRIPTION
## Summary

Closes #788 — an unsolved failure map showing which failure families MisakaNet has no effective lesson for, built so that raw queries physically cannot reach storage.

/claim #788

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🧪 Test improvement

## What changed

| File | Change |
|------|--------|
| `workers/register-proxy-sw.js` | Classifier, aggregation, `GET /api/insights/unsolved-map`, `POST /api/search-signal`, feedback hook |
| `docs/insights/unsolved-map.html` | Public page rendering top unsolved families + stale lessons |
| `docs/search/index.html` | Reports *only* unsolved searches (fire-and-forget, deduped per session) |
| `workers/unsolved-map.test.mjs` | 20 `node --test` cases |
| `tests/test_unsolved_map.py` | Privacy contract + runs the node suite in CI |
| `workers/README.md` | Endpoint + privacy documentation |

## How the privacy rule is enforced

The rule is "no raw query storage", so the query never becomes storable:

1. The search page posts `{query, result_count, top_score}` **only when a search was unsolved** — zero results, or a top score below the 0.35 low-confidence band. Solved searches send nothing.
2. The Worker calls `classifyTaskFamily(query)` in memory, which returns a label from a fixed keyword-cluster table, and the query string is then dropped. Labels are *derived*, never taken from a request field — there is no `task_family` input to spoof.
3. Only `{family, reason, day}` counters are written to KV. Reasons are a fixed enum (`no_match`, `low_confidence`, `not_helpful`, `outdated_lesson`, `missing_runtime_path`); anything else normalises to `no_match`, and unknown families to `unclassified`.
4. The log line prints the derived label only — never the query.

A test asserts this end-to-end: it posts `"ghp_pretend_token_in_a_query database locked /home/me/app.log"` and asserts the whole KV dump contains neither the token-shaped string nor the path, while the `database-lock` counter did increment. Another test checks the response object emits no `query`/`text`/`ip`/`path`/`prompt`/`user` field.

## Acceptance criteria

- [x] Aggregate search queries into task families (no raw query storage)
- [x] Track unsolved searches: queries with 0 results or low-confidence results
- [x] Track stale lessons: lessons that got `not-helpful` usage reports — `/api/feedback` `irrelevant`/`too_basic` now feeds an aggregate `not_helpful` signal plus a per-lesson counter
- [x] Output as JSON: `/api/insights/unsolved-map`
- [x] Optional: public docs page showing top unsolved families — `docs/insights/unsolved-map.html`
- [x] Privacy: no raw queries, no prompts, no logs, no paths, no secrets in output

## Response shape

```json
{
  "success": true, "available": true, "windowDays": 30,
  "families": [
    { "taskFamily": "database-lock", "unsolved7d": 2, "unsolved30d": 7,
      "reasons": { "no_match": 5, "low_confidence": 2 }, "lastSeen": "2026-08-05" }
  ],
  "staleLessons": [ { "lessonId": "npm-publish-otp", "notHelpful30d": 3, "lastSeen": "2026-08-04" } ],
  "meta": { "privacy": "aggregate-only", "raw_query": false, "prompts": false,
            "logs": false, "paths": false, "pii": false }
}
```

Lesson IDs are public repository identifiers, not user-derived text — that is the one identifier in the output, and it is required by the stale-lesson AC.

## Notes

- **Separate from #591's demand board.** New KV prefixes (`unsolved:family:`, `unsolved:lesson:`); `demand:family:` is untouched, so the existing board keeps working unchanged.
- **Degrades quietly** — without KV the endpoint returns `available: false` with empty arrays instead of erroring, and the signal endpoint returns 503. The search page ignores failures.
- **Bounded writes** — 30-day rolling window pruned on every write, KV TTL of 37 days, 30 signals/IP/minute, 4KB body cap, and the stale list is capped at 20 entries.
- Ordering note: this touches the same Worker file as #804/PR #807. They edit different regions, but whichever merges second may need a trivial rebase — happy to do it.

## Testing

```
node --test workers/unsolved-map.test.mjs     # 20 passed
node --test workers/register-proxy.test.mjs   #  8 passed (existing suite, unaffected)
python3 -m unittest tests.test_unsolved_map   # 12 passed
python3 scripts/check_worker_secrets.py       # 0 errors
```

## Checklist

- [x] My commit has `Signed-off-by:` (DCO required)
- [x] I have tested that the changes work correctly
- [x] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds)
