### PR TITLE
fix(security): escape m.time in danmaku widget — CodeQL #45

### DIFF
--- a/docs/search/danmaku-widget.html
+++ b/docs/search/danmaku-widget.html
@@ -50,7 +50,7 @@
 
   function render(){
     feed.innerHTML=msgs.slice(-30).map(m=>
-      '<div class="danmaku-msg"><span class="time">'+m.time+'</span> '+esc(m.text)+'</div>'
+      '<div class="danmaku-msg"><span class="time">'+esc(m.time)+'</span> '+esc(m.text)+'</div>'
     ).join('');
     count.textContent=msgs.length;
     feed.scrollTop=feed.scrollHeight;


### PR DESCRIPTION
## Fix

CodeQL alert #45: DOM text reinterpreted as HTML (high severity).

**Problem:**  was not escaped before  insertion in .

**Fix:** Use  instead of  — same escape function already used for .

## Before
```js
'<span class="time">'+m.time+'</span>'
```

## After
```js
'<span class="time">'+esc(m.time)+'</span>'
```

Closes CodeQL alert #45.