### PR TITLE
docs: sync README numbers to actual 275 indexed lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mcp-name: io.github.Ikalus1988/misakanet
 
 ### What is this?
 
-MisakaNet is a failure-memory layer for AI coding agents. When your agent hits an error — DCO failure, pip timeout, GitHub 401, MCP setup issue — MisakaNet searches 285 indexed failure-recovery lessons and returns a fix path. No prompt leaking, no raw logs stored.
+MisakaNet is a failure-memory layer for AI coding agents. When your agent hits an error — DCO failure, pip timeout, GitHub 401, MCP setup issue — MisakaNet searches 275 indexed failure-recovery lessons and returns a fix path. No prompt leaking, no raw logs stored.
 
 ### When to use it
 
@@ -98,7 +98,7 @@ Use cases: CI smoke test, isolated trial, Claude Desktop MCP config with Docker.
 
 | | Component | Purpose |
 |---|---|---|
-| **Core** | `search_knowledge.py` | Search 285 indexed failure-recovery lessons |
+| **Core** | `search_knowledge.py` | Search 275 indexed failure-recovery lessons |
 | **Core** | MCP server (local) | Give Cursor / Claude Code access to lessons |
 | **Core** | Remote MCP (`/mcp`) | Streamable HTTP endpoint — no clone needed |
 | **Core** | `POST /api/intake` | Submit redacted failure reports |
@@ -165,7 +165,7 @@ Didn't find a fix? [📮 Share your failure lesson →](https://github.com/Ikalu
 | **Best for** | DCO failures, GitHub token errors, pip timeout, Feishu API, WSL, FANUC |
 | **Not for** | Private memory storage, hosted vector database, general chatbot memory |
 | **License** | Apache 2.0 |
-| **Data** | 285 lessons, 59 assigned node IDs, 5 domains |
+| **Data** | 275 lessons, 59 assigned node IDs, 5 domains |
 | **MCP Endpoint** | `https://misakanet.org/mcp` (Remote) |
 | **Evidence Levels** | E0-E4 trust model |
 
@@ -489,7 +489,7 @@ python3 scripts/lesson_reuse_bench.py --compare         # with vs without lesson
 
 | Metric | Value |
 |--------|-------|
-| Shared Lessons | 285 (indexed) |
+| Shared Lessons | 275 (indexed) |
 | Registered Nodes | 59 assigned IDs |
 | Agent Types | CodeWhale, Claude, Codex, OpenClaw, OpenCode |
 | npm packages | [`@misaka-net/fatal-guard`](https://www.npmjs.com/package/@misaka-net/fatal-guard) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/Ikalus1988/MisakaNet/stargazers"><img src="https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social" alt="Stars"/></a>
   <a href="https://img.shields.io/badge/nodes-59-green"><img src="https://img.shields.io/badge/nodes-59-green?label=节点" alt="节点"/></a>
-  <a href="https://img.shields.io/badge/lessons-285-blue"><img src="https://img.shields.io/badge/lessons-285-blue?label=知识" alt="知识"/></a>
+  <a href="https://img.shields.io/badge/lessons-275-blue"><img src="https://img.shields.io/badge/lessons-275-blue?label=知识" alt="知识"/></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Ikalus1988/MisakaNet?style=flat&color=blueviolet" alt="License"/></a>
 </p>
 
@@ -50,7 +50,7 @@
 
 ### 这是什么？
 
-MisakaNet 是面向 AI 编码 Agent 的失败经验层。当你的 Agent 遇到错误 —— DCO 失败、pip 超时、GitHub 401、MCP 配置问题 —— MisakaNet 搜索 285 条索引化的失败修复经验并返回修复路径。无 prompt 泄漏，无原始日志存储。
+MisakaNet 是面向 AI 编码 Agent 的失败经验层。当你的 Agent 遇到错误 —— DCO 失败、pip 超时、GitHub 401、MCP 配置问题 —— MisakaNet 搜索 275 条索引化的失败修复经验并返回修复路径。无 prompt 泄漏，无原始日志存储。
 
 ### 什么时候使用？
 
@@ -225,7 +225,7 @@ python3 search_knowledge.py "database locked"
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 285 (indexed) |
+| 📚 Lessons | 275 (indexed) |
 | 🌐 Nodes | 59 |
 | 🎤 Network Voices | 5 条 |
 | 📡 Feed Items | 11 条 |


### PR DESCRIPTION
## Summary

Fixes #960. Updates hardcoded lesson count from 285 to actual 275 indexed lessons.

## Changes

- **EN README**: 285 → 275 (3 occurrences)
- **ZH README**: 285 → 275 (3 occurrences)

## Verification

275

The actual indexed lessons count from `data/lessons.json` is 275, not 285.

---

cc @Ikalus1988