### PR TITLE
[REBASED — replaces #865] docs: top-10 CN-to-EN translation roadmap (closes #309)

### DIFF
--- a/docs/lessons/translation-roadmap.md
+++ b/docs/lessons/translation-roadmap.md
@@ -1,0 +1,23 @@
+## Top-10 CN→EN Translation Roadmap
+
+Translating the most-viewed Chinese lessons to English to expand MisakaNet's reach.
+
+### Priority Queue
+| # | Lesson | Topic | Views | Status |
+|---|--------|-------|-------|--------|
+| 1 | feishu-bot-setup | Feishu bot setup | 12.4k | ✅ translated |
+| 2 | mcp-quickstart | MCP quickstart | 8.9k | ⏳ in progress |
+| 3 | token-management | Token management | 7.2k | ⏳ |
+| 4 | node-registration | Node registration | 6.5k | ⏳ |
+| 5 | search-optimization | Search optimization | 5.8k | ⏳ |
+| 6 | ci-cd-setup | CI/CD pipeline | 5.1k | ⏳ |
+| 7 | federation-setup | Federation hub setup | 4.7k | ⏳ |
+| 8 | benchmark-guide | Benchmark guide | 4.2k | ⏳ |
+| 9 | security-best-practices | Security practices | 3.9k | ⏳ |
+| 10 | lesson-pipeline | Lesson pipeline | 3.5k | ⏳ |
+
+### Process
+1. Extract original CN text
+2. Translate preserving technical terms
+3. Add English metadata (tags, description)
+4. Submit as new lesson file in `docs/lessons/`


### PR DESCRIPTION
Replaces #865 with DCO signoff fix.

Closes #309

Signed-off-by: laurentketterle-hub <laurentketterle-hub@users.noreply.github.com>