### PR TITLE
test(identity): verify Identity Aura badges for all three token types

### DIFF
--- a/workers/identity-aura.test.mjs
+++ b/workers/identity-aura.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  IDENTITY_AURA,
+  getIdentityAura,
+} from './register-proxy-sw.js';
+
+function createFakeKV(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    async get(key, type) {
+      if (!store.has(key)) return null;
+      const raw = store.get(key);
+      return type === 'json' ? JSON.parse(raw) : raw;
+    },
+    async put(key, value) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+// ── IDENTITY_AURA constants ──
+
+test('IDENTITY_AURA defines all three badge types', () => {
+  assert.equal(IDENTITY_AURA.static_token, '🧠 MisakaNet MCP — public read-only access.');
+  assert.equal(IDENTITY_AURA.basic, '🧠 MisakaNet failure-memory connected.');
+  assert.ok(IDENTITY_AURA.upgraded.includes('AIM拡散力場'));
+});
+
+// ── getIdentityAura: static token ──
+
+test('static MCP_TOKEN yields the public read-only badge', async () => {
+  const env = { MCP_TOKEN: 'static-secret-token', MISAKANET_KV: createFakeKV() };
+  const aura = await getIdentityAura(env, 'static-secret-token');
+  assert.equal(aura, IDENTITY_AURA.static_token);
+});
+
+test('missing token falls back to the static badge (no KV needed)', async () => {
+  const env = { MCP_TOKEN: 'static-secret-token' };
+  const aura = await getIdentityAura(env, null);
+  assert.equal(aura, IDENTITY_AURA.static_token);
+});
+
+test('no KV namespace falls back to the static badge', async () => {
+  const env = { MCP_TOKEN: 'static-secret-token' };
+  const aura = await getIdentityAura(env, 'static-secret-token');
+  assert.equal(aura, IDENTITY_AURA.static_token);
+});
+
+test('wrong static token without pairing identity falls back to basic badge', async () => {
+  const env = { MCP_TOKEN: 'static-secret-token', MISAKANET_KV: createFakeKV() };
+  const aura = await getIdentityAura(env, 'wrong-token');
+  assert.equal(aura, IDENTITY_AURA.basic);
+});
+
+// ── getIdentityAura: pairing token (basic) ──
+
+test('pairing token with registered identity yields the failure-memory badge', async () => {
+  const kv = createFakeKV({
+    'mcp_token:mcp_test123': JSON.stringify({ ip: '203.0.113.7' }),
+    'identity:203.0.113.7': JSON.stringify({ status: 'basic' }),
+  });
+  const env = { MCP_TOKEN: 'static-secret-token', MISAKANET_KV: kv };
+  const aura = await getIdentityAura(env, 'mcp_test123');
+  assert.equal(aura, IDENTITY_AURA.basic);
+});
+
+test('pairing token without identity record falls back to the basic badge', async () => {
+  const kv = createFakeKV({
+    'mcp_token:mcp_test123': JSON.stringify({ ip: '203.0.113.7' }),
+  });
+  const env = { MCP_TOKEN: 'static-secret-token', MISAKANET_KV: kv };
+  const aura = await getIdentityAura(env, 'mcp_test123');
+  assert.equal(aura, IDENTITY_AURA.basic);
+});
+
+// ── getIdentityAura: upgraded token ──
+
+test('upgraded identity yields the Japanese AIM拡散力場 badge', async () => {
+  const kv = createFakeKV({
+    'mcp_token:mcp_test123': JSON.stringify({ ip: '203.0.113.7' }),
+    'identity:203.0.113.7': JSON.stringify({ status: 'upgraded' }),
+  });
+  const env = { MCP_TOKEN: 'static-secret-token', MISAKANET_KV: kv };
+  const aura = await getIdentityAura(env, 'mcp_test123');
+  assert.equal(aura, IDENTITY_AURA.upgraded);
+  assert.ok(aura.includes('AIM拡散力場'));
+});
+
+test('unknown pairing token falls back to the basic badge', async () => {
+  const env = { MCP_TOKEN: 'static-secret-token', MISAKANET_KV: createFakeKV() };
+  const aura = await getIdentityAura(env, 'mcp_unknown');
+  assert.equal(aura, IDENTITY_AURA.basic);
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -1323,12 +1323,14 @@ async function getCode() {
 // Named exports for unit tests only (workers/unsolved-map.test.mjs). Wrangler
 // deploys this file for its default export; the extra exports are inert there.
 export {
+  IDENTITY_AURA,
   MAX_MCP_REQUEST_BYTES,
   UNSOLVED_FAMILY_WHITELIST,
   UNSOLVED_REASONS,
   UNSOLVED_WINDOW_DAYS,
   buildUnsolvedMap,
   classifyTaskFamily,
+  getIdentityAura,
   handleSearchSignal,
   handleUnsolvedMap,
   recordStaleLesson,


### PR DESCRIPTION
Closes #911

## Summary

Adds `workers/identity-aura.test.mjs` — a verification suite for the **Identity Aura badge system**, covering all three token types from the issue scope:

| Token type | Badge verified |
|---|---|
| Static MCP_TOKEN | `MisakaNet MCP — public read-only access` |
| Pairing token (basic identity) | `MisakaNet failure-memory connected` |
| Upgraded identity | Japanese `AIM拡散力場` badge |

**Coverage** (9 tests):
- Static token: exact badge match, missing-token fallback, no-KV fallback, wrong-token fallback
- Pairing token: registered basic identity → failure-memory badge; missing identity record → fallback
- Upgraded identity: exact `AIM拡散力場` badge + content check
- Unknown pairing token → safe fallback (no crash)

`getIdentityAura` and `IDENTITY_AURA` were added to the existing test-only named exports in `register-proxy-sw.js` (inert in production, same pattern as the unsolved-map exports).

**Verification**: 9/9 new tests pass; existing worker suites (`register-proxy.test.mjs`, `unsolved-map.test.mjs` — 28 tests) unaffected.
