### PR TITLE
feat: add 2 more original failure-recovery lessons (rate-limit auth, cross-repo schema coupling)

### DIFF
--- a/lessons/contrib/github-rate-limit-auth.md
+++ b/lessons/contrib/github-rate-limit-auth.md
@@ -1,0 +1,57 @@
+---
+{
+  "title": "GitHub rate limiting hitting unauthenticated searches during automation",
+  "domain": "network",
+  "tags": [
+    "github",
+    "rate-limit",
+    "api",
+    "automation",
+    "token"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# GitHub rate limiting hitting unauthenticated searches during automation
+
+## Problem
+
+A script that queries the GitHub API for issue/PR metadata suddenly returned `API rate limit exceeded` for the shared egress IP, even though the script had never hit the limit before. Local manual `curl` calls succeeded intermittently, making the failure appear random.
+
+## Root Cause
+
+The requests were unauthenticated, so they shared the anonymous per-IP quota (60 requests/hour) instead of the authenticated per-user quota. A burst of search calls (`/search/issues`, which is a separate, stricter budget) from the same egress IP exhausted the shared bucket. GitHub search endpoints have their own low limit (10/minute unauthenticated), which is easy to blow through in a loop.
+
+## Solution
+
+Authenticate every API call so you get the 5000/hour budget, and tune search call frequency.
+
+### Step 1
+Send an authorization header on every request:
+```bash
+curl -H "Authorization: Bearer $GHTOKEN" https://api.github.com/search/issues?q=repo:org/repo
+```
+
+### Step 2
+Verify the real budget before assuming a bug:
+```bash
+curl -H "Authorization: Bearer $GHTOKEN" https://api.github.com/rate_limit | jq .resources.core
+```
+`remaining` should be ~5000, not 60.
+
+### Step 3
+Throttle search queries (10/min max, even authenticated) and add retry/backoff so a temporary limit does not kill the whole run.
+
+## Verification
+
+1. `rate_limit` shows `core.remaining` near 5000 after adding the header.
+2. Search loop completes without `403/429`.
+3. Re-run survives consecutive calls with no limit errors.
+
+## Notes
+
+A stale or invalid token produces `Bad credentials` (401), which is different from `rate limit exceeded` (403/429). Check which one you are actually seeing before changing code. Keep the token out of logs and source — inject it via environment, never inline in the repo.

--- a/lessons/contrib/schema-coupled-cross-repo-ci.md
+++ b/lessons/contrib/schema-coupled-cross-repo-ci.md
@@ -1,0 +1,53 @@
+---
+{
+  "title": "Schemas coupled across repos break CI until the counterpart PR merges",
+  "domain": "development",
+  "tags": [
+    "schema",
+    "ci",
+    "pr",
+    "validation",
+    "maintenance"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# Schemas coupled across repos break CI until the counterpart PR merges
+
+## Problem
+
+A data repository changed a CSV header (e.g. renaming a column) and its CI failed with `'old_name' is a required property` / `Additional properties are not allowed ('new_name')`. The data change was valid; the validator being used came from a sibling tooling repo that still expected the old schema. No amount of data-side fixing cleared the check.
+
+## Root Cause
+
+The schema and the data lived in different repositories (a `data` repo + a `json-tools`/validator repo). CI on the data repo referenced the tooling repo's validator at its default branch, so the data PR stayed red until the *counterpart* schema PR in the tools repo was merged. Operators misread this as a data bug.
+
+## Solution
+
+Treat schema+data as one atomic change and communicate the pairing.
+
+### Step 1
+Check which repo actually owns the validator before "fixing" data. If a `schema.json`/validator lives upstream, the data change cannot go green alone.
+
+### Step 2
+Open the two PRs as a pair and note the coupling in both PR bodies: "schema-coupled: merge #A with #B".
+
+### Step 3
+If the tools PR is a prerequisite, merge it first, then rebase the data PR onto the new `main` so CI runs against the updated schema.
+
+### Step 4
+Optionally run the validator locally against your branch (extract it from the tools repo) to prove your data passes the target state.
+
+## Verification
+
+1. Data branch passes when pointed at the updated validator/tools branch.
+2. Both PRs merge in dependency order (tools first).
+3. CI is green post-merge for both.
+
+## Notes
+
+A red check is not always your fault — verify whether the failing check is schema-coupled to another repo before rewriting data. Rebase your data PR after the tools PR merges rather than squashing it pre-emptively.


### PR DESCRIPTION
## What changed

Two more original lessons (JSON frontmatter, `evidence_level` E2):

1. **`lessons/contrib/github-rate-limit-auth.md`** — unauthenticated GitHub API search loops hitting the anonymous 60/hr IP quota; fix = authorize every call + tune search frequency.
2. **`lessons/contrib/schema-coupled-cross-repo-ci.md`** — data repo CI stays red until the sibling tools-repo schema PR merges; fix = treat schema+data as one atomic paired change.

Both follow the `lessons/TEMPLATE.md` schema and pass the lesson quality gate validator.

Agent-Type: autonomous
Supported-by: deepseek-v4-flash-free

Signed-off-by: ElevaSync Solutions <elevasyncsolutions@gmail.com>

*I verify these are my original contributions.*
