### PR TITLE
feat: absorb UX journey report findings into docs and MCP server guidance (Closes #868)

### DIFF
--- a/docs/maintainer/journey-report-absorption.md
+++ b/docs/maintainer/journey-report-absorption.md
@@ -86,14 +86,14 @@ These are all non-blocking or expected for first-time contributors, but the labe
 
 ## Absorption Status
 
-| Finding | Issue Created | Docs Updated | Lesson Created | Code Fix |
-|---------|--------------|--------------|----------------|----------|
-| UX-1 | ❌ | ❌ | ❌ | ❌ |
-| UX-2 | ❌ | ❌ | ❌ | ❌ |
-| UX-3 | ❌ | ❌ | ❌ | ❌ |
-| UX-4 | ❌ | ❌ | ❌ | ❌ |
-| UX-5 | ❌ | ❌ | ❌ | ❌ |
-| UX-6 | ❌ | ❌ | ❌ | ❌ |
+| Finding | Issue Created | Docs Updated | Lesson Created | Code Fix | Absorbed? |
+|---------|--------------|--------------|----------------|----------|-----------|
+| UX-1 | N/A | ✅ | N/A | N/A | ✅ |
+| UX-2 | N/A | ✅ | N/A | ✅ | ✅ |
+| UX-3 | N/A | ✅ | N/A | N/A | ✅ |
+| UX-4 | Deferred v2.17 | ❌ | ❌ | ❌ | ⏳ Deferred |
+| UX-5 | N/A | ✅ | N/A | N/A | ✅ |
+| UX-6 | N/A | ✅ | N/A | ✅ | ✅ |
 
 ## Next Steps
 

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -146,11 +146,11 @@ def handle_search(args: dict) -> dict:
     if not query:
         return {
             "error": "query is required",
-            "hint": "Try: {"query": "python async", "domain": "core"}",
+            "hint": "Try: {\"query\": \"python async\", \"domain\": \"core\"}",
             "examples": [
-                "{"query": "machine learning"}",
-                "{"query": "REST API", "top": 3}",
-                "{"query": "tutorial", "domain": "core"}"
+                "{\"query\": \"machine learning\"}",
+                "{\"query\": \"REST API\", \"top\": 3}",
+                "{\"query\": \"tutorial\", \"domain\": \"core\"}"
             ],
             "guidance": "Provide a search term (e.g. 'pip install timeout'). For broader results, try shorter keywords. See docs/integrations/mcp-remote.md for usage examples."
         }
@@ -190,10 +190,10 @@ def handle_get_lesson(args: dict) -> dict:
     if not path_or_id:
         return {
             "error": "path or id is required",
-            "hint": "Try: {"path": "lessons/core/welcome.md"} or {"id": "welcome"}",
+            "hint": "Try: {\"path\": \"lessons/core/welcome.md\"} or {\"id\": \"welcome\"}",
             "examples": [
-                "{"path": "lessons/core/async-python.md"}",
-                "{"id": "async-python"}"
+                "{\"path\": \"lessons/core/async-python.md\"}",
+                "{\"id\": \"async-python\"}"
             ],
             "guidance": "Provide a lesson path (e.g. 'lessons/core/auto-merge-ci-pipeline.md') or lesson ID. Use misakanet_search first to discover available lessons."
         }
@@ -212,7 +212,7 @@ def handle_get_lesson(args: dict) -> dict:
         return {
             "error": f"Lesson not found: {path_or_id}",
             "hint": "Use misakanet_search to find available lessons by keyword",
-            "suggestion": "Try searching with: {"query": "" + path_or_id.replace("-", " ") + ""}",
+            "suggestion": "Try searching with: {\"query\": \"" + path_or_id.replace("-", " ") + "\"}",
             "guidance": f"Use misakanet_search with a related keyword to discover available lessons, or check docs/integrations/mcp-remote.md for the lesson index."
         }
 

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -151,7 +151,8 @@ def handle_search(args: dict) -> dict:
                 "{"query": "machine learning"}",
                 "{"query": "REST API", "top": 3}",
                 "{"query": "tutorial", "domain": "core"}"
-            ]
+            ],
+            "guidance": "Provide a search term (e.g. 'pip install timeout'). For broader results, try shorter keywords. See docs/integrations/mcp-remote.md for usage examples."
         }
 
     if HAS_SAG:
@@ -178,7 +179,8 @@ def handle_search(args: dict) -> dict:
         return {
             "error": "Search engine unavailable — index not built",
             "action": "Run: python3 scripts/build_sag_index.py to enable BM25/SAG search",
-            "fallback": "Browse lessons via misaka://lessons/index resource instead"
+            "fallback": "Browse lessons via misaka://lessons/index resource instead",
+            "guidance": "To obtain a token or search lessons, refer to docs/integrations/mcp-remote.md or contact maintainer."
         }
 
 
@@ -192,7 +194,8 @@ def handle_get_lesson(args: dict) -> dict:
             "examples": [
                 "{"path": "lessons/core/async-python.md"}",
                 "{"id": "async-python"}"
-            ]
+            ],
+            "guidance": "Provide a lesson path (e.g. 'lessons/core/auto-merge-ci-pipeline.md') or lesson ID. Use misakanet_search first to discover available lessons."
         }
 
     # Try direct path
@@ -209,7 +212,8 @@ def handle_get_lesson(args: dict) -> dict:
         return {
             "error": f"Lesson not found: {path_or_id}",
             "hint": "Use misakanet_search to find available lessons by keyword",
-            "suggestion": "Try searching with: {"query": "" + path_or_id.replace("-", " ") + ""}"
+            "suggestion": "Try searching with: {"query": "" + path_or_id.replace("-", " ") + ""}",
+            "guidance": f"Use misakanet_search with a related keyword to discover available lessons, or check docs/integrations/mcp-remote.md for the lesson index."
         }
 
     content = lesson_path.read_text(encoding="utf-8", errors="replace")
@@ -226,7 +230,10 @@ def handle_submit_usage(args: dict) -> dict:
     outcome = args.get("outcome", "unknown")
 
     if not lesson_id:
-        return {"error": "lesson_id is required"}
+        return {
+            "error": "lesson_id is required",
+            "guidance": "Provide the lesson ID (e.g. 'auto-merge-ci-pipeline'). Use misakanet_search to discover lesson IDs by topic."
+        }
 
     # For now, just log locally
     report = {


### PR DESCRIPTION
## Summary
Systematically absorb all 6 UX findings from journey reports (#850, #836, #834, #833, #847, #851) into actionable documentation and MCP server error responses.

## UX Absorption Matrix

| Finding | Issue | Status | Evidence |
|---------|-------|--------|----------|
| **UX-1** Token acquisition | #868 | ✅ Absorbed | `docs/integrations/mcp-remote.md` — "Getting a Token" section with 4 options (self-service, manual, public read-only, Glama) |
| **UX-2** Search empty state | #868 | ✅ Absorbed | `scripts/mcp_server.py` — added `guidance` field to empty query + no-engine errors with actionable next steps |
| **UX-3** Post-registration flow | #868 | ✅ Absorbed | `docs/integrations/mcp-remote.md` — integration flow and next steps documented |
| **UX-4** Discovery divergence | #868 | ⏳ Deferred v2.17 | Marked in absorption tracker — needs product decision |
| **UX-5** CI/bot labels misleading | #868 | ✅ Absorbed | `CONTRIBUTING.md` — "Understanding CI Checks" section explaining pr-genius, Workers Builds, auto-merge are non-blocking |
| **UX-6** Error messages lack guidance | #868 | ✅ Absorbed | `scripts/mcp_server.py` — ALL 5 error paths now include structured `guidance` field pointing users to docs/solutions |

## Code Changes

### `scripts/mcp_server.py` — +15/-0 lines
Added actionable `guidance` field to **all 5 error paths**:

| Error | Before | After |
|-------|--------|-------|
| Empty query | `{"error": "query is required"}` | + guidance with example search terms |
| No search engine | `{"error": "..."}` | + guidance pointing to token/docs |
| Missing path/id | `{"error": "path or id is required"}` | + guidance to use misakanet_search first |
| Lesson not found | `{"error": "Lesson not found: ..."}` | + guidance to search by keyword |
| Missing lesson_id | `{"error": "lesson_id is required"}` | + guidance to discover IDs via search |

### `docs/maintainer/journey-report-absorption.md` — matrix updated
Updated absorption status from all ❌ to accuracy: 5× ✅ + 1× ⏳ (UX-4 deferred)

## Verification
- ✅ Syntax errors fixed (JSON strings properly escaped)
- ✅ All error paths include guidance field
- ✅ Documentation updated
- ✅ Rebased onto main with undici 7.29.0 fix

## DCO
- ⏳ Pending — author needs to add Signed-off-by

---
**Supersedes:** #872 (closed due to GitHub caching stale commit SHA)