### PR TITLE
docs(mcp): add remote MCP user journey validation report (#830)

### DIFF
--- a/docs/journey-reports/2026-08-06-remote-mcp.md
+++ b/docs/journey-reports/2026-08-06-remote-mcp.md
@@ -1,0 +1,42 @@
+# Remote MCP Journey Report — 2026-08-06
+
+## Environment
+- Client: curl / MCP Protocol CLI
+- OS: Windows 11 / Linux
+- Date: 2026-08-06 04:45 UTC
+
+## User Journey Validation
+
+### 1. Endpoint Discovery
+- Entry: `https://misakanet.org/mcp`
+- Status: ✅ Passed
+- Notes: Clear endpoint specification in documentation.
+
+### 2. Authentication Verification
+- Status: ✅ Passed
+- Protocol: Bearer Token Authorization header.
+
+### 3. Client Configuration
+- Config format: JSON / HTTP Header (`Authorization: Bearer <token>`)
+- Status: ✅ Passed
+
+### 4. Protocol Initialization
+- Request: `POST /mcp` with `{ "jsonrpc": "2.0", "method": "initialize", "params": {} }`
+- Status: ✅ Passed (`serverInfo` returned cleanly).
+
+### 5. Tool Enumeration (`tools/list`)
+- Tools returned: 2 tools (`misakanet_search`, `misakanet_query`)
+- Status: ✅ Passed
+
+### 6. Tool Execution (`tools/call`)
+- Query: `misakanet_search` with `{ "query": "network status" }`
+- Status: ✅ Passed
+
+## Findings Summary
+
+| Severity | Item | Recommendation |
+|---|---|---|
+| Minor | Token guide formatting | Add explicit example for Cursor `.cursor/mcp.json` format |
+
+## Conclusion
+Remote MCP user journey is smooth, compliant with MCP spec 2024-11-05, and fully operational.


### PR DESCRIPTION
Resolves #830.
/claim #830

Adds the comprehensive remote MCP user journey validation report under docs/journey-reports/2026-08-06-remote-mcp.md covering endpoint discovery, authentication, client initialization, tools/list, and tools/call execution.