### PR TITLE
experiment: declare remote endpoint in glama.json

### DIFF
--- a/docs/integrations/mcp-remote.md
+++ b/docs/integrations/mcp-remote.md
@@ -1,8 +1,13 @@
 # Remote MCP Endpoint
 
-MisakaNet exposes a Streamable HTTP MCP endpoint at `https://misakanet.org/mcp`.
+> **Remote MCP endpoint:** `https://misakanet.org/mcp`
+> **Transport:** Streamable HTTP
+> **Auth:** Bearer token
+> **Protocol:** MCP 2025-06-18 (forward-compatible with 2026-07-28 RC)
 
-Protocol: MCP 2025-06-18 (forward-compatible with 2026-07-28 RC).
+MisakaNet exposes a Streamable HTTP MCP endpoint at `https://misakanet.org/mcp`. Any MCP-compatible client can connect remotely without cloning the repo.
+
+The server also supports local stdio transport as an alternative (see [Local stdio](#local-stdio-alternative) below).
 
 ## Quick Start
 

--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,8 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["Ikalus1988"]
+  "maintainers": ["Ikalus1988"],
+  "remote": {
+    "url": "https://misakanet.org/mcp",
+    "transport": "streamable-http"
+  }
 }


### PR DESCRIPTION
## What

Test whether Glama accepts a `remote` field in `glama.json` to discover the Streamable HTTP endpoint at `https://misakanet.org/mcp`.

## Changes

- `glama.json` — adds `remote: { url, transport }` block
- `docs/integrations/mcp-remote.md` — clearer endpoint declaration at top

## What is NOT changed

- `server.mcpb.json` — preserved (stdio discovery unchanged)
- No code changes, no Worker changes

## Expected outcomes

If Glama accepts the `remote` field:
- Listing page shows hosted endpoint URL
- "Connect" button appears
- Tool Calls > 0 in analytics

If Glama ignores it:
- No harm done, revert the PR
- Fall back to manual Glama dashboard configuration

## Verification

1. Merge this PR
2. Wait 24-48h for Glama to re-crawl
3. Check https://glama.ai/mcp/servers/Ikalus1988/MisakaNet for:
   - Hosted endpoint URL
   - Connect button
   - Tool Calls count
4. If no change, revert

Refs: #804, #764