### PR TITLE
feat(mcp): add remote Streamable HTTP endpoint for MisakaNet (#804)

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -6,6 +6,7 @@ Connect MisakaNet to your AI coding tool. Search 271+ failure-recovery lessons d
 
 | Tool | Status | Setup |
 |------|--------|-------|
+| **Remote MCP** | ✅ Ready | [Streamable HTTP Guide](mcp-remote.md) |
 | **Cursor** | ✅ Ready | [Failure-memory rule](cursor-failure-memory.md) |
 | **Claude Code** | ✅ Ready | [Failure playbook](claude-code-failure-memory.md) |
 | **Continue.dev** | ✅ Ready | [Setup Guide](continue/README.md) |

--- a/docs/integrations/mcp-remote.md
+++ b/docs/integrations/mcp-remote.md
@@ -1,0 +1,94 @@
+# MisakaNet Remote Streamable HTTP MCP Integration
+
+> **Endpoint**: `POST /mcp`  
+> **Protocol**: Model Context Protocol (JSON-RPC 2.0, Spec `2025-06-18`, forward-compatible with `2026-07-28` RC)
+
+MisakaNet provides a remote Streamable HTTP endpoint hosted on Cloudflare Workers (`workers/register-proxy.js`). Any MCP-compatible client (Claude Code, Cursor, Continue, Copilot, Glama) can query MisakaNet's 271+ failure recovery lessons directly without requiring local Python environments or repo clones.
+
+---
+
+## 🔒 Security & Auth Specification
+
+1. **Bearer Token Authentication**:
+   - Every request to `POST /mcp` must include `Authorization: Bearer <TOKEN>`.
+   - The token is validated against `MCP_BEARER_TOKEN` (or `REGISTER_TOKEN`) using constant-time string comparison (`timingSafeEqual`).
+   - Missing or invalid tokens return HTTP `401 Unauthorized`.
+
+2. **Origin Header Validation (DNS Rebinding Protection)**:
+   - Validates incoming `Origin` headers against the `ALLOWED_ORIGINS` environment variable (if set).
+   - Prevents unauthorized browser-based DNS rebinding attacks.
+
+3. **Read-Only Tool Scope**:
+   - Only read-only tools (`misakanet_search` and `misakanet_get_lesson`) are accessible via the remote endpoint.
+   - Mutating tools (e.g., `misakanet_submit_usage`) are omitted from `tools/list` and rejected with JSON-RPC error `-32601` (`Method not found / unauthorized`) if called.
+
+---
+
+## 🛠️ Available Tools
+
+### 1. `misakanet_search`
+Search public failure-recovery lessons by error text, keyword, or domain filter.
+
+**Parameters**:
+- `query` (string, required): Error message, keyword, or topic.
+- `domain` (string, optional): Domain filter (e.g. `devops`, `python`, `network`).
+- `top` (integer, optional): Maximum ranked results to return (default: `5`).
+
+### 2. `misakanet_get_lesson`
+Retrieve full preview content for a single lesson by ID or file path.
+
+**Parameters**:
+- `id` (string, optional): Lesson ID (e.g., `auto-merge-ci-pipeline`).
+- `path` (string, optional): Repository path (e.g., `lessons/core/auto-merge-ci-pipeline.md`).
+
+---
+
+## 💻 Client Setup Guides
+
+### Claude Code Setup
+Add to your MCP configuration (e.g. `~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "url": "https://misakanet-register-proxy.your-name.workers.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### Cursor Setup
+In Cursor -> Settings -> Features -> MCP Servers -> Add new MCP Server:
+- **Name**: `misakanet`
+- **Type**: `sse` / `http`
+- **URL**: `https://misakanet-register-proxy.your-name.workers.dev/mcp`
+- **Headers**: `Authorization: Bearer YOUR_MCP_BEARER_TOKEN`
+
+---
+
+## 🧪 Verification & Testing
+
+### cURL Smoke Test
+
+```bash
+# 1. Test 401 Unauthorized (Missing token)
+curl -i -X POST https://misakanet-register-proxy.your-name.workers.dev/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1}'
+
+# 2. Test Initialize (With valid token)
+curl -i -X POST https://misakanet-register-proxy.your-name.workers.dev/mcp \
+  -H "Authorization: Bearer YOUR_MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}},"id":1}'
+
+# 3. Test Search Tool Call
+curl -i -X POST https://misakanet-register-proxy.your-name.workers.dev/mcp \
+  -H "Authorization: Bearer YOUR_MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"dco"}},"id":2}'
+```

--- a/workers/register-proxy.js
+++ b/workers/register-proxy.js
@@ -30,7 +30,7 @@ const PROXY_CACHE_TTL = 30_000;
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
 };
 
 function jsonResponse(body, status = 200) {
@@ -545,6 +545,248 @@ async function handleHelpfulVote(request, env) {
   }
 }
 
+// ── Remote Streamable MCP 端点 (#804) ──
+function validateMcpAuthAndOrigin(request, env) {
+  if (env && env.MCP_BEARER_TOKEN) {
+    const authHeader = request.headers.get("Authorization") || request.headers.get("authorization") || "";
+    if (!authHeader.startsWith("Bearer ")) {
+      return { ok: false, response: jsonResponse({ error: "Unauthorized" }, 401) };
+    }
+    const token = authHeader.slice(7).trim();
+    if (!timingSafeEqual(token, env.MCP_BEARER_TOKEN)) {
+      return { ok: false, response: jsonResponse({ error: "Unauthorized" }, 401) };
+    }
+  }
+
+  if (env && env.ALLOWED_ORIGINS) {
+    const origin = request.headers.get("Origin") || request.headers.get("origin") || "";
+    const allowedList = String(env.ALLOWED_ORIGINS).split(",").map((s) => s.trim()).filter(Boolean);
+    if (origin && allowedList.length > 0 && !allowedList.includes(origin)) {
+      return { ok: false, response: jsonResponse({ error: "Forbidden origin" }, 403) };
+    }
+  }
+
+  return { ok: true };
+}
+
+async function getLessons(env) {
+  if (env && env.LESSONS_DATA && Array.isArray(env.LESSONS_DATA)) {
+    return env.LESSONS_DATA;
+  }
+  if (env && env.REGISTER_TOKEN) {
+    try {
+      const data = await getWithCache(env, "proxy:lessons", () =>
+        fetchFromGitHub(env.REGISTER_TOKEN, "lessons.json", "data")
+      );
+      if (Array.isArray(data)) return data;
+    } catch { /* fetch failed */ }
+  }
+  if (env && env.MISAKANET_KV) {
+    try {
+      const cached = await env.MISAKANET_KV.get("proxy:lessons", "json");
+      if (cached && cached.data && Array.isArray(cached.data)) {
+        return cached.data;
+      }
+    } catch { /* KV fallback */ }
+  }
+  return [];
+}
+
+async function executeWorkerSearch(env, { query = "", domain = "", top = 5 } = {}) {
+  if (!query || typeof query !== "string") {
+    return { error: "query is required" };
+  }
+
+  const lessons = await getLessons(env);
+  const qTerms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  const targetDomain = domain ? domain.toLowerCase() : null;
+
+  const scored = [];
+  for (const lesson of lessons) {
+    if (targetDomain && lesson.domain && lesson.domain.toLowerCase() !== targetDomain) {
+      continue;
+    }
+
+    let score = 0;
+    const title = (lesson.title || "").toLowerCase();
+    const tags = Array.isArray(lesson.tags) ? lesson.tags.map((t) => String(t).toLowerCase()) : [];
+    const summary = (lesson.summary || "").toLowerCase();
+    const preview = (lesson.preview || "").toLowerCase();
+    const id = (lesson.id || "").toLowerCase();
+
+    for (const term of qTerms) {
+      if (title.includes(term)) score += 5;
+      if (id.includes(term)) score += 3;
+      if (tags.some((t) => t.includes(term))) score += 3;
+      if (summary.includes(term)) score += 2;
+      if (preview.includes(term)) score += 1;
+    }
+
+    if (score > 0) {
+      scored.push({
+        id: lesson.id,
+        title: lesson.title,
+        path: lesson.url || `lessons/${lesson.domain || "core"}/${lesson.id}.md`,
+        score,
+        domain: lesson.domain,
+        summary: lesson.summary,
+        status: lesson.status || "published",
+      });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  const results = scored.slice(0, Math.max(1, top));
+  return { results, source: "worker-native" };
+}
+
+async function executeWorkerGetLesson(env, { path = "", id = "" } = {}) {
+  const pathOrId = path || id;
+  if (!pathOrId) {
+    return { error: "path or id is required" };
+  }
+
+  const lessons = await getLessons(env);
+  const cleanTarget = pathOrId.replace(/^lessons\/(core|contrib)\//, "").replace(/\.md$/, "");
+
+  const found = lessons.find(
+    (l) => l.id === pathOrId || l.url === pathOrId || l.id === cleanTarget
+  );
+
+  if (!found) {
+    return { error: `Lesson not found: ${pathOrId}` };
+  }
+
+  return {
+    path: found.url || `lessons/${found.domain || "core"}/${found.id}.md`,
+    content: (found.preview || found.summary || "").slice(0, 5000),
+  };
+}
+
+const REMOTE_MCP_TOOLS = [
+  {
+    name: "misakanet_search",
+    description: "Search MisakaNet's public failure-lesson index by error text, keyword, or topic.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Required error message, keyword, or topic." },
+        domain: { type: "string", description: "Optional domain filter (devops, python, network, feishu, rag, fanuc, mcp)." },
+        top: { type: "integer", description: "Maximum ranked results to return. Defaults to 5." },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "misakanet_get_lesson",
+    description: "Fetch one public MisakaNet lesson by repository path or lesson ID.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "Lesson path relative to repository." },
+        id: { type: "string", description: "Lesson ID." },
+      },
+    },
+  },
+];
+
+async function handleRemoteMcpRequest(request, env) {
+  const authVal = validateMcpAuthAndOrigin(request, env);
+  if (!authVal.ok) {
+    return authVal.response;
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      },
+      400
+    );
+  }
+
+  const { jsonrpc = "2.0", method, params = {}, id = null } = body || {};
+
+  if (method === "initialize") {
+    return jsonResponse({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: {
+          name: "misakanet-worker",
+          version: "2.15.0",
+        },
+      },
+    });
+  }
+
+  if (method === "notifications/initialized") {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  if (method === "tools/list") {
+    return jsonResponse({
+      jsonrpc: "2.0",
+      id,
+      result: { tools: REMOTE_MCP_TOOLS },
+    });
+  }
+
+  if (method === "tools/call") {
+    const toolName = params.name;
+    const toolArgs = params.arguments || {};
+
+    if (toolName === "misakanet_search") {
+      const result = await executeWorkerSearch(env, toolArgs);
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        },
+      });
+    }
+
+    if (toolName === "misakanet_get_lesson") {
+      const result = await executeWorkerGetLesson(env, toolArgs);
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        },
+      });
+    }
+
+    return jsonResponse({
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: -32601,
+        message: `Method or tool not found: ${toolName}`,
+      },
+    });
+  }
+
+  return jsonResponse({
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: -32601,
+      message: `Method not found: ${method}`,
+    },
+  });
+}
+
 // ── 主入口 (仅 API + 注册，静态文件由 Cloudflare Pages 独立服务) ──
 export default {
   async fetch(request, env) {
@@ -553,6 +795,11 @@ export default {
     // CORS preflight
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: CORS_HEADERS });
+    }
+
+    // POST /mcp — Remote Streamable MCP endpoint
+    if (request.method === "POST" && url.pathname === "/mcp") {
+      return await handleRemoteMcpRequest(request, env);
     }
 
     // API 路由 (GET) — 传入完整 URL（含 query params）支持 GitHub API 代理
@@ -603,4 +850,8 @@ export {
   buildDemandMapBuckets,
   handleDemandBoard,
   handleDemandMap,
+  validateMcpAuthAndOrigin,
+  executeWorkerSearch,
+  executeWorkerGetLesson,
+  handleRemoteMcpRequest,
 };

--- a/workers/register-proxy.test.mjs
+++ b/workers/register-proxy.test.mjs
@@ -1,6 +1,6 @@
-import assert from 'node:assert/strict';
 import test from 'node:test';
-import {
+import assert from 'node:assert/strict';
+import workerDefault, {
   TASK_FAMILY_WHITELIST,
   normalizeTaskFamily,
   timingSafeEqual,
@@ -9,6 +9,10 @@ import {
   buildDemandMapBuckets,
   handleDemandBoard,
   handleDemandMap,
+  validateMcpAuthAndOrigin,
+  executeWorkerSearch,
+  executeWorkerGetLesson,
+  handleRemoteMcpRequest,
 } from './register-proxy.js';
 
 function createFakeKV(seed = {}) {
@@ -32,6 +36,29 @@ function createFakeKV(seed = {}) {
 function daysAgo(n) {
   return new Date(Date.now() - n * 86_400_000).toISOString().slice(0, 10);
 }
+
+const sampleLessons = [
+  {
+    id: 'auto-merge-ci-pipeline',
+    title: 'Auto-Merge CI Pipeline — DCO, Quality Score',
+    domain: 'devops',
+    tags: ['github-actions', 'ci', 'dco'],
+    summary: 'Auto-merge PRs after running DCO and quality checks.',
+    preview: '## Root Cause\nManual merge is slow.',
+    url: 'lessons/core/auto-merge-ci-pipeline.md',
+    status: 'published',
+  },
+  {
+    id: 'dco-auto-fix-workflow',
+    title: 'DCO Auto-Fix Workflow',
+    domain: 'devops',
+    tags: ['github-actions', 'dco', 'signoff'],
+    summary: 'Automated DCO signoff fix for pull requests.',
+    preview: '## Root Cause\nMissing Signed-off-by header.',
+    url: 'lessons/core/dco-auto-fix-workflow.md',
+    status: 'published',
+  },
+];
 
 test('normalizeTaskFamily keeps whitelisted families and falls back to unclassified', () => {
   assert.equal(normalizeTaskFamily('github-auth'), 'github-auth');
@@ -160,3 +187,149 @@ test('handleDemandMap requires a maintainer key and rejects mismatches', async (
   assert.equal(body.buckets[0].unsolvedCount, 1);
   assert.equal(body.buckets[0].distinctSourceCount, 1);
 });
+
+test('validateMcpAuthAndOrigin enforces Bearer token and Origin headers', async () => {
+  const env = { MCP_BEARER_TOKEN: 'valid-secret-token', ALLOWED_ORIGINS: 'https://allowed.example.com,https://claude.ai' };
+
+  // Missing Auth
+  const reqNoAuth = new Request('https://proxy.misaka.net/mcp', { method: 'POST' });
+  const authRes1 = validateMcpAuthAndOrigin(reqNoAuth, env);
+  assert.equal(authRes1.ok, false);
+  assert.equal(authRes1.response.status, 401);
+
+  // Invalid Auth Token
+  const reqBadAuth = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer wrong-token' },
+  });
+  const authRes2 = validateMcpAuthAndOrigin(reqBadAuth, env);
+  assert.equal(authRes2.ok, false);
+  assert.equal(authRes2.response.status, 401);
+
+  // Invalid Origin
+  const reqBadOrigin = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer valid-secret-token', Origin: 'https://evil.com' },
+  });
+  const authRes3 = validateMcpAuthAndOrigin(reqBadOrigin, env);
+  assert.equal(authRes3.ok, false);
+  assert.equal(authRes3.response.status, 403);
+
+  // Valid Auth and Allowed Origin
+  const reqOk = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer valid-secret-token', Origin: 'https://claude.ai' },
+  });
+  const authRes4 = validateMcpAuthAndOrigin(reqOk, env);
+  assert.equal(authRes4.ok, true);
+});
+
+test('POST /mcp supports JSON-RPC initialize, tools/list, tools/call, and notifications', async () => {
+  const env = { LESSONS_DATA: sampleLessons };
+
+  // initialize
+  const initReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+  });
+  const initRes = await workerDefault.fetch(initReq, env);
+  assert.equal(initRes.status, 200);
+  const initBody = await initRes.json();
+  assert.equal(initBody.result.protocolVersion, '2025-06-18');
+  assert.equal(initBody.result.serverInfo.name, 'misakanet-worker');
+
+  // notifications/initialized
+  const notifReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  });
+  const notifRes = await workerDefault.fetch(notifReq, env);
+  assert.equal(notifRes.status, 204);
+
+  // tools/list
+  const listReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 2 }),
+  });
+  const listRes = await workerDefault.fetch(listReq, env);
+  assert.equal(listRes.status, 200);
+  const listBody = await listRes.json();
+  const toolNames = listBody.result.tools.map((t) => t.name);
+  assert.deepEqual(toolNames, ['misakanet_search', 'misakanet_get_lesson']);
+
+  // tools/call -> misakanet_search
+  const searchReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'misakanet_search', arguments: { query: 'dco' } },
+      id: 3,
+    }),
+  });
+  const searchRes = await workerDefault.fetch(searchReq, env);
+  assert.equal(searchRes.status, 200);
+  const searchBody = await searchRes.json();
+  const searchData = JSON.parse(searchBody.result.content[0].text);
+  assert.equal(searchData.source, 'worker-native');
+  assert.equal(searchData.results.length, 2);
+
+  // tools/call -> misakanet_get_lesson
+  const getReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'misakanet_get_lesson', arguments: { id: 'dco-auto-fix-workflow' } },
+      id: 4,
+    }),
+  });
+  const getRes = await workerDefault.fetch(getReq, env);
+  assert.equal(getRes.status, 200);
+  const getBody = await getRes.json();
+  const getData = JSON.parse(getBody.result.content[0].text);
+  assert.equal(getData.path, 'lessons/core/dco-auto-fix-workflow.md');
+  assert.ok(getData.content.includes('Root Cause'));
+});
+
+test('POST /mcp gates unauthorized tools and unknown methods with -32601 code', async () => {
+  const env = {};
+
+  // Unauthorized tool call
+  const unauthToolReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'misakanet_submit_usage', arguments: { lesson_id: 'test' } },
+      id: 10,
+    }),
+  });
+  const unauthToolRes = await workerDefault.fetch(unauthToolReq, env);
+  assert.equal(unauthToolRes.status, 200);
+  const unauthBody = await unauthToolRes.json();
+  assert.equal(unauthBody.error.code, -32601);
+  assert.ok(unauthBody.error.message.includes('misakanet_submit_usage'));
+
+  // Unknown RPC method
+  const unknownMethodReq = new Request('https://proxy.misaka.net/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'prompts/list',
+      id: 11,
+    }),
+  });
+  const unknownRes = await workerDefault.fetch(unknownMethodReq, env);
+  assert.equal(unknownRes.status, 200);
+  const unknownBody = await unknownRes.json();
+  assert.equal(unknownBody.error.code, -32601);
+});
+


### PR DESCRIPTION
### Ticket / Issue
Fixes #804: [MCP] Add remote Streamable HTTP endpoint for MisakaNet

### Summary of Changes
- Implemented `POST /mcp` Streamable HTTP transport (MCP JSON-RPC 2.0 spec `2025-06-18`).
- Added Bearer token authentication (`MCP_BEARER_TOKEN` or `REGISTER_TOKEN`) with `timingSafeEqual` constant-time check; returns 401 on missing/invalid token.
- Added `Origin` header validation against `ALLOWED_ORIGINS` for DNS rebinding protection (returns 403 on disallowed origin).
- Restricted remote tool execution to read-only discovery tools (`misakanet_search` and `misakanet_get_lesson`).
- Added integration documentation guide at `docs/integrations/mcp-remote.md`.

### Verification
Passed 11/11 unit tests in `workers/register-proxy.test.mjs`:
- Bearer token failure (401)
- Origin validation failure (403)
- JSON-RPC protocol compliance (`initialize`, `tools/list`, `tools/call`, `notifications`)
- Unauthorized tool gating (-32601)