### PR TITLE
test: stress MCP endpoint under concurrent load

### DIFF
--- a/.github/workflows/mcp-stress.yml
+++ b/.github/workflows/mcp-stress.yml
@@ -1,0 +1,46 @@
+name: MCP Endpoint Stress Tests
+
+on:
+  pull_request:
+    paths:
+      - "workers/register-proxy-sw.js"
+      - "workers/mcp-endpoint.stress.test.mjs"
+      - ".github/workflows/mcp-stress.yml"
+  push:
+    branches: [main]
+    paths:
+      - "workers/register-proxy-sw.js"
+      - "workers/mcp-endpoint.stress.test.mjs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Run MCP stress suite
+        run: |
+          set -o pipefail
+          node --expose-gc --test workers/mcp-endpoint.stress.test.mjs 2>&1 | tee mcp-stress-results.txt
+      - name: Publish performance metrics
+        if: always()
+        run: |
+          {
+            echo "## MCP stress metrics"
+            echo '```json'
+            grep 'MCP_STRESS_METRIC' mcp-stress-results.txt | sed 's/^.*MCP_STRESS_METRIC //' || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload stress results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: mcp-stress-results
+          path: mcp-stress-results.txt

--- a/workers/mcp-endpoint.stress.test.mjs
+++ b/workers/mcp-endpoint.stress.test.mjs
@@ -1,0 +1,115 @@
+// Deterministic in-process stress tests for POST /mcp (issue #910).
+// Run: node --expose-gc --test workers/mcp-endpoint.stress.test.mjs
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import test from 'node:test';
+import worker, { MAX_MCP_REQUEST_BYTES } from './register-proxy-sw.js';
+
+const TOKEN = 'stress-test-token';
+const env = { MCP_TOKEN: TOKEN, MCP_VERSION: 'stress-test' };
+const metrics = [];
+
+function mcpRequest(body, headers = {}) {
+  return new Request('https://misakanet.org/mcp', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function initialize(id) {
+  return mcpRequest({
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: { protocolVersion: '2025-06-18' },
+  });
+}
+
+async function runBatch(count) {
+  const started = performance.now();
+  const responses = await Promise.all(
+    Array.from({ length: count }, (_, id) => worker.fetch(initialize(id), env)),
+  );
+  const elapsedMs = performance.now() - started;
+  return { responses, elapsedMs, requestsPerSecond: count / (elapsedMs / 1000) };
+}
+
+test('serves 100 concurrent MCP connections with valid, isolated responses', async () => {
+  const { responses, elapsedMs, requestsPerSecond } = await runBatch(100);
+  const bodies = await Promise.all(responses.map((response) => response.json()));
+
+  assert.ok(responses.every((response) => response.status === 200));
+  assert.deepEqual(bodies.map((body) => body.id), Array.from({ length: 100 }, (_, id) => id));
+  assert.ok(bodies.every((body) => body.result?.serverInfo?.name === 'misakanet'));
+
+  metrics.push({ scenario: '100-concurrent', requests: 100, elapsedMs, requestsPerSecond });
+});
+
+test('rejects oversized payloads with and without a Content-Length hint', async () => {
+  const oversized = JSON.stringify({
+    jsonrpc: '2.0', id: 1, method: 'tools/list', padding: 'x'.repeat(MAX_MCP_REQUEST_BYTES),
+  });
+
+  const declared = await worker.fetch(mcpRequest('{}', {
+    'content-length': String(MAX_MCP_REQUEST_BYTES + 1),
+  }), env);
+  const measured = await worker.fetch(mcpRequest(oversized), env);
+
+  assert.equal(declared.status, 413);
+  assert.equal(measured.status, 413);
+  assert.match((await measured.json()).error.message, /Request too large/);
+});
+
+test('returns stable errors under mixed invalid load', async () => {
+  const requests = Array.from({ length: 100 }, (_, id) => {
+    if (id % 2 === 0) return mcpRequest('{not-json');
+    return new Request('https://misakanet.org/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/list' }),
+    });
+  });
+  const responses = await Promise.all(requests.map((request) => worker.fetch(request, env)));
+
+  assert.equal(responses.filter((response) => response.status === 400).length, 50);
+  assert.equal(responses.filter((response) => response.status === 401).length, 50);
+});
+
+test('repeated concurrent batches retain no unbounded heap', { skip: !global.gc }, async () => {
+  await runBatch(100); // warm runtime allocations before measuring
+  global.gc();
+  const baseline = process.memoryUsage().heapUsed;
+
+  for (let batch = 0; batch < 10; batch += 1) {
+    const { responses } = await runBatch(100);
+    await Promise.all(responses.map((response) => response.arrayBuffer()));
+  }
+  global.gc();
+
+  const finalHeap = process.memoryUsage().heapUsed;
+  const heapDeltaBytes = finalHeap - baseline;
+  const allowedHeapGrowthBytes = 32 * 1024 * 1024;
+  metrics.push({
+    scenario: 'memory-retention',
+    requests: 1000,
+    baselineHeapBytes: baseline,
+    finalHeapBytes: finalHeap,
+    heapDeltaBytes,
+    allowedHeapGrowthBytes,
+  });
+  assert.ok(
+    heapDeltaBytes <= allowedHeapGrowthBytes,
+    `heap grew by ${heapDeltaBytes} bytes (limit ${allowedHeapGrowthBytes})`,
+  );
+});
+
+test.after(() => {
+  for (const metric of metrics) {
+    console.log(`MCP_STRESS_METRIC ${JSON.stringify(metric)}`);
+  }
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -83,6 +83,7 @@ const MCP_TOOLS = [
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2026-07-28"];
+const MAX_MCP_REQUEST_BYTES = 64 * 1024;
 
 function getMcpServerInfo(env) {
   return {
@@ -304,8 +305,28 @@ async function handleMcpRequest(request, env) {
     );
   }
 
-  // 4. Parse JSON-RPC body
-  const body = await request.json().catch(() => null);
+  // 4. Bound and parse the JSON-RPC body. Do not trust Content-Length alone:
+  // clients using chunked transfer encoding may omit it.
+  const declaredLength = Number.parseInt(request.headers.get("content-length") || "0", 10);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_MCP_REQUEST_BYTES) {
+    return mcpJsonResponse({
+      jsonrpc: "2.0", id: null,
+      error: { code: -32600, message: `Request too large (max ${MAX_MCP_REQUEST_BYTES} bytes)` },
+    }, 413);
+  }
+
+  const rawBody = await request.text().catch(() => null);
+  if (rawBody !== null && new TextEncoder().encode(rawBody).byteLength > MAX_MCP_REQUEST_BYTES) {
+    return mcpJsonResponse({
+      jsonrpc: "2.0", id: null,
+      error: { code: -32600, message: `Request too large (max ${MAX_MCP_REQUEST_BYTES} bytes)` },
+    }, 413);
+  }
+
+  let body = null;
+  try {
+    body = rawBody === null ? null : JSON.parse(rawBody);
+  } catch {}
   if (!body) {
     return mcpJsonResponse({
       jsonrpc: "2.0", id: null,
@@ -1302,6 +1323,7 @@ async function getCode() {
 // Named exports for unit tests only (workers/unsolved-map.test.mjs). Wrangler
 // deploys this file for its default export; the extra exports are inert there.
 export {
+  MAX_MCP_REQUEST_BYTES,
   UNSOLVED_FAMILY_WHITELIST,
   UNSOLVED_REASONS,
   UNSOLVED_WINDOW_DAYS,


### PR DESCRIPTION
## Summary
- add deterministic stress coverage for 100 concurrent `/mcp` requests
- enforce a 64 KiB request limit using both declared and measured body size
- exercise stable malformed/auth failures under mixed load
- detect retained heap growth across 1,000 requests
- collect throughput and heap metrics in a dedicated CI workflow/artifact

## Validation
- `node --expose-gc --test workers/mcp-endpoint.stress.test.mjs` (4/4 passed)
- `node --test workers/register-proxy.test.mjs workers/unsolved-map.test.mjs` (28/28 passed)
- `python3 scripts/check_worker_secrets.py` (0 errors)

Local stress result: 100 concurrent requests in 70.0 ms (~1,428 req/s); retained heap delta 520,504 bytes after 1,000 requests (32 MiB ceiling).

Closes #910

/claim #910

Signed-off-by: 2lll5 <2lll5@users.noreply.github.com>