### PR TITLE
test(bench): add SAG-Lite performance benchmark suite

### DIFF
--- a/scripts/benchmark_sag_lite.py
+++ b/scripts/benchmark_sag_lite.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""SAG-Lite performance benchmark — Issue #909.
+
+Measures build time, per-query latency, throughput and top-1 accuracy of the
+SAG-Lite FTS index, and compares it against the lessons.json keyword fallback
+used by the MCP server. Results are written as JSON for reproducible baselines.
+
+Usage:
+    python3 scripts/benchmark_sag_lite.py
+    python3 scripts/benchmark_sag_lite.py --json
+    python3 scripts/benchmark_sag_lite.py --queries 25 --top 5
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts.build_sag_index import build_index, search as sag_search
+
+DEFAULT_OKF = REPO / "data" / "okf"
+DEFAULT_DB = REPO / "data" / "sag-bench.db"
+DEFAULT_QUERIES = 20
+DEFAULT_TOP = 5
+
+# Queries drawn from real lesson topics so accuracy is meaningful.
+BENCH_QUERIES = [
+    "MCP server",
+    "playwright",
+    "release notes",
+    "Docker",
+    "GPU",
+    "WSL",
+    "error handling",
+    "web scraping",
+    "security",
+    "automation",
+    "CI pipeline",
+    "knowledge base",
+    "lesson quality",
+    "Linux",
+    "Python",
+    "cache",
+    "search index",
+    "cloudflare",
+    "frontend",
+    "API endpoint",
+]
+
+
+def measure_latency(search_fn, queries, top):
+    """Run each query once, returning per-query latencies (ms)."""
+    latencies = []
+    for q in queries:
+        start = time.perf_counter()
+        search_fn(q, top=top)
+        latencies.append((time.perf_counter() - start) * 1000.0)
+    return latencies
+
+
+def fallback_search(lessons, query, top=5):
+    """Keyword fallback mirroring mcp_server._fallback_search scoring.
+
+    Scores each lesson by the number of query terms found across title,
+    summary, domain and tags; returns the top-N by score.
+    """
+    terms = [t.lower() for t in query.split() if t.strip()]
+    scored = []
+    for lesson in lessons:
+        blob = " ".join(
+            str(lesson.get(k, "")) for k in ("title", "summary", "domain", "tags")
+        ).lower()
+        score = sum(1 for t in terms if t in blob)
+        if score > 0:
+            scored.append((score, lesson))
+    scored.sort(key=lambda pair: (-pair[0], str(pair[1].get("id", ""))))
+    return [lesson for _, lesson in scored[:top]]
+
+
+def load_lessons_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run_benchmark(okf_path, db_path, queries, top, keep_db):
+    """Run the full benchmark and return the results dict."""
+    okf_path = Path(okf_path)
+    db_path = Path(db_path)
+
+    # 1. Build the SAG-Lite index (timed)
+    build_start = time.perf_counter()
+    build_index(okf_path, db_path)
+    build_secs = time.perf_counter() - build_start
+
+    # 2. SAG-Lite latency
+    sag_lat = measure_latency(
+        lambda q, top=top: sag_search(db_path, q, top=top), queries, top
+    )
+
+    # 3. Fallback latency + accuracy comparison
+    lessons = load_lessons_json(REPO / "data" / "lessons.json")
+    fb_lat = measure_latency(
+        lambda q, top=top: fallback_search(lessons, q, top=top), queries, top
+    )
+
+    # 4. Accuracy: does SAG top-1 equal fallback top-1 for each query?
+    # SAG returns `path` (e.g. lessons/contrib/x.md); the fallback returns
+    # the lessons.json record with a `url`. Normalize both to the lesson
+    # slug (basename without extension) before comparing.
+    def lesson_slug(value: str | None) -> str | None:
+        if not value:
+            return None
+        return Path(str(value).rstrip("/")).stem
+
+    top1_match = 0
+    for q in queries:
+        sag_top = sag_search(db_path, q, top=1)
+        fb_top = fallback_search(lessons, q, top=1)
+        sag_id = lesson_slug(sag_top[0]["path"]) if sag_top else None
+        fb_id = lesson_slug(fb_top[0].get("url") or fb_top[0].get("path")) if fb_top else None
+        if sag_id and sag_id == fb_id:
+            top1_match += 1
+
+    results = {
+        "queries": len(queries),
+        "top": top,
+        "build_secs": round(build_secs, 3),
+        "sag_latency_ms": {
+            "mean": round(sum(sag_lat) / len(sag_lat), 3),
+            "min": round(min(sag_lat), 3),
+            "max": round(max(sag_lat), 3),
+        },
+        "fallback_latency_ms": {
+            "mean": round(sum(fb_lat) / len(fb_lat), 3),
+            "min": round(min(fb_lat), 3),
+            "max": round(max(fb_lat), 3),
+        },
+        "sag_throughput_qps": round(len(queries) / (sum(sag_lat) / 1000.0), 2),
+        "top1_agreement_with_fallback": f"{top1_match}/{len(queries)}",
+    }
+
+    if not keep_db and db_path.exists():
+        db_path.unlink()
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SAG-Lite performance benchmark (#909)")
+    parser.add_argument("--okf", default=str(DEFAULT_OKF), help="OKF lessons.jsonl path")
+    parser.add_argument("--db", default=str(DEFAULT_DB), help="SQLite output path")
+    parser.add_argument("--queries", type=int, default=DEFAULT_QUERIES, help="number of queries")
+    parser.add_argument("--top", type=int, default=DEFAULT_TOP, help="results per query")
+    parser.add_argument("--json", action="store_true", help="output raw JSON")
+    parser.add_argument("--keep-db", action="store_true", help="keep the built index after run")
+    args = parser.parse_args()
+
+    queries = BENCH_QUERIES[: args.queries]
+    results = run_benchmark(args.okf, args.db, queries, args.top, args.keep_db)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        print(f"SAG-Lite benchmark ({results['queries']} queries, top {results['top']}):")
+        print(f"  build:            {results['build_secs']}s")
+        print(f"  SAG latency:      {results['sag_latency_ms']['mean']}ms mean "
+              f"({results['sag_latency_ms']['min']}-{results['sag_latency_ms']['max']})")
+        print(f"  fallback latency: {results['fallback_latency_ms']['mean']}ms mean "
+              f"({results['fallback_latency_ms']['min']}-{results['fallback_latency_ms']['max']})")
+        print(f"  SAG throughput:   {results['sag_throughput_qps']} qps")
+        print(f"  top-1 agreement:  {results['top1_agreement_with_fallback']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_benchmark_sag_lite.py
+++ b/tests/test_benchmark_sag_lite.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Tests for the SAG-Lite benchmark script (Issue #909).
+
+The benchmark runs a real SQLite build + queries, so tests use a tiny
+synthetic OKF corpus and a temp DB to keep them fast and hermetic.
+"""
+import json
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+import pytest
+
+from scripts.benchmark_sag_lite import (
+    BENCH_QUERIES,
+    fallback_search,
+    load_lessons_json,
+    measure_latency,
+    run_benchmark,
+)
+
+
+@pytest.fixture
+def tiny_okf(tmp_path):
+    """A tiny OKF lessons.jsonl with two lessons."""
+    lines = [
+        json.dumps({"id": "mcp", "title": "MCP server guide", "domain": "core",
+                    "tags": ["mcp"], "summary": "Build an MCP server", "path": "lessons/core/mcp.md"}),
+        json.dumps({"id": "gpu", "title": "GPU setup", "domain": "core",
+                    "tags": ["gpu"], "summary": "Configure GPU drivers", "path": "lessons/core/gpu.md"}),
+    ]
+    d = tmp_path / "okf"
+    d.mkdir()
+    (d / "lessons.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def tiny_lessons_json(tmp_path):
+    """lessons.json mirroring the fixture lessons (for fallback)."""
+    lessons = [
+        {"id": "mcp", "title": "MCP server guide", "domain": "core",
+         "tags": ["mcp"], "summary": "Build an MCP server", "path": "lessons/core/mcp.md"},
+        {"id": "gpu", "title": "GPU setup", "domain": "core",
+         "tags": ["gpu"], "summary": "Configure GPU drivers", "path": "lessons/core/gpu.md"},
+    ]
+    p = tmp_path / "lessons.json"
+    p.write_text(json.dumps(lessons), encoding="utf-8")
+    return p
+
+
+class TestFallbackSearch:
+    def test_matches_by_term(self, tiny_lessons_json):
+        lessons = json.loads(tiny_lessons_json.read_text())
+        results = fallback_search(lessons, "MCP server", top=5)
+        assert results
+        assert results[0]["id"] == "mcp"
+
+    def test_top_limit_respected(self, tiny_lessons_json):
+        lessons = json.loads(tiny_lessons_json.read_text())
+        assert len(fallback_search(lessons, "core", top=1)) <= 1
+
+    def test_no_match_returns_empty(self, tiny_lessons_json):
+        lessons = json.loads(tiny_lessons_json.read_text())
+        assert fallback_search(lessons, "zzzznope", top=5) == []
+
+
+class TestMeasureLatency:
+    def test_returns_one_entry_per_query(self):
+        calls = []
+        lat = measure_latency(lambda q, top=5: calls.append(q), ["a", "b"], 5)
+        assert len(lat) == 2
+        assert all(isinstance(x, float) for x in lat)
+
+    def test_zero_cost_fn_still_returns_numbers(self):
+        lat = measure_latency(lambda q, top=5: None, ["a", "b", "c"], 5)
+        assert len(lat) == 3
+        assert all(x >= 0 for x in lat)
+
+
+class TestRunBenchmark:
+    def test_full_benchmark_produces_expected_shape(self, tmp_path, tiny_okf, tiny_lessons_json):
+        # Point the fallback at the tiny lessons.json by monkeypatching REPO
+        import scripts.benchmark_sag_lite as bench
+
+        db = tmp_path / "sag-bench.db"
+        # run_benchmark reads REPO/data/lessons.json — patch the module's REPO
+        # so load_lessons_json uses our fixture dir.
+        fake_repo = tmp_path
+        (fake_repo / "data").mkdir(exist_ok=True)
+        (fake_repo / "data" / "lessons.json").write_text(tiny_lessons_json.read_text(), encoding="utf-8")
+
+        monkeypatch_repo = lambda: None
+        bench.REPO = fake_repo
+
+        results = run_benchmark(tiny_okf, db, ["MCP server", "GPU setup"], 5, keep_db=False)
+
+        assert "build_secs" in results
+        assert "sag_latency_ms" in results
+        assert "fallback_latency_ms" in results
+        assert "sag_throughput_qps" in results
+        assert results["queries"] == 2
+        assert results["sag_latency_ms"]["mean"] >= 0
+        assert not db.exists(), "benchmark must clean up its temp DB by default"
+
+    def test_queries_are_meaningful_topics(self):
+        assert len(BENCH_QUERIES) >= 10
+        assert all(isinstance(q, str) and q.strip() for q in BENCH_QUERIES)


### PR DESCRIPTION
Closes #909

## Goal
Benchmark suite for SAG-Lite search performance (issue #909): latency, throughput, and comparison against the lessons.json keyword fallback.

## Changes
- **scripts/benchmark_sag_lite.py** (new):
  - timed FTS5 index build from the OKF bundle
  - per-query latency (mean/min/max) for SAG-Lite vs the keyword fallback (mirroring `mcp_server._fallback_search` scoring)
  - throughput (qps) and top-1 agreement between the two paths
  - table or `--json` output for reproducible baselines; temp DB cleaned up unless `--keep-db`
- **tests/test_benchmark_sag_lite.py** (new): 7 hermetic tests (tiny synthetic corpus + temp DB) covering fallback scoring, latency measurement, result shape, DB cleanup, and query sanity

## Verified (real corpus)
- build: 0.005s · SAG latency: 0.42ms mean (vs fallback 0.57ms) · throughput: ~2.4k qps
- top-1 agreement: 6/20 (different algorithms — expected; the numbers give a reproducible baseline for future tuning)
- `pytest tests/test_benchmark_sag_lite.py` → **7 passed**