### PR TITLE
test(mcp): cover lessons.json keyword fallback (Issue #913)

### DIFF
--- a/tests/test_mcp_fallback.py
+++ b/tests/test_mcp_fallback.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for the lessons.json keyword fallback (Issue #913).
+
+When neither SAG-Lite nor BM25 is available, the MCP search tool falls
+back to keyword matching over data/lessons.json (implemented in
+mcp_server._fallback_search) and reports source "fallback" so callers
+can distinguish the three modes. These tests pin the behaviour and
+prevent regressions in the sandbox fallback path.
+"""
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import pytest
+
+import scripts.mcp_server as mcp
+
+
+@pytest.fixture(autouse=True)
+def no_engines(monkeypatch):
+    """Force both SAG-Lite and BM25 to be unavailable."""
+    monkeypatch.setattr(mcp, "HAS_SAG", False)
+    monkeypatch.setattr(mcp, "HAS_BM25", False)
+    yield
+
+
+def test_fallback_returns_results_instead_of_error():
+    resp = mcp.handle_search({"query": "MCP", "top": 5})
+    assert "error" not in resp
+    assert "results" in resp
+    assert resp["source"] == "fallback"
+
+
+def test_fallback_source_is_distinct():
+    """The source field must be exactly 'fallback' (not sag-lite/bm25)."""
+    resp = mcp.handle_search({"query": "MCP", "top": 3})
+    assert resp["source"] == "fallback"
+
+
+def test_fallback_results_have_lesson_shape():
+    """Fallback results carry the documented shape (title/path/domain)."""
+    resp = mcp.handle_search({"query": "sandbox", "top": 3})
+    for r in resp["results"]:
+        assert isinstance(r, dict)
+        assert "title" in r
+        assert "path" in r
+        assert "domain" in r
+
+
+def test_fallback_matches_real_content():
+    """A query for a real lesson topic must return a relevant hit."""
+    resp = mcp.handle_search({"query": "release notes", "top": 5})
+    assert resp["results"], "expected at least one hit for 'release notes'"
+    top = resp["results"][0]
+    blob = " ".join(str(v).lower() for v in top.values())
+    assert "release" in blob or "notes" in blob
+
+
+def test_fallback_respects_top_limit():
+    resp = mcp.handle_search({"query": "MCP", "top": 2})
+    assert len(resp["results"]) <= 2
+
+
+def test_fallback_empty_query_is_rejected():
+    resp = mcp.handle_search({"query": "", "top": 5})
+    assert "error" in resp
+
+
+def test_fallback_domain_filter():
+    """A domain filter narrows the fallback results."""
+    resp = mcp.handle_search({"query": "MCP", "top": 20, "domain": "core"})
+    for r in resp["results"]:
+        assert r.get("domain") == "core"
+
+
+def test_sag_still_preferred_when_available(monkeypatch):
+    """With SAG available, the source must be sag-lite (no fallback)."""
+    monkeypatch.setattr(mcp, "HAS_SAG", True)
+    monkeypatch.setattr(mcp, "SAG_DB", Path("/nonexistent/sag.db"))
+
+    def fake_sag(db, query, domain=None, top=5):
+        return [{"id": "x", "title": query}]
+
+    monkeypatch.setattr(mcp, "sag_search", fake_sag)
+    resp = mcp.handle_search({"query": "MCP", "top": 5})
+    assert resp["source"] == "sag-lite"


### PR DESCRIPTION
Closes #913

## Context
The sandbox fallback path (`mcp_server._fallback_search`) returns `source: "fallback"` when SAG-Lite and BM25 are both unavailable, but had **no test coverage**. This PR pins the behaviour so the fallback doesn't regress.

## Changes
- **tests/test_mcp_fallback.py** (new): 8 tests covering
  - fallback returns results instead of error
  - source field distinction (sag-lite / bm25 / fallback)
  - result shape (title/path/domain)
  - real-content relevance (query for an actual lesson topic)
  - top-N limit
  - empty-query rejection
  - domain filter narrowing results
  - SAG still preferred when available

## Verification
- `pytest tests/test_mcp_fallback.py tests/test_mcp_server.py` → **17 passed** (8 new + 9 existing smoke tests)