### PR TITLE
fix(security): P0 hotfix — path traversal + XSS + secret redaction (clean)

### DIFF
--- a/scripts/mcp_http_server.py
+++ b/scripts/mcp_http_server.py
@@ -75,15 +75,31 @@ def misakanet_get_lesson(path: str = "", id: str = "") -> dict:
     if not path_or_id:
         return {"error": "path or id is required", "voice": "failure-warning"}
 
-    lesson_path = REPO_ROOT / path_or_id
-    if not lesson_path.exists():
-        for subdir in ["core", "contrib"]:
-            candidate = REPO_ROOT / "lessons" / subdir / f"{path_or_id}.md"
-            if candidate.exists():
-                lesson_path = candidate
-                break
+    # Helper: check if path is within allowed lessons directory
+    def _is_allowed_lesson_path(p):
+        resolved = p.resolve()
+        lessons_dir = (REPO_ROOT / "lessons").resolve()
+        return resolved.is_relative_to(lessons_dir) and resolved.suffix == ".md"
 
-    if not lesson_path.exists():
+    # Try direct path first (with traversal protection)
+    lesson_path = (REPO_ROOT / path_or_id).resolve()
+    if lesson_path.is_relative_to(REPO_ROOT.resolve()) and _is_allowed_lesson_path(lesson_path):
+        if lesson_path.exists():
+            content = lesson_path.read_text(encoding="utf-8", errors="replace")
+            return {
+                "path": str(lesson_path.relative_to(REPO_ROOT)),
+                "content": content[:5000],
+                "voice": "connect-success",
+            }
+
+    # Fallback: try searching by ID in lessons/core|contrib/
+    for subdir in ["core", "contrib"]:
+        candidate = REPO_ROOT / "lessons" / subdir / f"{path_or_id}.md"
+        if candidate.exists() and _is_allowed_lesson_path(candidate):
+            lesson_path = candidate
+            break
+
+    if not lesson_path.exists() or not _is_allowed_lesson_path(lesson_path):
         return {"error": f"Lesson not found: {path_or_id}", "voice": "failure-warning"}
 
     content = lesson_path.read_text(encoding="utf-8", errors="replace")

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -204,17 +204,31 @@ def handle_get_lesson(args: dict) -> dict:
             "voice": "failure-warning",
         }
 
-    # Try direct path
-    lesson_path = REPO_ROOT / path_or_id
-    if not lesson_path.exists():
-        # Try searching by ID in lessons/
-        for subdir in ["core", "contrib"]:
-            candidate = REPO_ROOT / "lessons" / subdir / f"{path_or_id}.md"
-            if candidate.exists():
-                lesson_path = candidate
-                break
+    # Helper: check if path is within allowed lessons directory
+    def _is_allowed_lesson_path(p):
+        resolved = p.resolve()
+        lessons_dir = (REPO_ROOT / "lessons").resolve()
+        return resolved.is_relative_to(lessons_dir) and resolved.suffix == ".md"
 
-    if not lesson_path.exists():
+    # Try direct path first (with traversal protection)
+    lesson_path = (REPO_ROOT / path_or_id).resolve()
+    if lesson_path.is_relative_to(REPO_ROOT.resolve()) and _is_allowed_lesson_path(lesson_path):
+        if lesson_path.exists():
+            content = lesson_path.read_text(encoding="utf-8", errors="replace")
+            return {
+                "path": str(lesson_path.relative_to(REPO_ROOT)),
+                "content": content[:5000],
+                "voice": "connect-success",
+            }
+
+    # Fallback: try searching by ID in lessons/core|contrib/
+    for subdir in ["core", "contrib"]:
+        candidate = REPO_ROOT / "lessons" / subdir / f"{path_or_id}.md"
+        if candidate.exists() and _is_allowed_lesson_path(candidate):
+            lesson_path = candidate
+            break
+
+    if not lesson_path.exists() or not _is_allowed_lesson_path(lesson_path):
         return {
             "error": f"Lesson not found: {path_or_id}",
             "hint": "Use misakanet_search to find available lessons by keyword",

--- a/tests/test_security_hotfix.py
+++ b/tests/test_security_hotfix.py
@@ -1,0 +1,37 @@
+"""Tests for security hotfix: path traversal, XSS, secret redaction."""
+import pytest
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from mcp_server import handle_get_lesson
+
+
+def test_path_traversal_blocked():
+    """Path traversal attempts should be blocked."""
+    result = handle_get_lesson({"path": "../../etc/passwd"})
+    assert "error" in result
+
+
+def test_git_config_blocked():
+    """Access to .git/config should be blocked."""
+    result = handle_get_lesson({"path": ".git/config"})
+    assert "error" in result
+
+
+def test_non_md_blocked():
+    """Non-.md files should be blocked."""
+    result = handle_get_lesson({"path": "package.json"})
+    assert "error" in result
+
+
+def test_valid_lesson_allowed():
+    """Valid lesson paths should be allowed."""
+    result = handle_get_lesson({"path": "lessons/core/dco-auto-fix-workflow.md"})
+    assert "content" in result
+
+
+def test_lesson_id_allowed():
+    """Lesson ID lookup should work."""
+    result = handle_get_lesson({"id": "dco-auto-fix-workflow"})
+    assert "content" in result

--- a/workers/email-register/src/index.js
+++ b/workers/email-register/src/index.js
@@ -42,6 +42,12 @@ export default {
       return;
     }
 
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+    if (!emailRegex.test(sender)) {
+      console.log(`Invalid email format: ${sender}`);
+      return;
+    }
+
     const lastReg = await env.MISAKANET_KV.get(`rate:email:${sender}`, 'text');
     if (lastReg && (Date.now() - parseInt(lastReg)) < 86400000) {
       console.log(`Rate limited email: ${sender}`);
@@ -83,7 +89,7 @@ export default {
       to: recipient,
       subject,
       intakeType,
-      lessonContent,
+      lessonContent: redactSecrets(lessonContent),
       nodeId,
       receivedAt,
       status: 'processed',
@@ -228,6 +234,29 @@ export default {
   }
 };
 
+function redactSecrets(text) {
+  if (!text) return text;
+  return text
+    .replace(/ghp_[A-Za-z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/gho_[A-Za-z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/github_pat_[A-Za-z0-9_]{82}/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/sk-[A-Za-z0-9]{48}/g, '[REDACTED_API_KEY]')
+    .replace(/AKIA[A-Z0-9]{16}/g, '[REDACTED_AWS_KEY]')
+    .replace(/-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----[\s\S]*?-----END (RSA |EC |DSA )?PRIVATE KEY-----/g, '[REDACTED_PRIVATE_KEY]')
+    .replace(/(?:password|passwd|pwd)\s*[:=]\s*[^\s,;]+/gi, '[REDACTED_PASSWORD]')
+    .replace(/(?:token|secret|api_key|apikey)\s*[:=]\s*[^\s,;]+/gi, '[REDACTED_SECRET]');
+}
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 async function createAuditIssue(env, intake) {
   const repo = env.GH_REPO || 'Ikalus1988/MisakaNet';
   const labels = intake.intakeType === 'lesson-submission'
@@ -310,8 +339,8 @@ function renderPage(view, data) {
       <div class="card">
         <div class="badge">✅ Registered</div>
         <h1>Welcome to the network</h1>
-        <div class="node-id">${data.nodeId}</div>
-        <p style="text-align:center;margin-bottom:20px">${data.email}${data.name ? ' · ' + data.name : ''}</p>
+        <div class="node-id">${escapeHtml(data.nodeId)}</div>
+        <p style="text-align:center;margin-bottom:20px">${escapeHtml(data.email)}${data.name ? ' · ' + escapeHtml(data.name) : ''}</p>
         <div class="steps">
           <b>Next steps:</b><br>
           1. <code>git clone https://github.com/Ikalus1988/MisakaNet.git</code><br>


### PR DESCRIPTION
## Security Hotfix (Clean)

Only security-related changes, no GX1 or unrelated files.

### Fixes

1. **MCP Path Traversal (C3/M1)**
   - File: scripts/mcp_server.py, scripts/mcp_http_server.py
   - Fix: _is_allowed_lesson_path() helper
   - Restricts to lessons/*.md only

2. **Email Intake Secret Redaction (C2)**
   - File: workers/email-register/src/index.js
   - Fix: redactSecrets() function
   - Redacts GitHub tokens, API keys, private keys, passwords

3. **Register Success Page XSS (M2)**
   - File: workers/email-register/src/index.js
   - Fix: escapeHtml() function
   - Escapes nodeId, email, name in HTML output

4. **Email Format Validation**
   - File: workers/email-register/src/index.js
   - Fix: regex validation

5. **Security Regression Tests**
   - File: tests/test_security_hotfix.py
   - Tests: path traversal, .git/config, non-md, valid lesson, id lookup

### Files Changed
- scripts/mcp_server.py
- scripts/mcp_http_server.py
- workers/email-register/src/index.js
- tests/test_security_hotfix.py

### Labels
security, hotfix, priority:critical