### PR TITLE
feat: add 3 more original failure-recovery lessons (git worktree recovery, escrow fee rounding, squash force-push lease)

### DIFF
--- a/lessons/contrib/escrow-fee-rounding-per-provider.md
+++ b/lessons/contrib/escrow-fee-rounding-per-provider.md
@@ -1,0 +1,43 @@
+---
+{
+  "title": "Banking-style escrow fee estimate has a per-provider rounding disparity",
+  "domain": "development",
+  "tags": [
+    "payments",
+    "calculation",
+    "rounding",
+    "precision",
+    "ledger"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# Escrow fee estimates round differently per provider — and it silently changes totals
+
+## Problem
+
+A payout/reward schema recorded a fee estimate computed with floating-point math, while the escrow engine (and the human maintainers) expected per-provider integer-percent rounding. Invoices, reward cells, and gateway payloads diverged by a few basis points — invisible on a single row, yet every cross-check and tally disagreed.
+
+## Root cause
+
+Money math was done as `amount * rate` in binary floating point and then summed, instead of using currency-centric integer arithmetic (cents/wei/sats) with explicit rounding at the end. Two compounding effects:
+
+- `0.1 * 3` style products are not exact in binary floats (e.g. `0.30000000000000004`), so *identical* fee logic produced *different* totals depending on provider defaults and where the rounding was applied (per-row vs. at-the-end).
+- A schema that allows the number of decimal places to differ per provider makes the same invoice look correct under one and wrong under another.
+
+## Failure & recovery
+
+The failure surfaced only when an independent audit added totals and compared them to the stored fee. The recovery checklist:
+
+1. Move all money arithmetic to integer units (cents, sats, or the token's smallest unit).
+2. Choose a single rounding mode (and mention it: round-half-up, truncation, banker's rounding).
+3. Sum in integer units, round once at the end, never per-row mid-computation.
+4. Add a "recompute and compare to stored" invariant check in tests.
+
+## Lesson
+
+Fee/escrow math is currency math: use integer units, apply one rounding policy, and validate stored totals by recomputation. "It's almost right" is how payment bugs get shipped.

--- a/lessons/contrib/git-worktree-dangling-commit-recovery.md
+++ b/lessons/contrib/git-worktree-dangling-commit-recovery.md
@@ -1,0 +1,51 @@
+---
+{
+  "title": "git worktree commit lost after pushing from the wrong directory",
+  "domain": "development",
+  "tags": [
+    "git",
+    "worktree",
+    "reflog",
+    "recovery",
+    "branch"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# git worktree commits "disappear" after pushing from the wrong directory
+
+## Problem
+
+A commit made inside a `git worktree add <path> <branch>` appeared to vanish: the remote branch did not move, and the local branch was suddenly empty. The work had taken hours and seemed unrecoverable.
+
+## Root cause
+
+`git worktree` attaches a worktree to a *branch*. When a push or commit runs from the wrong place (for example a second worktree, or the main clone, or a bare path) the HEAD you commit on can be a different branch or a detached HEAD:
+
+- Commits made on a detached HEAD or an unexpected branch are not referenced by any branch name, so they are invisible in normal `git log`.
+- The original branch ref itself was not updated — it still pointed at the old commit. The work exists in the object database but nothing references it.
+
+The commit is not lost; it is simply *unreferenced*.
+
+## Failure & recovery
+
+Panic-driven string searches for the files failed because the working tree had been cleaned. The reliable recovery path:
+
+1. `git fsck --lost-found` — lists dangling commits. Look for commits whose dates/messages match the work.
+2. Or `git reflog --all` — shows every HEAD movement including the detached-HEAD history.
+3. `git branch <name> <sha>` or `git checkout -b <name> <sha>` — re-attach a branch to the recovered commit.
+4. Push from the correct worktree (or folder), or from the re-attached branch directly.
+
+## Prevent it
+
+- Always confirm `git rev-parse --abbrev-ref HEAD` and `git status -b` before committing/pushing when using worktrees.
+- Verify the remote moved: after push, `git ls-remote origin <branch>`.
+- Keep a habit of writing useful commit messages you can grep for in `fsck --lost-found` output.
+
+## Lesson
+
+A "missing" git commit is almost always a dangling object. Recover with `fsck --lost-found`/`reflog` instead of rewriting from memory, and fix the workflow that created it.

--- a/lessons/contrib/squash-rebase-force-push-lease.md
+++ b/lessons/contrib/squash-rebase-force-push-lease.md
@@ -1,0 +1,43 @@
+---
+{
+  "title": "Squash-rebase rewrites the patch base and breaks force-push expectations",
+  "domain": "development",
+  "tags": [
+    "git",
+    "rebase",
+    "squash",
+    "force-push",
+    "collaboration"
+  ],
+  "status": "published",
+  "evidence_level": "E2",
+  "created": "2026-08-11 00:00:00 UTC",
+  "updated": "2026-08-11 00:00:00 UTC"
+}
+---
+
+# Squash-rebase silently changes the base — and force-push races follow
+
+## Problem
+
+A contribution branch had been periodically force-pushed while staying based on an older commit. After a squash-rebase intended to tidy history, the next force-push hit `remote contains work you do not have locally` and reviewers could no longer reconcile the branch with the PR.
+
+## Root cause
+
+Two compounding git behaviors:
+
+1. A squash-rebase (or any rebase that "updates" the branch) changes not just the history but the *base* commit the branch grows from. Reviewers comparing against the PR's recorded base see a rewritten set of files, not an incremental diff.
+2. `--force-with-lease` protects against overwriting work *you haven't seen* — but after a local rebase, the local ref diverges from remote in a way that the semantic guard misjudges, and a plain `--force` overwrites something you may have based your squash on.
+
+## Failure & recovery
+
+The fix is to treat squash-rebase as a *conflict resolution*, not a formatting step:
+
+1. Before squashing, capture the current remote head: `git rev-parse origin/<branch>`.
+2. `git rebase -i` to squash, then verify `git diff origin/main...HEAD` shows exactly the intended net change.
+3. Push with `--force-with-lease=refs/heads/<branch>:<old-remote-sha>` explicitly naming the sha you are allowed to replace — never a naked `--force`.
+4. If reviewers already commented on line numbers, say clearly that the patch was rebased/squashed so they re-review by file diff, not by conversation.
+
+## Lesson
+
+Squash is not cosmetic: it rewrites the base and re-opens the merge contract. Name the lease explicitly and re-verify the net diff before force-pushing a squashed branch.


### PR DESCRIPTION
Third round of original failure-recovery lessons, JSON frontmatter with `evidence_level: E2`, allowed domains.

- `git-worktree-dangling-commit-recovery.md` — commit "disappearing" after pushing from the wrong worktree; recover via `fsck --lost-found`/`reflog`
- `escrow-fee-rounding-per-provider.md` — floating-point fee math vs integer-unit currency math, per-provider rounding
- `squash-rebase-force-push-lease.md` — squash-rebase rewrites the base; use explicit `--force-with-lease`

Same quality-gate schema as the merged #950 / #954 / #956. Original content.

Signed-off-by: ElevaSync Solutions <elevasyncsolutions@gmail.com>