### PR TITLE
feat(voice): add Windows support for voice hook script

### DIFF
--- a/scripts/misakanet_voice_hook.bat
+++ b/scripts/misakanet_voice_hook.bat
@@ -1,0 +1,39 @@
+@echo off
+REM MisakaNet Voice Hook for Windows
+REM Plays audio prompts when MCP tools return voice hints.
+REM
+REM Usage in Claude Code settings.json:
+REM   "PostToolUse": [{
+REM     "hooks": [{
+REM       "type": "command",
+REM       "command": "C:\path\to\MisakaNet\scripts\misakanet_voice_hook.bat"
+REM     }]
+REM   }]
+
+setlocal enabledelayedexpansion
+
+REM Get script directory
+set "SCRIPT_DIR=%~dp0"
+set "VOICE_DIR=%SCRIPT_DIR%..\docs\voice"
+
+REM Read stdin (tool result JSON)
+set "INPUT="
+for /f "delims=" %%a in ('more') do set "INPUT=!INPUT! %%a"
+
+REM Extract voice field using python
+for /f "tokens=*" %%a in ('echo !INPUT! ^| python -c "import sys,json; d=json.load(sys.stdin); print(d.get('voice',''))" 2^>nul') do set "VOICE=%%a"
+
+if "!VOICE!"=="" exit /b 0
+
+REM Map voice name to file
+if "!VOICE!"=="connect-success" set "FILE=%VOICE_DIR%\connect-success.mp3"
+if "!VOICE!"=="pair-success" set "FILE=%VOICE_DIR%\pair-success.mp3"
+if "!VOICE!"=="lesson-found" set "FILE=%VOICE_DIR%\lesson-found.mp3"
+if "!VOICE!"=="failure-warning" set "FILE=%VOICE_DIR%\failure-warning.mp3"
+
+if not exist "!FILE!" exit /b 0
+
+REM Play audio using PowerShell (non-blocking)
+powershell -Command "Start-Process -FilePath '!FILE!' -WindowStyle Hidden" 2>nul
+
+exit /b 0

--- a/scripts/misakanet_voice_hook.ps1
+++ b/scripts/misakanet_voice_hook.ps1
@@ -1,0 +1,58 @@
+# MisakaNet Voice Hook for Windows (PowerShell)
+# Plays audio prompts when MCP tools return voice hints.
+#
+# Usage in Claude Code settings.json:
+#   "PostToolUse": [{
+#     "hooks": [{
+#       "type": "command",
+#       "command": "pwsh -File C:\path\to\MisakaNet\scripts\misakanet_voice_hook.ps1"
+#     }]
+#   }]
+
+param()
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Get script directory
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$VoiceDir = Join-Path (Split-Path -Parent $ScriptDir) "docs\voice"
+
+# Read stdin (tool result JSON)
+$Input = [Console]::In.ReadToEnd()
+
+# Extract voice field
+try {
+    $Data = $Input | ConvertFrom-Json
+    $Voice = $Data.voice
+} catch {
+    exit 0
+}
+
+if ([string]::IsNullOrEmpty($Voice)) { exit 0 }
+
+# Map voice name to file
+$FileMap = @{
+    "connect-success" = "connect-success.mp3"
+    "pair-success" = "pair-success.mp3"
+    "lesson-found" = "lesson-found.mp3"
+    "failure-warning" = "failure-warning.mp3"
+}
+
+if (-not $FileMap.ContainsKey($Voice)) { exit 0 }
+
+$FileName = $FileMap[$Voice]
+$FilePath = Join-Path $VoiceDir $FileName
+
+if (-not (Test-Path $FilePath)) { exit 0 }
+
+# Play audio using Windows Media Player (non-blocking)
+try {
+    $Player = New-Object System.Media.SoundPlayer
+    $Player.SoundLocation = $FilePath
+    $Player.Play()
+} catch {
+    # Fallback: use Start-Process
+    Start-Process -FilePath $FilePath -WindowStyle Hidden
+}
+
+exit 0

--- a/scripts/misakanet_voice_hook.sh
+++ b/scripts/misakanet_voice_hook.sh
@@ -44,9 +44,18 @@ esac
 
 # Play audio (non-blocking, suppress errors from headless environments)
 if command -v afplay &>/dev/null; then
+    # macOS
     afplay "$FILE" &>/dev/null &
 elif command -v aplay &>/dev/null; then
+    # Linux (ALSA)
     aplay "$FILE" &>/dev/null &
 elif command -v paplay &>/dev/null; then
+    # Linux (PulseAudio)
     paplay "$FILE" &>/dev/null &
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    # Windows (Git Bash / MSYS2)
+    powershell -Command "Start-Process -FilePath '$FILE' -WindowStyle Hidden" &>/dev/null &
+elif command -v powershell.exe &>/dev/null; then
+    # Windows (WSL)
+    powershell.exe -Command "Start-Process -FilePath '$(wslpath -w "$FILE")' -WindowStyle Hidden" &>/dev/null &
 fi


### PR DESCRIPTION
## Summary

Add Windows support for the voice hook script, enabling Voice Prompts functionality on Windows.

## Changes

### New Files
- **scripts/misakanet_voice_hook.bat** — Windows batch script
- **scripts/misakanet_voice_hook.ps1** — PowerShell script

### Updated Files
- **scripts/misakanet_voice_hook.sh** — Added Windows detection (MSYS2/Cygwin/WSL)

## Windows Support

| Environment | Script | Audio Player |
|-------------|--------|--------------|
| macOS | misakanet_voice_hook.sh | afplay |
| Linux (ALSA) | misakanet_voice_hook.sh | aplay |
| Linux (PulseAudio) | misakanet_voice_hook.sh | paplay |
| Windows (Git Bash/MSYS2) | misakanet_voice_hook.sh | PowerShell |
| Windows (WSL) | misakanet_voice_hook.sh | powershell.exe |
| Windows (native) | misakanet_voice_hook.bat | PowerShell |
| Windows (PowerShell) | misakanet_voice_hook.ps1 | System.Media.SoundPlayer |

## Usage

### Option 1: PowerShell (Recommended)
Add to :



### Option 2: Batch Script


### Option 3: Bash (Git Bash/MSYS2/WSL)


## Testing

Tested on Windows 11 with PowerShell:
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows

PS C:\Users\hp\MisakaNet> 

---
**Related:** #912, #928, #930