### PR TITLE
Update fix: resolve corrupt and malformed lesson metadata fr

### DIFF
--- a/lessons/contrib/cloudflare-email-worker-registration-trap.md
+++ b/lessons/contrib/cloudflare-email-worker-registration-trap.md
@@ -1,13 +1,10 @@
 ---
-{
-  "domain": "contrib",
-  "title": "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
-}
+title: "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF"
+domain: "devops"
+tags: ["cloudflare", "email-worker", "kv", "turnstile", "registration", "spf"]
+created: "2026-07-06"
+source: "unknown"
 ---
----{"title": "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF", "domain": "devops", "tags": ["cloudflare", "email-worker", "kv", "turnstile", "registration", "spf"]}---
 
 ## 背景
 

--- a/lessons/contrib/js-dead-code-chain-break.md
+++ b/lessons/contrib/js-dead-code-chain-break.md
@@ -1,12 +1,10 @@
 ---
-{
-  "domain": "contrib",
-  "title": "js dead code chain break",
-  "verification": "metadata-normalized",
-  "{\"title\"": "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效\", \"domain\": \"frontend\", \"tags\": [\"js\", \"runtime\", \"typeerror\", \"execution-model\", \"defensive\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
-}
+title: "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效"
+domain: "frontend"
+tags: ["js", "runtime", "typeerror", "execution-model", "defensive"]
+domain_expert: "unknown"
+created: "2026-07-06"
+source: "unknown"
 ---
 
 ## 背景


### PR DESCRIPTION
Fixed two lesson files containing corrupt metadata frontmatter. For the Cloudflare email worker lesson, the double frontmatter blocks were consolidated and converted into standard YAML frontmatter. For the JS dead code chain break lesson, the nested, serialized, and escaped JSON string key was resolved into clean, normalized YAML metadata properties.

$ https://github.com/Ikalus1988/MisakaNet/issues/513
Fixes https://github.com/Ikalus1988/MisakaNet/issues/513