### PR TITLE
[#835] docs: v2.16.0 release notes (clean — replaces #862)

### DIFF
--- a/docs/releases/v2.16.0.md
+++ b/docs/releases/v2.16.0.md
@@ -1,0 +1,48 @@
+# MisakaNet v2.16.0 -- Remote MCP Stable + First-Call Experience
+
+**Related issue:** [#835](https://github.com/Ikalus1988/MisakaNet/issues/835)
+
+## Release Summary
+
+v2.16.0 stabilizes the Remote MCP endpoint and closes the first-call experience loop.
+
+## Milestone 1: Remote MCP Available
+
+- POST /mcp endpoint stable and production-ready
+- Bearer token + Origin validation in place
+- Read-only tools: search + get_lesson
+- Protocol compatibility: 2025-06-18 + 2026-07-28 RC
+- GET /mcp returns 405 (spec-compliant)
+
+## Milestone 2: Glama First-Call
+
+- #831 stdio sandbox fallback -- search no longer errors
+- #817 Glama remote metadata -- merged, live on Glama
+- Glama routing confirmed: remote endpoint preferred, stdio sandbox as fallback
+- User can search regardless of routing path
+
+## Milestone 3: User Journey Verified
+
+- #830 First-call journey validated end-to-end
+- Friction points documented: token acquisition, CORS, client config
+- Multi-client tested: Claude Desktop, Cursor, curl
+- All 6 journey steps pass
+
+## Known Issues
+
+| Issue | Status | Mitigation |
+|-------|--------|------------|
+| Token acquisition UX | Needs improvement | Documented in journey report |
+| CORS for browser clients | Working | Origin validation active |
+| Client config discovery | Documentation gap | README + Glama listing updated |
+
+## Next Steps (v2.17.0)
+
+- #309 Translate top10 Chinese lessons to English
+- #818 Social media promotion for Remote MCP
+- Token management UI in Glama listing
+- Monitor Glama analytics dashboard (growth-funnel.md)
+
+---
+
+*Generated from bounty #835 -- v2.16.0 Remote MCP*


### PR DESCRIPTION
v2.16.0 Release Notes — Closes #835

This PR adds the official v2.16.0 release notes.

## M1: Remote MCP Available
- POST /mcp endpoint stable, Bearer + Origin validation, read-only tools
- Protocol 2025-06-18 + 2026-07-28 RC compatible

## M2: Glama First-Call
- #831 stdio sandbox fallback fixed
- #817 Glama remote metadata live
- Dual-path routing confirmed (remote -> stdio fallback)

## M3: User Journey Verified
- #830 first-call journey validated (6 steps)
- All friction points documented
- Multi-client tested (Claude Desktop, Cursor, curl)

## Deliverable
- docs/releases/v2.16.0.md — full release notes

**Bounty:** #835

**Note:** This replaces #862 which was auto-closed due to a branch corruption during DCO fix. Clean commit with proper signoff.
