### PR TITLE
docs: add Python/TypeScript code style guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,6 +295,50 @@ Certain critical paths require Reviewer-tier approval:
 - `misakanet/search/` — Search engine modifications
 - `.github/workflows/` — CI pipeline changes
 
+## Code Style Guidelines
+
+### Python
+
+The repository uses **ruff** for linting and formatting (configured in `pyproject.toml`).
+
+- **Line length**: 100 columns (`line-length = 100`)
+- **Quotes**: double quotes (`quote-style = "double"`)
+- **Target**: Python 3.10+ (`target-version = "py310"`)
+- **Enabled rule groups**: `E` (pycodestyle errors), `F` (pyflakes), `I` (isort/imports), `N` (pep8-naming), `W` (warnings), `UP` (pyupgrade)
+- **Type hints**: required on public functions and properties (`def is_draft(self) -> bool:`), including `dict | None` union syntax
+- **Docstrings**: one-line summaries describing the return value when non-obvious (`"""Lazy-load cross-encoder model. Returns None if unavailable."""`); avoid multi-line Google/numpy styles unless the docstring needs parameter details
+- **Imports**: ruff `I` enforces isort ordering — standard library, then third-party, then local
+
+Verify before pushing:
+
+```bash
+ruff check .
+ruff format --check .
+```
+
+### TypeScript
+
+The VS Code extension (`vscode-extension/`) and Explorer (`explorer/`) follow the ESLint defaults configured in each package.
+
+- **Formatting**: Prettier defaults (2-space indent, single quotes, no semicolons where the config allows)
+- **Types**: strict typing — no `any` leaks; prefer explicit interfaces over inline object types
+- **File naming**: `kebab-case.ts` for modules, `PascalCase.tsx` for components
+- **Async**: prefer `async/await` over `.then()` chains; always handle rejections (no floating promises)
+
+Verify before pushing (from the package root):
+
+```bash
+npm run lint
+npm run format:check
+```
+
+### PR Checklist (all contributions)
+
+- [ ] Tests pass (or a CI check covers the change)
+- [ ] Docs updated if behavior changed
+- [ ] Commits signed with `Signed-off-by:` (DCO)
+- [ ] No unrelated changes bundled in the same PR
+
 ## Code of Conduct
 
 Please note that this project follows the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to maintain a respectful and inclusive environment.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ MisakaNet is useful in different ways depending on what you are trying to do:
 |---|---|
 | 🔴 Debugging a real failure | [Search existing lessons](https://ikalus1988.github.io/MisakaNet/search/) before retrying |
 | 🤖 Building an AI agent / tool | Use lessons as [failure-memory](docs/mcp-quickstart.md) for your workflow |
-| 🔧 Contributing a fix | Check [related lessons](https://ikalus1988.github.io/MisakaNet/search/), then open a small PR |
+| 🔧 Contributing a fix | Read [CONTRIBUTING.md](CONTRIBUTING.md) for code style + PR checklist, check [related lessons](https://ikalus1988.github.io/MisakaNet/search/), then open a small PR |
 | 📝 Sharing a failure case | Submit a [5-line failure note](https://github.com/Ikalus1988/MisakaNet/issues/new?template=lesson-feedback.yml) — no polished PR required |
 | 📊 Evaluating agent learning | Run the [benchmarks](scripts/retrieval_noisebench.py) and compare reuse behavior |
 | 💬 Reporting friction | [Email intake](docs/email-intake.md) or [journey report #510](https://github.com/Ikalus1988/MisakaNet/issues/510) |


### PR DESCRIPTION
Closes #903

## Summary

Adds a **Code Style Guidelines** section to `CONTRIBUTING.md`, grounded in the repository's actual tooling:

**Python** (ruff, configured in `pyproject.toml`):
- line-length 100, double quotes, target py310
- rule groups `E/F/I/N/W/UP` (pycodestyle, pyflakes, isort, pep8-naming, warnings, pyupgrade)
- required type hints on public functions/properties, `dict | None` union syntax
- one-line docstrings describing non-obvious return values
- verification commands (`ruff check .`, `ruff format --check .`)

**TypeScript** (VS Code extension + Explorer):
- ESLint/Prettier defaults, strict typing (no `any` leaks)
- file naming conventions, async/await without floating promises

**PR checklist** covering tests, docs, DCO sign-off, and scope discipline.

Also references `CONTRIBUTING.md` from the README contribution table (per the issue's acceptance criteria).

## Validation

- Style rules match the existing codebase patterns (verified against `misakanet/search/engine.py` and `pyproject.toml` ruff config)
- No CI-affecting changes — docs only
