### PR TITLE
docs: fix MCP pairing endpoint paths in v2.16.0 release notes

### DIFF
--- a/docs/release/v2.16.0-release-notes.md
+++ b/docs/release/v2.16.0-release-notes.md
@@ -78,4 +78,4 @@ None.
 
 - `MCP_TOKEN` secret required for remote endpoint
 - `MCP_VERSION` secret optional (defaults to pyproject.toml version)
-- Cloudflare Routes: `misakanet.org/api/connect*`, `/api/pair*`, `/connect*` → register-proxy Worker
+- Cloudflare Routes: `misakanet.org/mcp/connect*`, `/mcp/pair*`, `/connect*` → register-proxy Worker


### PR DESCRIPTION
## Summary
Normalizes the MCP pairing endpoint documentation to the confirmed paths. Closes #884.

## Changes
The v2.16.0 release notes still referenced the deprecated `/api/connect` and `/api/pair` paths, while the worker code (`workers/register-proxy-sw.js`) exposes:
- `POST /mcp/connect` — generate 6-char pairing code (10min TTL)
- `POST /mcp/pair` — exchange code for 24h MCP token

Updated all 3 occurrences (endpoint list + Cloudflare Routes) to the confirmed paths.

## Verification
- `grep -rn "api/connect\|api/pair" docs/ --include="*.md"` → no matches
- `docs/integrations/mcp-remote.md` and `docs/release/v2.16.0-acceptance.md` already correct (checked per #884 checklist)
- `docs/mcp-quickstart.md` and `README.md` have no pairing endpoint references (checked per #884 checklist)