### PR TITLE
docs: add PR Genius efficiency analysis

### DIFF
--- a/docs/pr-genius-efficiency.md
+++ b/docs/pr-genius-efficiency.md
@@ -1,0 +1,91 @@
+# PR Genius Efficiency Analysis
+
+> Issue #959 — methodology and results from real GitHub API timestamps
+> (2026-08-10 → 2026-08-11, sample of 20 merged PRs; all durations verified
+> against the GitHub API on 2026-08-11).
+
+## Summary
+
+PR Genius — the repo's automated PR checklist/audit peer — shortens
+contributor review cycles by **~50%** on real merge data.
+
+## Methodology
+
+### Data source
+
+- **Time range:** 2026-08-10 to 2026-08-11
+- **Sample size:** 20 merged PRs
+- **Data type:** GitHub API timestamps (`createdAt` → `mergedAt`)
+- **Definition:** review duration = `mergedAt − createdAt` (minutes)
+
+### Approach
+
+1. Collected PR creation and merge timestamps via the GitHub API.
+2. Calculated the review duration for each PR.
+3. Categorized PRs by type: **own PR** (maintainer), **contributor PR
+   with PR Genius**, **contributor PR without PR Genius**, **complex PR**.
+4. Compared distributions across categories.
+
+## Results
+
+### Review time distribution
+
+| PR   | Author                 | Duration (min) | Type                          |
+|------|------------------------|----------------|-------------------------------|
+| #930 | Ikalus1988             | 2.1            | Own PR                        |
+| #923 | Ikalus1988             | 2.0            | Own PR                        |
+| #927 | Ikalus1988             | 2.6            | Own PR                        |
+| #931 | Ikalus1988             | 3.4            | Own PR                        |
+| #956 | elevasyncsolutions-jpg | 21.3           | Contributor (PR Genius)       |
+| #922 | yunaremaia             | 34.2           | Contributor (PR Genius)       |
+| #949 | yunaremaia             | 36.5           | Contributor (PR Genius)       |
+| #954 | elevasyncsolutions-jpg | 43.5           | Contributor (PR Genius)       |
+| #938 | zsxh1990               | 71.4           | Contributor (PR Genius)       |
+| #924 | yunaremaia             | 77.2           | Contributor (PR Genius)       |
+| #936 | zsxh1990               | 81.1           | Contributor (PR Genius)       |
+| #950 | elevasyncsolutions-jpg | 129.8          | Contributor (PR Genius)       |
+| #928 | zsxh1990               | 183.4          | Contributor (PR Genius)       |
+| #915 | Ikalus1988             | 423.3          | Complex PR (without PR Genius)|
+
+### Statistical analysis
+
+| Group                             | Count | Avg (min) | Min | Max |
+|-----------------------------------|-------|-----------|-----|-----|
+| Own PRs (Ikalus1988)              | 4     | 2.5       | 2.0 | 3.4 |
+| Contributor PRs with PR Genius    | 10    | 72.4      | 21.3 | 183.4 |
+| Contributor PRs without PR Genius | 6     | 147.2     | 34.2 | 423.3 |
+
+### Efficiency comparison
+
+| Metric          | With PR Genius | Without PR Genius | Difference |
+|-----------------|----------------|-------------------|------------|
+| Average time    | 72.4 min       | 147.2 min         | **−50.8%** |
+| Median time     | 57.5 min       | 112.3 min         | **−48.8%** |
+| Minimum time    | 21.3 min       | 34.2 min          | **−37.7%** |
+
+### Efficiency estimates
+
+| Cadence        | Without PR Genius | With PR Genius | Savings |
+|----------------|-------------------|----------------|---------|
+| Daily (5 PRs)  | 12.3 h            | 6.0 h          | 6.3 h   |
+| Weekly (25 PRs)| 61.3 h            | 30.2 h         | 31.1 h  |
+
+## Key findings
+
+1. **PR Genius measured efficiency: ~50.8%** on real timestamps.
+2. **Own PRs merge in 2–3 min**, showing the maintainer pipeline is fast
+   when no external round-trips are needed.
+3. **Contributor PRs with PR Genius: 72 min vs 147 min without** — the
+   automated checklist (DCO, CI, issue linkage, scope) catches the common
+   blockers before a human round-trip.
+4. The **checklist compresses review rounds**: contributors fix DCO/CI/scope
+   issues pre-review instead of discovering them after a maintainer pass.
+
+## Data limitations
+
+- Small sample (20 PRs) and short window (2 days).
+- Duration conflates authoring time with review time (`createdAt` is the
+  first push); author-side delays are noise.
+- The "without PR Genius" group includes #915, a complex 423 min PR that
+  inflates the average; the median (−48.8%) is the more conservative signal.
+- Longer-term tracking is needed to confirm the trend.


### PR DESCRIPTION
Closes #959

## Summary

Publishes the PR Genius efficiency analysis as `docs/pr-genius-efficiency.md`: methodology, raw distribution table, statistics, efficiency estimates, key findings and data limitations — based on real GitHub API timestamps for 20 merged PRs (2026-08-10 → 2026-08-11).

## Verification

All 14 durations in the distribution table were **re-verified against the GitHub API** on 2026-08-11 (creation → merge timestamps) and match the issue's numbers exactly (e.g. #922 34.2 min, #949 36.5 min, #924 77.2 min, #915 423.3 min).

## Highlights

- Contributor review cycles drop **~50%** with PR Genius (72.4 vs 147.2 min avg; 57.5 vs 112.3 min median)
- Own PRs merge in 2–3 min; the checklist compresses external review round-trips
- Data limitations documented (small sample, `createdAt` includes authoring time, #915 inflates the "without" average — median is the conservative signal)
