### PR TITLE
feat: add 3 more original failure-recovery lessons (mergeable_state, contents-API sha, CDN edge cache)

### DIFF
--- a/lessons/contrib/cdn-edge-cache-stale-after-deploy.md
+++ b/lessons/contrib/cdn-edge-cache-stale-after-deploy.md
@@ -1,0 +1,49 @@
+---
+{
+  "title": "CDN edge cache serves stale responses for minutes after deploy",
+  "domain": "network",
+  "tags": [
+    "cdn",
+    "cache",
+    "deployment",
+    "edge",
+    "cloudflare"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# CDN edge cache serves stale responses for minutes after deploy
+
+## Problem
+
+After deploying a fix to a worker script, repeated requests still returned the old behaviour. Verifying the change "didn't work" wasted time until it was realized the CDN edge cache was still serving a stale snapshot.
+
+## Root cause
+
+A CDN (Cloudflare and similar) caches responses at the edge for a configurable TTL (~30–60 s in the observed case). Right after a deploy, the edge node closest to the requester can still hold and serve the previous version. Requests without a cache-busting parameter hit that stale copy, so the freshly deployed logic is invisible to the first several checks.
+
+## Failure & recovery
+
+The mistake was treating the first post-deploy request as a live verification. The recovery is cheap and reliable:
+
+1. Add a random query parameter to force a cache miss: `?x=$RANDOM` (or `?ts=<epoch>`).
+2. Disable browser/edge caching during verification (or use a curl one-shot with a unique query string).
+3. Confirm the routed response carries the new revision before moving on.
+
+## Principle: verify what you just shipped
+
+Deployment verification must bypass the cache for the exact zone you changed. Without this, the engineer "proves" a regression that never existed and can even roll back a good deploy.
+
+## Reusable checklist
+
+- Always assume the edge is stale for the first N seconds/minutes.
+- Use a unique query parameter when confirming behavior.
+- Read `cf-cache-status`/response headers to see whether the reply came from the edge or origin.
+
+## Lesson
+
+"Deployed" and "served" are different states. Cache-bust the verification request, and read the cache-status header, before trusting that your new code is really live.

--- a/lessons/contrib/github-contents-api-sha-required.md
+++ b/lessons/contrib/github-contents-api-sha-required.md
@@ -1,0 +1,48 @@
+---
+{
+  "title": "GitHub contents API edit fails with 422 without the file sha",
+  "domain": "development",
+  "tags": [
+    "github-api",
+    "automation",
+    "rest-api",
+    "file-edit",
+    "scripting"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# GitHub contents API edit fails 422 when the file `sha` is missing
+
+## Problem
+
+A script that updates existing files in a repository through the REST contents API started failing with `422 Validation Failed` and a body that only mentioned `"sha" wasn't supplied`. The script treated edits like an initial create and sent only `message` + `content`.
+
+## Root cause
+
+The GitHub contents API (`PUT /repos/{owner}/{repo}/contents/{path}`) changes behavior depending on whether the file already exists:
+
+- **Create:** only `message` + `content` (+ `branch`) needed.
+- **Update:** must also include the current blob `sha` of the file being overwritten. Omitting it produces exactly that `422` with `"sha" wasn't supplied` — misleading because a create with the same three fields would succeed.
+
+GitHub uses this as an optimistic-concurrency guard: writing the `sha` you fetched ensures you are not silently overwriting a newer version.
+
+## Failure & recovery
+
+The check run reported the HTTP error but not the fix location, so the diagnostic loop stalled until the response body was inspected. The recovery, which succeeds in one round trip each time:
+
+1. `GET /repos/{owner}/{repo}/contents/{path}` (optionally with `?ref={branch}`).
+2. Extract `sha` from the response. When importing with Base64, decode `content` carefully (GitHub returns Base64; re-encoding must match exactly).
+3. `PUT` the same endpoint with `message`, `content`, `branch`, `sha`.
+
+## Reusable pattern
+
+Write a small `update(path, content)` helper that always fetches the current `sha` first. It makes create and update uniform and self-healing: if the file is new, `sha` is simply absent, so pass it only when present.
+
+## Lesson
+
+For file mutations via the contents API: fetch-then-write with `sha` is the rule. The 422 body is the hint — read it before changing the strategy.

--- a/lessons/contrib/mergeable-state-blocked-not-red-ci.md
+++ b/lessons/contrib/mergeable-state-blocked-not-red-ci.md
@@ -1,0 +1,46 @@
+---
+{
+  "title": "mergeable_state blocked does not mean failing CI",
+  "domain": "development",
+  "tags": [
+    "github",
+    "ci",
+    "pull-request",
+    "merge-queue",
+    "workflow"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# `mergeable_state: blocked` does not mean failing CI
+
+## Problem
+
+After pushing a fix, the GitHub API reported `mergeable_state: blocked` on the pull request and all attention (and worry) shifted to "why is my PR blocked". In fact the branch had no failing checks at all.
+
+## Root cause
+
+The PR API field `mergeable_state` has several values: `clean`, `dirty`, `has_hooks`, `unknown`, `blocked`, and `behind`. `blocked` does **not** mean a check failed. It means the branch protection or merge settings prevent an automatic merge right now — most commonly a *required review* (human or bot) is still pending, or the branch is behind the base and needs an update.
+
+## Failure & recovery
+
+- The lesson validator in this very repo initially failed because the frontmatter was not JSON — that is a real, actionable failure and was the actual root cause of the red CI, not the `blocked` status.
+- Mistaking `blocked` for a failing check sends you chasing a non-existent test failure. Fix is to read `statuses`/`check-runs` endpoints, not the summary field, to find whether anything truly failed.
+
+## Use evidence, not vibes
+
+Cross-check with the concrete evidence: `GET /repos/{owner}/{repo}/commits/{sha}/check-runs` returns each check exactly, and `mergeable`/`mergeable_state` is only about whether the *merge button* can be used. A green `mergeable_state: clean` plus all-success checks is the only thing to rely on.
+
+## What I do now
+
+1. Never panic on `blocked`.
+2. Always enumerate `check-runs` before concluding failure.
+3. If a real check fails, fix the *content* the check validates — not cosmetic retries.
+
+## Lesson
+
+Separate "cannot merge right now" (reviews, behind) from "should not merge" (failed checks). The API summary tells you about the first; only the individual checks tell you about the second.


### PR DESCRIPTION
Three more original failure-recovery lessons from real automation/deploy incidents, each with JSON frontmatter (`evidence_level: E2`, allowed domains `development`/`network`)

- `mergeable-state-blocked-not-red-ci.md`
- `github-contents-api-sha-required.md`
- `cdn-edge-cache-stale-after-deploy.md`

Same quality-gate schema as #950 / #954. Original content, no downloads involved.

Signed-off-by: ElevaSync Solutions <elevasyncsolutions@gmail.com>