### PR TITLE
feat(connect): mobile responsive layout for small screens

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -127,6 +127,21 @@
     .footer a { color: var(--accent); text-decoration: none; }
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
     .pulse { animation: pulse 2s ease-in-out infinite; }
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    body { padding: 1rem; }
+    .card { padding: 20px; }
+    .pair-code { font-size: 2rem; letter-spacing: 0.2em; }
+    .btn { padding: 12px 20px; font-size: 14px; min-height: 44px; }
+  }
+  @media (max-width: 480px) {
+    body { padding: 0.75rem; }
+    .card { padding: 16px; }
+    .pair-code { font-size: 1.5rem; letter-spacing: 0.15em; }
+    .voice-toggle { padding: 10px; }
+    .btn { padding: 10px 16px; font-size: 13px; min-height: 48px; }
+    .toggle { min-width: 44px; min-height: 44px; }
+  }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Fixes #904
- Add mobile responsive CSS to the Connect page
- Pair code and controls scale down on tablets and phones
- Touch targets ≥44px on mobile for accessibility

## Changes
- 768px breakpoint: reduce card padding and pair code size
- 480px breakpoint: further reduce, ensure touch targets

## Test plan
- [ ] Open `/connect` on desktop (unchanged layout)
- [ ] Resize to tablet width (768px): card should fit without horizontal scroll
- [ ] Resize to phone width (480px): all controls accessible, no overlap
- [ ] Test on actual phone: voice toggle and buttons tappable

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>
Signed-off-by: Ikalus1988 <Ikalus1988@users.noreply.github.com>