### PR TITLE
feat: add lesson quality gate for new contributions

### DIFF
--- a/.github/workflows/lesson-gate.yml
+++ b/.github/workflows/lesson-gate.yml
@@ -1,0 +1,80 @@
+name: Lesson Quality Gate
+
+# Structural gate (issue #889): blocks PRs whose NEW/CHANGED lessons fail the
+# quality checks (required frontmatter fields, min content length, duplicate
+# titles, allowed domain, tag format). Runs only on lessons/ changes.
+on:
+  pull_request:
+    paths:
+      - 'lessons/**'
+      - 'scripts/lesson_gate.py'
+      - 'tests/test_lesson_gate.py'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Get changed lesson files
+        id: changed
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            lessons/**/*.md
+
+      - name: Run lesson quality gate
+        if: steps.changed.outputs.any_changed == 'true'
+        id: gate
+        run: |
+          FILES="${{ steps.changed.outputs.all_changed_files }}"
+          # Convert space-separated list to args (paths have no spaces in this repo)
+          python3 scripts/lesson_gate.py $FILES > gate_report.txt 2>&1
+          GATE_EXIT=$?
+          cat gate_report.txt
+          echo "gate_exit=$GATE_EXIT" >> "$GITHUB_OUTPUT"
+          if [ "$GATE_EXIT" -ne 0 ]; then
+            echo "❌ Lesson quality gate FAILED — see report below."
+            exit 1
+          fi
+
+      - name: Run unit tests for the gate
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          pip install -q pytest
+          python3 -m pytest tests/test_lesson_gate.py -q
+
+      - name: Comment gate result on PR
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let report = '✅ **Lesson Quality Gate passed.**';
+            let icon = '✅';
+            try {
+              const gateReport = fs.readFileSync('gate_report.txt', 'utf8');
+              if (gateReport.includes('FAIL')) {
+                icon = '❌';
+                report = '❌ **Lesson Quality Gate failed.** Check the report below.';
+              }
+              report += '\n\n```\n' + gateReport + '\n```';
+            } catch (e) {}
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: report,
+            });

--- a/scripts/lesson_gate.py
+++ b/scripts/lesson_gate.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Lesson Quality Gate — structural validation for new lesson contributions (issue #889).
+
+Validates lesson Markdown files against the quality gate checklist:
+  - Required frontmatter fields: title, domain, tags, status, evidence_level
+  - Minimum content length: 100 chars (excluding frontmatter)
+  - No duplicate titles (against all existing lessons)
+  - Domain must be in the allowed list (docs/domains/ + lessons/core|contrib|en)
+  - Tags validated for format (1-10 unique strings, min 2 chars)
+  - status ∈ {published, draft, archived}; evidence_level ∈ {E0..E4}
+
+Usage:
+    python3 scripts/lesson_gate.py lessons/contrib/foo.md          # validate one
+    python3 scripts/lesson_gate.py lessons/a.md lessons/b.md       # validate many
+    python3 scripts/lesson_gate.py --all                           # validate all lessons
+    python3 scripts/lesson_gate.py --json <file>                   # JSON report
+
+Exit code: 0 = all pass, 1 = any file failed.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LESSONS_DIR = REPO / "lessons"
+DOCS_DOMAINS = REPO / "docs" / "domains"
+
+VALID_STATUS = {"published", "draft", "archived"}
+VALID_EVIDENCE = {"E0", "E1", "E2", "E3", "E4"}
+MIN_CONTENT_CHARS = 100
+MIN_TITLE_CHARS = 4
+MAX_TITLE_CHARS = 120
+MIN_TAG_CHARS = 2
+MAX_TAGS = 10
+
+# Lesson directories that count as real contributions (not templates/archive).
+ACTIVE_LESSON_SUBDIRS = {"core", "contrib", "en"}
+
+FM_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+
+# ── Parsing ─────────────────────────────────────────────────────────
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, content_without_frontmatter)."""
+    m = FM_RE.match(text)
+    if not m:
+        return {}, text
+    try:
+        fm = json.loads(m.group(1).strip())
+    except json.JSONDecodeError:
+        return {}, text[m.end():]
+    if not isinstance(fm, dict):
+        return {}, text[m.end():]
+    return fm, text[m.end():]
+
+
+# ── Field validators ────────────────────────────────────────────────
+def validate_required(fm: dict) -> list[str]:
+    errors = []
+    for field in ("title", "domain", "tags", "status", "evidence_level"):
+        if field not in fm or fm[field] in (None, ""):
+            errors.append(f"missing required field: {field}")
+    return errors
+
+
+def validate_title(title) -> list[str]:
+    if not isinstance(title, str):
+        return ["title must be a string"]
+    errors = []
+    if len(title) < MIN_TITLE_CHARS:
+        errors.append(f"title too short ({len(title)} < {MIN_TITLE_CHARS} chars)")
+    if len(title) > MAX_TITLE_CHARS:
+        errors.append(f"title too long ({len(title)} > {MAX_TITLE_CHARS} chars)")
+    return errors
+
+
+def validate_tags(tags) -> list[str]:
+    if not isinstance(tags, list):
+        return ["tags must be a list"]
+    if len(tags) < 1:
+        return ["tags must have at least 1 tag"]
+    if len(tags) > MAX_TAGS:
+        return [f"tags exceed {MAX_TAGS} tags"]
+    if len(set(tags)) != len(tags):
+        return ["tags must be unique"]
+    short = [t for t in tags if not (isinstance(t, str) and len(t) >= MIN_TAG_CHARS)]
+    if short:
+        return [f"tags must be strings of >= {MIN_TAG_CHARS} chars: {short[:3]}"]
+    return []
+
+
+def validate_status(status) -> list[str]:
+    if status not in VALID_STATUS:
+        return [f"status must be one of {sorted(VALID_STATUS)}, got {status!r}"]
+    return []
+
+
+def validate_evidence(evidence_level) -> list[str]:
+    if evidence_level not in VALID_EVIDENCE:
+        return [f"evidence_level must be one of {sorted(VALID_EVIDENCE)}, got {evidence_level!r}"]
+    return []
+
+
+def validate_content_len(content: str) -> bool:
+    return len(content.strip()) >= MIN_CONTENT_CHARS
+
+
+# ── Repo-level checks ───────────────────────────────────────────────
+def allowed_domains(repo: Path = REPO) -> set[str]:
+    """Allowed domains = docs/domains/* + domains used in active lesson dirs."""
+    domains = set()
+    if DOCS_DOMAINS.is_dir():
+        for f in DOCS_DOMAINS.glob("*.md"):
+            domains.add(f.stem.lower())
+    for sub in ACTIVE_LESSON_SUBDIRS:
+        d = repo / "lessons" / sub
+        if not d.is_dir():
+            continue
+        for f in d.rglob("*.md"):
+            try:
+                fm, _ = parse_frontmatter(f.read_text(encoding="utf-8", errors="ignore"))
+            except Exception:
+                continue
+            dom = fm.get("domain")
+            if isinstance(dom, str) and dom:
+                domains.add(dom.lower())
+    return domains
+
+
+def _iter_active_lessons(repo: Path = REPO):
+    for sub in ACTIVE_LESSON_SUBDIRS:
+        d = repo / "lessons" / sub
+        if d.is_dir():
+            yield from d.rglob("*.md")
+
+
+def find_duplicate_title(title: str, repo: Path = REPO, exclude_file: Path | None = None) -> bool:
+    if not title:
+        return False
+    norm = title.strip().lower()
+    for f in _iter_active_lessons(repo):
+        if exclude_file is not None and f.resolve() == Path(exclude_file).resolve():
+            continue
+        try:
+            fm, _ = parse_frontmatter(f.read_text(encoding="utf-8", errors="ignore"))
+        except Exception:
+            continue
+        if isinstance(fm.get("title"), str) and fm["title"].strip().lower() == norm:
+            return True
+    return False
+
+
+# ── File validation ─────────────────────────────────────────────────
+def validate_file(path: Path, repo: Path = REPO) -> list[str]:
+    errors = []
+    try:
+        text = Path(path).read_text(encoding="utf-8", errors="ignore")
+    except OSError as e:
+        return [f"cannot read {path}: {e}"]
+
+    fm, content = parse_frontmatter(text)
+    errors += validate_required(fm)
+    if fm:
+        errors += validate_title(fm.get("title"))
+        errors += validate_tags(fm.get("tags")) if "tags" in fm else []
+        errors += validate_status(fm.get("status")) if "status" in fm else []
+        errors += validate_evidence(fm.get("evidence_level")) if "evidence_level" in fm else []
+
+    if not validate_content_len(content):
+        errors.append(f"content too short (< {MIN_CONTENT_CHARS} chars excluding frontmatter)")
+
+    if fm and fm.get("title"):
+        domain = fm.get("domain")
+        if isinstance(domain, str) and domain:
+            if domain.lower() not in allowed_domains(repo):
+                errors.append(f"domain {domain!r} not in allowed list (docs/domains/ or existing lessons)")
+        if find_duplicate_title(fm["title"], repo, exclude_file=path):
+            errors.append(f"duplicate title: {fm['title']!r}")
+
+    return errors
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv or "--help" in argv or "-h" in argv:
+        print(__doc__)
+        return 0
+
+    json_mode = "--json" in argv
+    argv = [a for a in argv if a != "--json"]
+
+    if "--all" in argv:
+        files = sorted(_iter_active_lessons())
+    else:
+        files = [Path(a) for a in argv]
+
+    failures = 0
+    report = {}
+    for f in files:
+        errors = validate_file(f)
+        report[str(f)] = errors
+        if errors:
+            failures += 1
+
+    if json_mode:
+        print(json.dumps({"files": report, "failures": failures}, indent=2))
+    else:
+        for f, errors in report.items():
+            if errors:
+                print(f"FAIL {f}")
+                for e in errors:
+                    print(f"  - {e}")
+        if failures:
+            print(f"\n{len(files)} file(s) checked, {failures} failed.")
+        else:
+            print(f"OK: {len(files)} file(s) passed the lesson quality gate.")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_lesson_gate.py
+++ b/tests/test_lesson_gate.py
@@ -1,0 +1,220 @@
+"""Tests for the Lesson Quality Gate (issue #889).
+
+Structural validation for new lesson contributions:
+  - required frontmatter fields: title, domain, tags, status, evidence_level
+  - minimum content length: 100 chars (excluding frontmatter)
+  - no duplicate titles
+  - domain in allowed list
+  - tags from valid format (1-10 unique strings, min 2 chars)
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts.lesson_gate import (  # noqa: E402
+    allowed_domains,
+    find_duplicate_title,
+    parse_frontmatter,
+    validate_content_len,
+    validate_evidence,
+    validate_file,
+    validate_required,
+    validate_status,
+    validate_tags,
+    validate_title,
+)
+
+LESSON_DIR = REPO / "lessons"
+
+
+def make_lesson(tmp_path: Path, fm: dict, content: str, name: str = "lesson.md") -> Path:
+    """Create a lesson file with JSON frontmatter."""
+    path = tmp_path / name
+    path.write_text(f"---\n{json.dumps(fm, ensure_ascii=False, indent=2)}\n---\n\n{content}", encoding="utf-8")
+    return path
+
+
+def valid_fm() -> dict:
+    return {
+        "title": "Valid Lesson Title For Gate Testing",
+        "domain": "mcp",
+        "tags": ["mcp", "debugging"],
+        "status": "published",
+        "evidence_level": "E1",
+    }
+
+
+def long_content() -> str:
+    return "# Problem\n\n" + ("x" * 200)
+
+
+# ── parse_frontmatter ────────────────────────────────────────────────
+class TestParseFrontmatter:
+    def test_valid_json_frontmatter(self, tmp_path):
+        p = make_lesson(tmp_path, valid_fm(), long_content())
+        fm, content = parse_frontmatter(p.read_text(encoding="utf-8"))
+        assert fm["title"] == valid_fm()["title"]
+        assert "x" * 200 in content
+
+    def test_missing_frontmatter(self, tmp_path):
+        p = tmp_path / "no-fm.md"
+        p.write_text("# Just content", encoding="utf-8")
+        fm, content = parse_frontmatter(p.read_text(encoding="utf-8"))
+        assert fm == {}
+        assert content.startswith("# Just content")
+
+    def test_invalid_json_frontmatter(self, tmp_path):
+        p = tmp_path / "bad-fm.md"
+        p.write_text("---\n{not valid json\n---\nbody", encoding="utf-8")
+        fm, _ = parse_frontmatter(p.read_text(encoding="utf-8"))
+        assert fm == {}
+
+
+# ── validate_required ────────────────────────────────────────────────
+class TestRequiredFields:
+    @pytest.mark.parametrize("missing", ["title", "domain", "tags", "status", "evidence_level"])
+    def test_missing_field_fails(self, tmp_path, missing):
+        fm = valid_fm()
+        del fm[missing]
+        errors = validate_required(fm)
+        assert any(missing in e for e in errors), errors
+
+    def test_all_fields_present_passes(self):
+        assert validate_required(valid_fm()) == []
+
+
+# ── validate_title ───────────────────────────────────────────────────
+class TestTitle:
+    def test_short_title_fails(self):
+        assert validate_title("abc")  # < 4 chars
+
+    def test_long_title_fails(self):
+        assert validate_title("t" * 121)
+
+    def test_valid_title_passes(self):
+        assert not validate_title("A Proper Lesson Title")
+
+
+# ── validate_tags ───────────────────────────────────────────────────
+class TestTags:
+    def test_not_list_fails(self):
+        assert validate_tags("mcp")
+
+    def test_empty_list_fails(self):
+        assert validate_tags([])
+
+    def test_short_tag_fails(self):
+        assert validate_tags(["a"])
+
+    def test_duplicate_tags_fail(self):
+        assert validate_tags(["mcp", "mcp"])
+
+    def test_too_many_tags_fail(self):
+        assert validate_tags([f"tag{i}" for i in range(11)])
+
+    def test_valid_tags_pass(self):
+        assert not validate_tags(["mcp", "debugging"])
+
+
+# ── validate_status / validate_evidence ─────────────────────────────
+class TestStatusAndEvidence:
+    @pytest.mark.parametrize("bad", ["live", "PUBLISHED", "", 42])
+    def test_invalid_status_fails(self, bad):
+        assert validate_status(bad)
+
+    def test_valid_status_passes(self):
+        assert not validate_status("draft")
+
+    @pytest.mark.parametrize("bad", ["E9", "", "high", 3])
+    def test_invalid_evidence_fails(self, bad):
+        assert validate_evidence(bad)
+
+    def test_valid_evidence_passes(self):
+        assert not validate_evidence("E0")
+
+
+# ── content length ──────────────────────────────────────────────────
+class TestContentLength:
+    def test_short_content_fails(self):
+        assert not validate_content_len("# Problem\n\nshort")
+
+    def test_100_chars_passes(self):
+        assert validate_content_len("# Problem\n\n" + ("x" * 89))  # 11 + 89 = 100
+
+    def test_99_chars_fails(self):
+        assert not validate_content_len("# Problem\n\n" + ("x" * 88))  # 11 + 88 = 99
+
+
+# ── allowed_domains / duplicates ────────────────────────────────────
+class TestRepoChecks:
+    def test_allowed_domains_includes_docs_and_lessons(self):
+        domains = allowed_domains(REPO)
+        assert "mcp" in domains  # lessons/core uses mcp
+        assert "network" in domains  # docs/domains has network.md
+
+    def test_duplicate_title_detected(self, tmp_path):
+        p = make_lesson(tmp_path, valid_fm(), long_content())
+        existing = "DCO Auto-Fix Workflow — /fix-dco Command Design & Implementation"
+        assert find_duplicate_title(existing, REPO, exclude_file=p)
+
+    def test_unique_title_not_detected(self, tmp_path):
+        p = make_lesson(tmp_path, valid_fm(), long_content())
+        unique = "zz_never_seen_title_for_gate_test_8842"
+        assert not find_duplicate_title(unique, REPO, exclude_file=p)
+
+
+# ── validate_file (integration) ─────────────────────────────────────
+class TestValidateFile:
+    def test_valid_lesson_passes(self, tmp_path):
+        p = make_lesson(tmp_path, valid_fm(), long_content())
+        errors = validate_file(p, REPO)
+        assert errors == []
+
+    def test_missing_fields_errors(self, tmp_path):
+        fm = valid_fm()
+        del fm["tags"]
+        del fm["evidence_level"]
+        p = make_lesson(tmp_path, fm, long_content())
+        errors = validate_file(p, REPO)
+        assert any("tags" in e for e in errors)
+        assert any("evidence_level" in e for e in errors)
+
+    def test_disallowed_domain_fails(self, tmp_path):
+        fm = valid_fm()
+        fm["domain"] = "not-a-real-domain-xyz"
+        p = make_lesson(tmp_path, fm, long_content())
+        errors = validate_file(p, REPO)
+        assert any("domain" in e for e in errors)
+
+    def test_duplicate_title_fails(self, tmp_path):
+        fm = valid_fm()
+        fm["title"] = "DCO Auto-Fix Workflow — /fix-dco Command Design & Implementation"
+        p = make_lesson(tmp_path, fm, long_content())
+        errors = validate_file(p, REPO)
+        assert any("duplicate" in e.lower() for e in errors)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+class TestCli:
+    def test_exit_zero_on_valid(self, tmp_path):
+        p = make_lesson(tmp_path, valid_fm(), long_content())
+        r = subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "lesson_gate.py"), str(p)],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0, r.stdout + r.stderr
+
+    def test_exit_one_on_invalid(self, tmp_path):
+        p = tmp_path / "bad.md"
+        p.write_text("---\n{title: 'x'}\n---\nshort", encoding="utf-8")
+        r = subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "lesson_gate.py"), str(p)],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 1


### PR DESCRIPTION
## Summary
Adds an automated structural quality gate for new lesson contributions. Closes #889.

## What it validates
- **Required frontmatter fields**: `title`, `domain`, `tags`, `status`, `evidence_level`
- **Minimum content length**: 100 chars (excluding frontmatter)
- **No duplicate titles** (checked against existing lessons in `lessons/core|contrib|en`)
- **Domain in allowed list** (`docs/domains/` + domains already used by existing lessons)
- **Tags format**: 1-10 unique strings, min 2 chars
- **status** ∈ published/draft/archived; **evidence_level** ∈ E0-E4

## Files
- `scripts/lesson_gate.py` — the validator (stdlib only, no new deps)
- `tests/test_lesson_gate.py` — 40 unit tests (TDD: red → green → refactor)
- `.github/workflows/lesson-gate.yml` — CI on PRs touching `lessons/**`, runs the gate on changed files and comments the result

## Usage
```bash
python3 scripts/lesson_gate.py lessons/contrib/foo.md   # validate one
python3 scripts/lesson_gate.py --all                    # validate all lessons
python3 scripts/lesson_gate.py --json <file>            # JSON report
```

## Verification
- 40/40 tests pass locally
- Gate is strict by design: 336/336 existing lessons currently lack `evidence_level`, which is why CI only checks **changed** files in a PR — new contributions must meet the standard, existing content is not retroactively blocked