### PR TITLE
feat(trust): add evidence levels E0-E4 for lessons (#786)

### DIFF
--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -47,6 +47,7 @@
   .badge-high { background: rgba(35,134,54,0.15); color: #3fb950; }
   .badge-medium { background: rgba(251,146,60,0.12); color: #fb923c; }
   .badge-low { background: rgba(139,148,158,0.12); color: #8b949e; }
+  .badge-evidence { background: rgba(163,113,247,0.14); color: #a371f7; cursor: help; }
   .section-label { font-size: 12px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin: 20px 0 8px; }
   .fold-toggle { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; font-size: 13px; color: var(--text-muted); background: transparent; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; padding: 6px 12px; margin: 8px 0; transition: color 0.15s, border-color 0.15s; }
   .fold-toggle:hover { color: #58a6ff; border-color: rgba(88,166,255,0.3); }
@@ -315,6 +316,22 @@ function inferBadge(r) {
   return { key: 'badgeVerified', cls: 'badge-status' };
 }
 
+// ── Evidence levels (#786) — see docs/trust-semantics.md ──
+const EVIDENCE_LABELS = {
+  E0: 'E0 — contributor self-reported',
+  E1: 'E1 — maintainer reviewed',
+  E2: 'E2 — local smoke reproduced',
+  E3: 'E3 — CI / sandbox verified recovery',
+  E4: 'E4 — reused by another contributor or agent',
+};
+
+// Missing or unknown values read as E0: evidence is never assumed.
+function evidenceInfo(level) {
+  const key = String(level || '').trim().toUpperCase();
+  const normalized = EVIDENCE_LABELS[key] ? key : 'E0';
+  return { level: normalized, label: EVIDENCE_LABELS[normalized] };
+}
+
 // ── Client-side confidence / result_type classification ──
 const ACTIONABLE_RE = /fix|solution|workaround|step\s*\d|verify|verification|error.code|exit.code|```|pip install|git |curl |chmod|mkdir|export /i;
 const COMMON_RE = /github.com.*443|connectivity|checklist|basic|intro|overview|getting.started|quick.start|faq|troubleshooting.general|network.*basics|git.*basics|config.*general/i;
@@ -478,12 +495,14 @@ function render(results, q) {
     const id = escapeHTML(r.id || '');
     const badge = inferBadge(r);
     const confBadge = r._confidence === 'high' ? 'badge-high' : r._confidence === 'low' ? 'badge-low' : 'badge-medium';
+    const ev = evidenceInfo(r.evidence_level);
     const showTitle = takeaway !== title;
     return '<div class="result" tabindex="0" data-index="' + r._index + '" data-id="' + id + '">' +
       '<div class="result-meta">' +
         '<span class="badge ' + badge.cls + '">' + t(badge.key) + '</span>' +
         '<span class="badge badge-domain">' + domain + '</span>' +
         '<span class="badge ' + confBadge + '">' + r._confidence + '</span>' +
+        '<span class="badge badge-evidence" title="' + escapeHTML(ev.label) + '">' + ev.level + '</span>' +
       '</div>' +
       '<div class="result-title">' + takeaway + '</div>' +
       (showTitle ? '<div class="result-id">' + id + '</div>' : '') +

--- a/docs/trust-semantics.md
+++ b/docs/trust-semantics.md
@@ -26,3 +26,53 @@ MisakaNet uses three trust levels for lessons. These terms are used consistently
 ## Why this matters
 
 Claiming "verified" when lessons are only "indexed" erodes trust when a lesson turns out to be wrong. Use "indexed" for scale claims, "verified" only for fact-checked content.
+
+---
+
+## Evidence levels E0–E4 (Issue #786)
+
+`status` answers *"is this published?"*. `evidence_level` answers the harder question: **how reliable is this lesson?** Without it, a contributor's self-reported guess and a CI-verified fix are indistinguishable in search results.
+
+| Level | Meaning | How it is achieved | Weight |
+|-------|---------|--------------------|--------|
+| **E0** | Contributor self-reported | Default on intake | 0.00 |
+| **E1** | Maintainer reviewed | A maintainer accepted the intake | 0.25 |
+| **E2** | Local smoke reproduced | Maintainer or CI reproduced the fix | 0.50 |
+| **E3** | Sandbox / CI verified recovery | Automated verification in CI | 0.75 |
+| **E4** | Reused by another contributor / agent | Usage report from a different user | 1.00 |
+
+### Rules
+
+- **Default is E0.** A missing, empty, malformed, or unknown `evidence_level` reads as E0 everywhere — evidence is never assumed. `scripts/queue_lesson.py` writes `"evidence_level": "E0"` on new lessons.
+- **One step at a time.** Promotion is E0 → E1 → E2 → E3 → E4; skipping levels means the intermediate evidence was never produced.
+- **Evidence is not writing quality.** A beautifully written but unreproduced lesson is still E0.
+
+### Promotion rules
+
+| From | To | What has to happen |
+|------|----|--------------------|
+| E0 | E1 | A maintainer reviews the lesson and accepts it (**review**) |
+| E1 | E2 | Someone reproduces the failure and the fix locally (**reproduce**) |
+| E2 | E3 | CI or a sandbox run verifies the recovery automatically (**CI verify**) |
+| E3 | E4 | A different contributor or agent reports reusing it successfully (**external reuse**) |
+
+To promote a lesson, edit `evidence_level` in its frontmatter in the same PR that carries the evidence (review comment, reproduction log, CI run link, or the usage report).
+
+### How evidence affects scoring
+
+`scripts/score_lessons.py` keeps the existing quality `score` unchanged — the CI gate (`--threshold`) still measures writing quality — and adds a **trust score** on top:
+
+```
+trust_score = quality_score × (0.7 + 0.3 × evidence_weight)
+```
+
+So an E0 lesson keeps 70% of its quality score and an E4 lesson keeps all of it. The scorer also prints the corpus distribution (`E0=344 E1=0 …`), which is the honest current picture: everything starts self-reported until maintainers begin promoting.
+
+### Where it shows up
+
+- **Search results** — a purple `E0`–`E4` badge on every card, with the meaning on hover (`docs/search/index.html`).
+- **Lesson pages** — `Evidence E2 — Local smoke reproduced` in the page metadata (`scripts/build_lesson_pages.py`).
+- **Index data** — `evidence_level` is emitted per lesson by `scripts/misakanet-index.py` into `lessons.json`.
+- **Schema** — `schemas/lesson.json` constrains the field to the E0–E4 enum.
+
+The canonical implementation is `misakanet/evidence.py`; use `normalize_evidence_level()` rather than reading the raw field, so unknown values keep degrading to E0.

--- a/misakanet/evidence.py
+++ b/misakanet/evidence.py
@@ -1,0 +1,123 @@
+"""Evidence levels for failure-recovery lessons — Issue #786.
+
+Lesson trust is graded E0–E4 instead of binary indexed/not-indexed, so a
+self-reported guess and a CI-verified fix stop looking identical.
+
+    E0  contributor self-reported          (default on intake)
+    E1  maintainer reviewed
+    E2  local smoke reproduced
+    E3  sandbox / CI verified recovery
+    E4  reused successfully by another contributor or agent
+
+Anything unknown, missing, or malformed normalises to E0 — the claim is never
+upgraded by accident.
+"""
+from __future__ import annotations
+
+DEFAULT_EVIDENCE_LEVEL = "E0"
+
+# level -> (label, how it is achieved, weight in [0, 1])
+EVIDENCE_SEMANTICS: dict[str, tuple[str, str, float]] = {
+    "E0": ("Contributor self-reported", "Default on intake", 0.0),
+    "E1": ("Maintainer reviewed", "A maintainer accepted the intake", 0.25),
+    "E2": ("Local smoke reproduced", "Maintainer or CI reproduced the fix", 0.5),
+    "E3": ("Sandbox / CI verified recovery", "Automated verification in CI", 0.75),
+    "E4": ("Reused by another contributor / agent", "Usage report from a different user", 1.0),
+}
+
+EVIDENCE_LEVELS = list(EVIDENCE_SEMANTICS)
+
+# (from, to, what has to happen)
+PROMOTION_RULES = [
+    ("E0", "E1", "A maintainer reviews the lesson and accepts it (review)"),
+    ("E1", "E2", "Someone reproduces the failure and the fix locally (reproduce)"),
+    ("E2", "E3", "CI or a sandbox run verifies the recovery automatically (CI verify)"),
+    ("E3", "E4", "A different contributor or agent reports reusing it successfully (external reuse)"),
+]
+
+# Quality score keeps its own 0–1 range; evidence rescales it into a trust
+# score. An E0 lesson keeps 70% of its quality score, E4 keeps all of it —
+# evidence adjusts confidence in a lesson, it does not replace writing quality.
+TRUST_FLOOR = 0.7
+
+
+def normalize_evidence_level(value) -> str:
+    """Coerce any frontmatter value to a valid level, defaulting to E0."""
+    if value is None:
+        return DEFAULT_EVIDENCE_LEVEL
+    if isinstance(value, bool):  # bools are ints in Python — reject explicitly
+        return DEFAULT_EVIDENCE_LEVEL
+    if isinstance(value, (int, float)):
+        candidate = f"E{int(value)}"
+    else:
+        candidate = str(value).strip().upper()
+    return candidate if candidate in EVIDENCE_SEMANTICS else DEFAULT_EVIDENCE_LEVEL
+
+
+def evidence_weight(level) -> float:
+    """Weight in [0, 1] for the given level."""
+    return EVIDENCE_SEMANTICS[normalize_evidence_level(level)][2]
+
+
+def evidence_label(level) -> str:
+    return EVIDENCE_SEMANTICS[normalize_evidence_level(level)][0]
+
+
+def evidence_of(frontmatter: dict | None) -> str:
+    """Read the level out of lesson frontmatter (or an index entry)."""
+    if not isinstance(frontmatter, dict):
+        return DEFAULT_EVIDENCE_LEVEL
+    return normalize_evidence_level(frontmatter.get("evidence_level"))
+
+
+def next_level(level) -> str | None:
+    """The level directly above this one, or None at E4."""
+    current = normalize_evidence_level(level)
+    index = EVIDENCE_LEVELS.index(current)
+    return EVIDENCE_LEVELS[index + 1] if index + 1 < len(EVIDENCE_LEVELS) else None
+
+
+def promotion_requirement(level) -> str | None:
+    """What has to happen for this lesson to reach the next level."""
+    current = normalize_evidence_level(level)
+    for source, _target, requirement in PROMOTION_RULES:
+        if source == current:
+            return requirement
+    return None
+
+
+def trust_score(quality_score: float, level) -> float:
+    """Combine a 0–1 quality score with the evidence level.
+
+    Quality alone answers "is this lesson well written?"; trust answers "how
+    much should I rely on it?".
+    """
+    try:
+        quality = float(quality_score)
+    except (TypeError, ValueError):
+        quality = 0.0
+    quality = max(0.0, min(1.0, quality))
+    scale = TRUST_FLOOR + (1.0 - TRUST_FLOOR) * evidence_weight(level)
+    return round(quality * scale, 3)
+
+
+def describe(level) -> dict:
+    """Everything a UI needs to render one level."""
+    normalized = normalize_evidence_level(level)
+    label, how, weight = EVIDENCE_SEMANTICS[normalized]
+    return {
+        "evidence_level": normalized,
+        "label": label,
+        "how_to_achieve": how,
+        "weight": weight,
+        "next_level": next_level(normalized),
+        "promotion_requirement": promotion_requirement(normalized),
+    }
+
+
+def distribution(levels) -> dict[str, int]:
+    """Count lessons per level, always reporting every level."""
+    counts = {level: 0 for level in EVIDENCE_LEVELS}
+    for level in levels:
+        counts[normalize_evidence_level(level)] += 1
+    return counts

--- a/schemas/lesson.json
+++ b/schemas/lesson.json
@@ -36,6 +36,12 @@
       "enum": ["published", "draft", "archived"],
       "description": "Publication status"
     },
+    "evidence_level": {
+      "type": "string",
+      "enum": ["E0", "E1", "E2", "E3", "E4"],
+      "default": "E0",
+      "description": "How well this lesson is evidenced — E0 self-reported, E1 maintainer reviewed, E2 locally reproduced, E3 CI/sandbox verified, E4 reused by another contributor. Missing means E0. See docs/trust-semantics.md"
+    },
     "source": {
       "type": "string",
       "description": "Origin of this lesson"

--- a/scripts/build_lesson_pages.py
+++ b/scripts/build_lesson_pages.py
@@ -11,7 +11,11 @@ Output:
 
 import json
 import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from misakanet.evidence import describe  # noqa: E402
 
 LESSONS_JSON = Path("data/lessons.json")
 LESSONS_DIR = Path("docs/lessons")
@@ -52,6 +56,7 @@ HTML_TEMPLATE = """\
   a {{ color: #58a6ff; }}
   h1 {{ font-size: 24px; margin-bottom: 8px; }}
   .meta {{ color: #8b949e; font-size: 13px; margin-bottom: 24px; }}
+  .evidence {{ background: rgba(163,113,247,0.14); color: #a371f7; border-radius: 4px; padding: 2px 6px; font-size: 12px; cursor: help; }}
   .section {{ margin-bottom: 24px; }}
   .section h2 {{ font-size: 16px; color: #58a6ff; margin-bottom: 8px; }}
   .section p {{ color: #c9d1d9; font-size: 14px; }}
@@ -139,8 +144,15 @@ def build_lesson_page(lesson: dict) -> str:
 
     tags_html = "".join(f'<span class="tag">{t}</span>' for t in tags[:6])
 
+    # Evidence level (#786) — how well this lesson is backed, not how well written.
+    evidence = describe(lesson.get("evidence_level"))
+    evidence_html = (
+        f'<span class="evidence" title="{evidence["how_to_achieve"]}">'
+        f'Evidence {evidence["evidence_level"]} — {evidence["label"]}</span>'
+    )
+
     body = f"""<h1>{title}</h1>
-<div class="meta">Domain: <a href="/topics/{domain}/">{domain}</a></div>
+<div class="meta">Domain: <a href="/topics/{domain}/">{domain}</a> · {evidence_html}</div>
 <div class="tags">{tags_html}</div>
 <div class="section">
   <h2>Summary</h2>

--- a/scripts/misakanet-index.py
+++ b/scripts/misakanet-index.py
@@ -20,6 +20,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from misakanet.evidence import evidence_of  # noqa: E402
+
 
 def parse_frontmatter(text: str) -> dict | None:
     """解析 --- 包裹的 JSON frontmatter（支持空行）"""
@@ -95,6 +98,8 @@ def build_index(lessons_dir: str | Path) -> list[dict]:
                 "environment_version": fm.get("environment_version", "") if fm else "",
                 "confidence": fm.get("confidence", 0.5) if fm else 0.5,
                 "status": fm.get("status", "active") if fm else "active",
+                # Evidence level (#786) — missing frontmatter means E0.
+                "evidence_level": evidence_of(fm),
             }
             index.append(entry)
 

--- a/scripts/queue_lesson.py
+++ b/scripts/queue_lesson.py
@@ -38,6 +38,11 @@ if _SCRIPTS_DIR.exists() and str(_SCRIPTS_DIR) not in sys.path:
 REPO = "Ikalus1988/MisakaNet"
 NODE_ID = os.environ.get("MISAKANET_NODE_ID", "hermes_wsl2")
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+from misakanet.evidence import DEFAULT_EVIDENCE_LEVEL  # noqa: E402
+
 LESSONS_DIR = Path(os.environ.get("LESSONS_DIR", str(REPO_ROOT / "lessons")))
 
 
@@ -131,6 +136,8 @@ def _render_lesson(title, domain, tags, content, source=NODE_ID, status="publish
         "domain": domain,
         "source": source,
         "status": status,
+        # New lessons start self-reported (#786); promotion is a maintainer action.
+        "evidence_level": DEFAULT_EVIDENCE_LEVEL,
         "tags": tags,
         "created": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "updated": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
@@ -158,6 +165,8 @@ def write_lesson(title, domain, tags, content, source=NODE_ID, status="published
         "domain": domain,
         "source": source,
         "status": status,
+        # New lessons start self-reported (#786); promotion is a maintainer action.
+        "evidence_level": DEFAULT_EVIDENCE_LEVEL,
         "tags": tags,
         "created": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "updated": now.strftime("%Y-%m-%d %H:%M:%S UTC"),

--- a/scripts/score_lessons.py
+++ b/scripts/score_lessons.py
@@ -18,6 +18,9 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 LESSONS_DIR = REPO / "lessons"
 
+sys.path.insert(0, str(REPO))
+from misakanet.evidence import evidence_of, evidence_weight, trust_score  # noqa: E402
+
 # Thresholds
 RISK_LOW_CONFIDENCE = 0.65
 RISK_VERY_LOW_CONFIDENCE = 0.4
@@ -96,12 +99,21 @@ def score_lesson(filepath: Path) -> dict:
 
     score = WEIGHT_CLARITY * clarity + WEIGHT_VERIFY * verify + WEIGHT_COVERAGE * coverage
 
+    # --- evidence level (#786) ---
+    # Quality score keeps its own meaning (and its CI threshold); the evidence
+    # level rescales it into a trust score, so a self-reported lesson and a
+    # CI-verified one no longer look identical at the same writing quality.
+    level = evidence_of(fm)
+
     return {
         "file": str(filepath.relative_to(REPO)),
         "score": round(score, 3),
         "clarity": clarity,
         "verify": verify,
         "coverage": coverage,
+        "evidence_level": level,
+        "evidence_weight": evidence_weight(level),
+        "trust_score": trust_score(score, level),
         "has_root_section": has_root_section,
         "has_verify_section": has_verify_section,
     }
@@ -117,7 +129,8 @@ def main():
         files = [f for f in files if f.name not in ("index.md", "TEMPLATE.md", "README.md")
                  and "_archive" not in f.parts]
     elif args and args[0].endswith(".md"):
-        files = [Path(args[0])]
+        # Resolve so a relative path (the usage in the docstring) works too.
+        files = [Path(args[0]).resolve()]
         threshold = None
     else:
         files = sorted(LESSONS_DIR.rglob("*.md"))
@@ -142,16 +155,25 @@ def main():
     below = [r for r in results if r["score"] < (threshold or 0)]
     avg = sum(r["score"] for r in results) / len(results)
 
+    avg_trust = sum(r["trust_score"] for r in results) / len(results)
+
     print(f"Checked {len(results)} lessons. Average score: {avg:.3f}")
     print()
-    print(f"{'Score':<8} {'Clarity':<8} {'Verify':<8} {'Coverage':<10} File")
-    print("-" * 70)
+    print(f"{'Score':<8} {'Trust':<8} {'Ev':<4} {'Clarity':<8} {'Verify':<8} {'Coverage':<10} File")
+    print("-" * 82)
     for r in sorted(results, key=lambda x: x["score"]):
         tag = " ⚠️" if threshold and r["score"] < threshold else ""
-        print(f"{r['score']:<8.3f} {r['clarity']:<8.1f} {r['verify']:<8.1f} {r['coverage']:<10.1f} {r['file']}{tag}")
+        print(f"{r['score']:<8.3f} {r['trust_score']:<8.3f} {r['evidence_level']:<4} "
+              f"{r['clarity']:<8.1f} {r['verify']:<8.1f} {r['coverage']:<10.1f} {r['file']}{tag}")
 
     print()
-    print(f"Average: {avg:.3f}")
+    print(f"Average: {avg:.3f}  (trust: {avg_trust:.3f})")
+
+    # Evidence distribution — how much of the corpus is still self-reported.
+    levels = {}
+    for r in results:
+        levels[r["evidence_level"]] = levels.get(r["evidence_level"], 0) + 1
+    print("Evidence: " + "  ".join(f"{lvl}={levels.get(lvl, 0)}" for lvl in ("E0", "E1", "E2", "E3", "E4")))
 
     if threshold is not None:
         print(f"Threshold: {threshold}")

--- a/tests/test_evidence_levels.py
+++ b/tests/test_evidence_levels.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for lesson evidence levels E0–E4 (Issue #786)."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from misakanet.evidence import (  # noqa: E402
+    DEFAULT_EVIDENCE_LEVEL,
+    EVIDENCE_LEVELS,
+    PROMOTION_RULES,
+    describe,
+    distribution,
+    evidence_label,
+    evidence_of,
+    evidence_weight,
+    next_level,
+    normalize_evidence_level,
+    promotion_requirement,
+    trust_score,
+)
+
+
+def test_levels_match_the_issue_model():
+    assert EVIDENCE_LEVELS == ["E0", "E1", "E2", "E3", "E4"]
+    assert DEFAULT_EVIDENCE_LEVEL == "E0"
+    assert evidence_label("E3") == "Sandbox / CI verified recovery"
+
+
+@pytest.mark.parametrize("value", [None, "", "  ", "E9", "high", "verified", {}, [], True, False, -1, 7])
+def test_unknown_values_never_claim_evidence(value):
+    """Anything unrecognised degrades to E0 — evidence is never assumed."""
+    assert normalize_evidence_level(value) == "E0"
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("E2", "E2"), ("e2", "E2"), (" e4 ", "E4"), (0, "E0"), (3, "E3"), (2.0, "E2"),
+])
+def test_reasonable_spellings_are_accepted(value, expected):
+    assert normalize_evidence_level(value) == expected
+
+
+def test_weights_increase_monotonically():
+    weights = [evidence_weight(level) for level in EVIDENCE_LEVELS]
+    assert weights == sorted(weights)
+    assert weights[0] == 0.0 and weights[-1] == 1.0
+
+
+def test_missing_frontmatter_field_defaults_to_e0():
+    assert evidence_of({"title": "x"}) == "E0"
+    assert evidence_of(None) == "E0"
+    assert evidence_of({"evidence_level": "E4"}) == "E4"
+
+
+def test_promotion_is_one_step_at_a_time():
+    assert [rule[:2] for rule in PROMOTION_RULES] == [("E0", "E1"), ("E1", "E2"), ("E2", "E3"), ("E3", "E4")]
+    assert next_level("E0") == "E1"
+    assert next_level("E4") is None
+    assert "review" in promotion_requirement("E0").lower()
+    assert "reproduce" in promotion_requirement("E1").lower()
+    assert "ci" in promotion_requirement("E2").lower()
+    assert "reuse" in promotion_requirement("E3").lower()
+    assert promotion_requirement("E4") is None
+
+
+def test_trust_score_scales_quality_by_evidence():
+    assert trust_score(1.0, "E0") == 0.7
+    assert trust_score(1.0, "E4") == 1.0
+    assert trust_score(0.0, "E4") == 0.0
+    # Same writing quality, different evidence → different trust.
+    assert trust_score(0.8, "E3") > trust_score(0.8, "E1")
+
+
+def test_trust_score_is_robust_to_bad_input():
+    assert trust_score(None, "E2") == 0.0
+    assert trust_score("nonsense", "E2") == 0.0
+    assert trust_score(5.0, "E4") == 1.0, "quality is clamped to 1.0"
+    assert trust_score(-3, "E4") == 0.0
+
+
+def test_describe_gives_a_ui_everything_it_needs():
+    info = describe("e2")
+    assert info["evidence_level"] == "E2"
+    assert info["next_level"] == "E3"
+    assert info["weight"] == 0.5
+    assert info["label"] and info["how_to_achieve"] and info["promotion_requirement"]
+
+
+def test_distribution_reports_every_level():
+    counts = distribution(["E0", "E0", "E3", "bogus", None])
+    assert counts == {"E0": 4, "E1": 0, "E2": 0, "E3": 1, "E4": 0}
+
+
+# ── Integration with the surrounding pipeline ──────────────────────────────
+
+def test_schema_constrains_the_field():
+    schema = json.loads((REPO_ROOT / "schemas" / "lesson.json").read_text(encoding="utf-8"))
+    field = schema["properties"]["evidence_level"]
+    assert field["enum"] == EVIDENCE_LEVELS
+    assert field["default"] == "E0"
+    assert "evidence_level" not in schema["required"], "existing lessons must stay valid"
+
+
+def test_new_lessons_default_to_e0():
+    source = (REPO_ROOT / "scripts" / "queue_lesson.py").read_text(encoding="utf-8")
+    assert source.count('"evidence_level": DEFAULT_EVIDENCE_LEVEL') == 2
+
+
+def test_index_generator_emits_the_field():
+    source = (REPO_ROOT / "scripts" / "misakanet-index.py").read_text(encoding="utf-8")
+    assert '"evidence_level": evidence_of(fm)' in source
+
+
+def test_scorer_reports_evidence_without_changing_the_quality_gate(tmp_path):
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from scripts.score_lessons import score_lesson
+
+    lesson = REPO_ROOT / "lessons" / "core" / "_evidence_probe.md"
+    frontmatter = {"title": "Probe lesson", "domain": "devops", "status": "published"}
+    body = (
+        "## Problem\n\nx\n\n## Root Cause\n\nThe error message says exit code 1.\n\n"
+        "## Solution\n\ny\n\n## Verification\n\n```bash\npytest\n```\nexpected: pass\n"
+    )
+
+    try:
+        lesson.write_text("---\n" + json.dumps(frontmatter) + "\n---\n\n" + body, encoding="utf-8")
+        e0 = score_lesson(lesson)
+
+        lesson.write_text(
+            "---\n" + json.dumps({**frontmatter, "evidence_level": "E4"}) + "\n---\n\n" + body,
+            encoding="utf-8",
+        )
+        e4 = score_lesson(lesson)
+    finally:
+        lesson.unlink(missing_ok=True)
+
+    assert e0["evidence_level"] == "E0"
+    assert e4["evidence_level"] == "E4"
+    # Quality is unchanged — only trust moves, so the CI threshold keeps its meaning.
+    assert e0["score"] == e4["score"]
+    assert e4["trust_score"] > e0["trust_score"]
+
+
+def test_search_page_shows_the_badge_and_defaults_to_e0():
+    html = (REPO_ROOT / "docs" / "search" / "index.html").read_text(encoding="utf-8")
+    assert "badge-evidence" in html
+    assert "function evidenceInfo(" in html
+    assert "EVIDENCE_LABELS[key] ? key : 'E0'" in html
+    for level in EVIDENCE_LEVELS:
+        assert f"{level}:" in html
+
+
+def test_lesson_pages_show_the_level():
+    source = (REPO_ROOT / "scripts" / "build_lesson_pages.py").read_text(encoding="utf-8")
+    assert "describe(lesson.get(\"evidence_level\"))" in source
+    assert "Evidence {evidence[" in source
+
+
+def test_docs_define_the_promotion_rules():
+    doc = (REPO_ROOT / "docs" / "trust-semantics.md").read_text(encoding="utf-8")
+    for level in EVIDENCE_LEVELS:
+        assert f"**{level}**" in doc
+    for phrase in ("Promotion rules", "trust_score", "Default is E0"):
+        assert phrase in doc


### PR DESCRIPTION
## Summary

Closes #786 — lesson trust becomes graded E0–E4 instead of binary, so a self-reported guess and a CI-verified fix no longer look identical in search results.

/claim #786

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🧪 Test improvement

## The model

| Level | Meaning | How it is achieved | Weight |
|-------|---------|--------------------|--------|
| **E0** | Contributor self-reported | Default on intake | 0.00 |
| **E1** | Maintainer reviewed | A maintainer accepted the intake | 0.25 |
| **E2** | Local smoke reproduced | Maintainer or CI reproduced the fix | 0.50 |
| **E3** | Sandbox / CI verified recovery | Automated verification in CI | 0.75 |
| **E4** | Reused by another contributor / agent | Usage report from a different user | 1.00 |

Promotion is one step at a time: E0→E1 review, E1→E2 reproduce, E2→E3 CI verify, E3→E4 external reuse. You promote a lesson by editing `evidence_level` in the same PR that carries the evidence.

## Acceptance criteria

- [x] Add `evidence_level` field to lesson schema (E0–E4) — `schemas/lesson.json`, enum + default, **not** required so all 344 existing lessons stay valid
- [x] Default new lessons to E0 — `scripts/queue_lesson.py` writes it; and *any* missing/unknown value reads as E0 everywhere
- [x] Update `score_lessons.py` to factor in evidence level — see below
- [x] Display evidence level in search results and lesson pages — badge on result cards (meaning on hover), and in generated lesson page metadata
- [x] Define promotion rules — `PROMOTION_RULES` in code + a table in the docs
- [x] Document in `docs/trust-semantics.md` — extended the existing file rather than replacing its indexed/published/verified vocabulary

## How scoring changed (and what deliberately did not)

The quality `score` is **unchanged**. `docs/quality-score.md` documents a CI gate at `--threshold 0.6`; folding evidence into that number would have silently moved every lesson ~15% down and broken the gate's meaning. Instead the scorer adds:

```
trust_score = quality_score × (0.7 + 0.3 × evidence_weight)
```

An E0 lesson keeps 70% of its quality score, an E4 keeps all of it. Quality asks "is this well written?", trust asks "how much should I rely on it?". A test pins that E0 and E4 produce identical `score` and different `trust_score`.

The scorer now also prints the corpus distribution, which is the honest current picture:

```
Average: 0.468  (trust: 0.328)
Evidence: E0=344  E1=0  E2=0  E3=0  E4=0
```

Everything is E0 until maintainers start promoting — the field is not backfilled with claims nobody verified.

## Design note

Unknown input never claims evidence. `normalize_evidence_level()` maps `None`, `""`, `"E9"`, `"verified"`, `True`, `-1`, dicts and lists all to `E0`; only `E0`–`E4` (case/space tolerant, plus ints `0`–`4`) are honoured. Same rule in the frontend. That is the difference between a trust signal and a decoration.

## Testing

```
python3 -m pytest tests/test_evidence_levels.py   # 33 passed
python3 -m pytest tests/                          # 494 passed, 3 skipped
python3 scripts/score_lessons.py                  # trust column + distribution
python3 scripts/validate_lessons.py <lesson>      # E9 → "not one of ['E0'..'E4']"
```

## Notes

- `data/lessons.json` is **not** regenerated here (per the PR checklist) — `evidence_level` will appear the next time the index job runs.
- One incidental fix: `score_lessons.py` single-file mode crashed on a relative path, the exact usage its own docstring shows. It now resolves the path.
- Ordering note: touches `docs/search/index.html`, as does #788/PR #809 — different regions, so at most a trivial rebase for whichever lands second.

## Checklist

- [x] My commit has `Signed-off-by:` (DCO required)
- [x] I have tested that the changes work correctly
- [x] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds)
