### PR TITLE
chore(release): sync v2.17 lesson count and data index

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Git-backed failure-memory for AI coding agents.**
 >
 > Zero dependencies. Zero server. Zero database.
-> Paste an error → search 287 lessons → get a fix path.
+> Paste an error → search 289 lessons → get a fix path.
 
 mcp-name: io.github.Ikalus1988/misakanet
 
@@ -24,7 +24,7 @@ mcp-name: io.github.Ikalus1988/misakanet
 
 ### What is this?
 
-MisakaNet is a failure-memory layer for AI coding agents. When your agent hits an error — DCO failure, pip timeout, GitHub 401, MCP setup issue — MisakaNet searches 287 indexed failure-recovery lessons and returns a fix path. No prompt leaking, no raw logs stored.
+MisakaNet is a failure-memory layer for AI coding agents. When your agent hits an error — DCO failure, pip timeout, GitHub 401, MCP setup issue — MisakaNet searches 289 indexed failure-recovery lessons and returns a fix path. No prompt leaking, no raw logs stored.
 
 ### When to use it
 
@@ -249,7 +249,7 @@ Use skills when you want an agent to do something. Use MisakaNet when you want a
 
 | Metric | Value |
 |--------|-------|
-| Shared Lessons | 287 (indexed) |
+| Shared Lessons | 289 (indexed) |
 | Registered Nodes | 59 assigned IDs |
 | Agent Types | CodeWhale, Claude, Codex, OpenClaw, OpenCode |
 | npm packages | [`@misaka-net/fatal-guard`](https://www.npmjs.com/package/@misaka-net/fatal-guard) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/Ikalus1988/MisakaNet/stargazers"><img src="https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social" alt="Stars"/></a>
   <a href="https://img.shields.io/badge/nodes-59-green"><img src="https://img.shields.io/badge/nodes-59-green?label=节点" alt="节点"/></a>
-  <a href="https://img.shields.io/badge/lessons-275-blue"><img src="https://img.shields.io/badge/lessons-275-blue?label=知识" alt="知识"/></a>
+  <a href="https://img.shields.io/badge/lessons-289-blue"><img src="https://img.shields.io/badge/lessons-289-blue?label=知识" alt="知识"/></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Ikalus1988/MisakaNet?style=flat&color=blueviolet" alt="License"/></a>
 </p>
 
@@ -50,7 +50,7 @@
 
 ### 这是什么？
 
-MisakaNet 是面向 AI 编码 Agent 的失败经验层。当你的 Agent 遇到错误 —— DCO 失败、pip 超时、GitHub 401、MCP 配置问题 —— MisakaNet 搜索 275 条索引化的失败修复经验并返回修复路径。无 prompt 泄漏，无原始日志存储。
+MisakaNet 是面向 AI 编码 Agent 的失败经验层。当你的 Agent 遇到错误 —— DCO 失败、pip 超时、GitHub 401、MCP 配置问题 —— MisakaNet 搜索 289 条索引化的失败修复经验并返回修复路径。无 prompt 泄漏，无原始日志存储。
 
 ### 什么时候使用？
 
@@ -225,7 +225,7 @@ python3 search_knowledge.py "database locked"
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 275 (indexed) |
+| 📚 Lessons | 289 (indexed) |
 | 🌐 Nodes | 59 |
 | 🎤 Network Voices | 5 条 |
 | 📡 Feed Items | 11 条 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ MisakaNet should stay offline-first and Git-backed. External listings are useful
 - Test suite: passing.
 - Public site is online: homepage, `/search/`, journey page, Worker APIs, and
   lesson data endpoints are healthy.
-- Corpus wording baseline: **287 indexed failure lessons**; avoid claiming
+- Corpus wording baseline: **289 indexed failure lessons**; avoid claiming
   all are verified unless also stating the verified count separately.
 - Local MCP server exposes three tools: `misakanet_search`,
   `misakanet_get_lesson`, and `misakanet_submit_usage`.
@@ -35,7 +35,7 @@ Goal: 把 v2.16.0 的增长势能收敛成"可信、可维护、可审计的 fai
 | Track | Priority | What to ship | Gate |
 |---|---:|---|---|
 | **Lesson Lint** | P0 | `scripts/lesson_lint.py` 非阻塞试运行 | 0 high issues, CI job running |
-| **GX1 闭环** | P0 | #968 合并, lessons.json 同步 | README/STATUS/lessons.json = 287 |
+| **GX1 闭环** | P0 | #968 合并, lessons.json 同步 | README/STATUS/lessons.json = 289 |
 | **版本漂移清理** | P0 | STATUS/ROADMAP 同步到 v2.17 | 无版本号矛盾 |
 | **Security 收尾** | P0 | #969 合并, #964 关闭 | Release notes 包含安全修复 |
 | **定位固化** | P1 | "这不是什么" + Git-backed 到 CONCEPTS.md | 文档一致 |
@@ -51,7 +51,7 @@ python scripts/site_health.py
 ```
 
 并且：
-- README / STATUS / ROADMAP 数字一致（287）
+- README / STATUS / ROADMAP 数字一致（289）
 - `data/lessons.json` 已重新生成
 - 没有无关未跟踪文件
 - Lesson lint 0 high issues

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,7 +6,7 @@
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 287 篇 |
+| 📚 Lessons | 289 篇 |
 | 🏛️ 领域覆盖 | 25 个 |
 | 🎤 Network Voices | 5 条 |
 | 📡 Feed Items | 5 条 |

--- a/data/lessons.json
+++ b/data/lessons.json
@@ -1,21 +1,5 @@
 [
   {
-    "id": "README",
-    "title": "README",
-    "domain": "core",
-    "tags": [],
-    "summary": "Lessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confide…",
-    "preview": "# Core Lessons\n\nLessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confidence.\n\nSubmit curated lessons via PR with `curated` label.",
-    "url": "lessons/core/README.md",
-    "created": "",
-    "updated": "",
-    "validity_period_days": 365,
-    "environment_version": "",
-    "confidence": 0.5,
-    "status": "active",
-    "verified": false
-  },
-  {
     "id": "auto-merge-ci-pipeline",
     "title": "Auto-Merge CI Pipeline — DCO, Quality Score, Shadow Branch, Dynamic Deps, Auto-Merge",
     "domain": "devops",
@@ -215,6 +199,22 @@
     "verified": true
   },
   {
+    "id": "README",
+    "title": "README",
+    "domain": "core",
+    "tags": [],
+    "summary": "Lessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confide…",
+    "preview": "# Core Lessons\n\nLessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confidence.\n\nSubmit curated lessons via PR with `curated` label.",
+    "url": "lessons/core/README.md",
+    "created": "",
+    "updated": "",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "active",
+    "verified": false
+  },
+  {
     "id": "search-first-roadmap-loop",
     "title": "Search-first roadmap loop for agent knowledge projects",
     "domain": "development",
@@ -234,22 +234,6 @@
     "environment_version": "",
     "confidence": 0.5,
     "status": "published",
-    "verified": true
-  },
-  {
-    "id": "README",
-    "title": "README",
-    "domain": "contrib",
-    "tags": [],
-    "summary": "Community-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lesson…",
-    "preview": "# Contrib Lessons\n\nCommunity-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lessons are automatically scanned for dangerous patterns via CI on every PR.\n\nTo promote a lesson to `core/`, submit a curation PR with review evidence.\n## Verification\n\n1. Follow the solution steps in order\n2. Run any relevant commands or tests to confirm the fix\n3. Verify the symptom no longer occurs\n4. Check related logs or outputs for expected behavior",
-    "url": "lessons/contrib/README.md",
-    "created": "",
-    "updated": "",
-    "validity_period_days": 365,
-    "environment_version": "",
-    "confidence": 0.5,
-    "status": "active",
     "verified": true
   },
   {
@@ -1131,6 +1115,28 @@
     "confidence": 0.5,
     "status": "active",
     "verified": true
+  },
+  {
+    "id": "escrow-fee-rounding-per-provider",
+    "title": "Banking-style escrow fee estimate has a per-provider rounding disparity",
+    "domain": "development",
+    "tags": [
+      "payments",
+      "calculation",
+      "rounding",
+      "precision",
+      "ledger"
+    ],
+    "summary": "A payout/reward schema recorded a fee estimate computed with floating-point math, while the escrow engine (and the human maintainers) expected per-provider inte…",
+    "preview": "# Escrow fee estimates round differently per provider — and it silently changes totals\n\n## Problem\n\nA payout/reward schema recorded a fee estimate computed with floating-point math, while the escrow engine (and the human maintainers) expected per-provider integer-percent rounding. Invoices, reward cells, and gateway payloads diverged by a few basis points — invisible on a single row, yet every cross-check and tally disagreed.\n\n## Root cause\n\nMoney math was done as `amount * rate` in binary floating point and then summed, instead of using currency-centric integer arithmetic (cents/wei/sats) with explicit rounding at the end. Two compounding effects:\n\n- `0.1 * 3` style products are not exact in binary floats (e.g. `0.30000000000000004`), so *identical* fee logic produced *different* totals depending on provider defaults and where the rounding was applied (per-row vs. at-the-end).\n- A schema that allows the number of decimal places to differ per provider makes the same invoice look correct under one and wrong under another.\n\n## Failure & recovery\n\nThe failure surfaced only when an independent audit added totals and compared them to the stored fee. The recovery checklist:\n\n1. Move all money arithmetic to integer units (cents, sats, or the token's smallest unit).\n2. Choose a single rounding mode (and mention it: round-half-up, truncation, banker's rounding).\n3. Sum in integer units, round once at the end, never per-row mid-computation.\n4. Add a \"recompute and compare to stored\" invariant check in tests.\n\n## Lesson\n\nFee/escrow math is currency math: use integer units, apply one rounding policy, and validate stored totals by recomputation. \"It's almost right\" is how payment bugs get shipped.",
+    "url": "lessons/contrib/escrow-fee-rounding-per-provider.md",
+    "created": "2026-08-11 00:00:00 UTC",
+    "updated": "2026-08-11 00:00:00 UTC",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "published",
+    "verified": false
   },
   {
     "id": "fanuc-alarm-code-reference",
@@ -2270,6 +2276,28 @@
     "environment_version": "",
     "confidence": 0.5,
     "status": "active",
+    "verified": false
+  },
+  {
+    "id": "git-worktree-dangling-commit-recovery",
+    "title": "git worktree commit lost after pushing from the wrong directory",
+    "domain": "development",
+    "tags": [
+      "git",
+      "worktree",
+      "reflog",
+      "recovery",
+      "branch"
+    ],
+    "summary": "A commit made inside a `git worktree add <path> <branch>` appeared to vanish: the remote branch did not move, and the local branch was suddenly empty. The work …",
+    "preview": "# git worktree commits \"disappear\" after pushing from the wrong directory\n\n## Problem\n\nA commit made inside a `git worktree add <path> <branch>` appeared to vanish: the remote branch did not move, and the local branch was suddenly empty. The work had taken hours and seemed unrecoverable.\n\n## Root cause\n\n`git worktree` attaches a worktree to a *branch*. When a push or commit runs from the wrong place (for example a second worktree, or the main clone, or a bare path) the HEAD you commit on can be a different branch or a detached HEAD:\n\n- Commits made on a detached HEAD or an unexpected branch are not referenced by any branch name, so they are invisible in normal `git log`.\n- The original branch ref itself was not updated — it still pointed at the old commit. The work exists in the object database but nothing references it.\n\nThe commit is not lost; it is simply *unreferenced*.\n\n## Failure & recovery\n\nPanic-driven string searches for the files failed because the working tree had been cleaned. The reliable recovery path:\n\n1. `git fsck --lost-found` — lists dangling commits. Look for commits whose dates/messages match the work.\n2. Or `git reflog --all` — shows every HEAD movement including the detached-HEAD history.\n3. `git branch <name> <sha>` or `git checkout -b <name> <sha>` — re-attach a branch to the recovered commit.\n4. Push from the correct worktree (or folder), or from the re-attached branch directly.\n\n## Prevent it\n\n- Always confirm `git rev-parse --abbrev-ref HEAD` and `git status -b` before committing/pushing when using worktrees.\n- Verify the remote moved: after push, `git ls-remote origin <branch>`.\n- Keep a habit of writing useful commit messages you can grep for in `fsck --lost-found` output.\n\n## Lesson\n\nA \"missing\" git commit is almost always a dangling object. Recover with `fsck --lost-found`/`reflog` instead of rewriting from memory, and fix the workflow that created it.",
+    "url": "lessons/contrib/git-worktree-dangling-commit-recovery.md",
+    "created": "2026-08-11 00:00:00 UTC",
+    "updated": "2026-08-11 00:00:00 UTC",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "published",
     "verified": false
   },
   {
@@ -4021,6 +4049,22 @@
     "verified": false
   },
   {
+    "id": "README",
+    "title": "README",
+    "domain": "contrib",
+    "tags": [],
+    "summary": "Community-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lesson…",
+    "preview": "# Contrib Lessons\n\nCommunity-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lessons are automatically scanned for dangerous patterns via CI on every PR.\n\nTo promote a lesson to `core/`, submit a curation PR with review evidence.\n## Verification\n\n1. Follow the solution steps in order\n2. Run any relevant commands or tests to confirm the fix\n3. Verify the symptom no longer occurs\n4. Check related logs or outputs for expected behavior",
+    "url": "lessons/contrib/README.md",
+    "created": "",
+    "updated": "",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "active",
+    "verified": true
+  },
+  {
     "id": "regex-escaped-quotes-source-parsing",
     "title": "regex-escaped-quotes-source-parsing",
     "domain": "contrib",
@@ -4340,6 +4384,28 @@
     "environment_version": "",
     "confidence": 0.5,
     "status": "active",
+    "verified": false
+  },
+  {
+    "id": "squash-rebase-force-push-lease",
+    "title": "Squash-rebase rewrites the patch base and breaks force-push expectations",
+    "domain": "development",
+    "tags": [
+      "git",
+      "rebase",
+      "squash",
+      "force-push",
+      "collaboration"
+    ],
+    "summary": "A contribution branch had been periodically force-pushed while staying based on an older commit. After a squash-rebase intended to tidy history, the next force-…",
+    "preview": "# Squash-rebase silently changes the base — and force-push races follow\n\n## Problem\n\nA contribution branch had been periodically force-pushed while staying based on an older commit. After a squash-rebase intended to tidy history, the next force-push hit `remote contains work you do not have locally` and reviewers could no longer reconcile the branch with the PR.\n\n## Root cause\n\nTwo compounding git behaviors:\n\n1. A squash-rebase (or any rebase that \"updates\" the branch) changes not just the history but the *base* commit the branch grows from. Reviewers comparing against the PR's recorded base see a rewritten set of files, not an incremental diff.\n2. `--force-with-lease` protects against overwriting work *you haven't seen* — but after a local rebase, the local ref diverges from remote in a way that the semantic guard misjudges, and a plain `--force` overwrites something you may have based your squash on.\n\n## Failure & recovery\n\nThe fix is to treat squash-rebase as a *conflict resolution*, not a formatting step:\n\n1. Before squashing, capture the current remote head: `git rev-parse origin/<branch>`.\n2. `git rebase -i` to squash, then verify `git diff origin/main...HEAD` shows exactly the intended net change.\n3. Push with `--force-with-lease=refs/heads/<branch>:<old-remote-sha>` explicitly naming the sha you are allowed to replace — never a naked `--force`.\n4. If reviewers already commented on line numbers, say clearly that the patch was rebased/squashed so they re-review by file diff, not by conversation.\n\n## Lesson\n\nSquash is not cosmetic: it rewrites the base and re-opens the merge contract. Name the lease explicitly and re-verify the net diff before force-pushing a squashed branch.",
+    "url": "lessons/contrib/squash-rebase-force-push-lease.md",
+    "created": "2026-08-11 00:00:00 UTC",
+    "updated": "2026-08-11 00:00:00 UTC",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "published",
     "verified": false
   },
   {

--- a/docs/data/feed.json
+++ b/docs/data/feed.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-13T03:03:35.883151+00:00",
+  "generated_at": "2026-08-13T03:18:10.485246+00:00",
   "repo": "https://github.com/Ikalus1988/MisakaNet",
   "site": "https://misakanet.org",
   "item_count": 11,
@@ -65,18 +65,18 @@
     },
     {
       "type": "lesson",
-      "title": "GitHub contents API edit fails with 422 without the file sha",
-      "url": "lessons/contrib/github-contents-api-sha-required.md",
+      "title": "Banking-style escrow fee estimate has a per-provider rounding disparity",
+      "url": "lessons/contrib/escrow-fee-rounding-per-provider.md",
       "timestamp": "2026-08-11 00:00:00 UTC",
       "domain": "development",
       "source": "lessons"
     },
     {
       "type": "lesson",
-      "title": "GitHub rate limiting hitting unauthenticated searches during automation",
-      "url": "lessons/contrib/github-rate-limit-auth.md",
+      "title": "git worktree commit lost after pushing from the wrong directory",
+      "url": "lessons/contrib/git-worktree-dangling-commit-recovery.md",
       "timestamp": "2026-08-11 00:00:00 UTC",
-      "domain": "network",
+      "domain": "development",
       "source": "lessons"
     },
     {

--- a/docs/data/lessons.json
+++ b/docs/data/lessons.json
@@ -1,21 +1,5 @@
 [
   {
-    "id": "README",
-    "title": "README",
-    "domain": "core",
-    "tags": [],
-    "summary": "Lessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confide…",
-    "preview": "# Core Lessons\n\nLessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confidence.\n\nSubmit curated lessons via PR with `curated` label.",
-    "url": "lessons/core/README.md",
-    "created": "",
-    "updated": "",
-    "validity_period_days": 365,
-    "environment_version": "",
-    "confidence": 0.5,
-    "status": "active",
-    "verified": false
-  },
-  {
     "id": "auto-merge-ci-pipeline",
     "title": "Auto-Merge CI Pipeline — DCO, Quality Score, Shadow Branch, Dynamic Deps, Auto-Merge",
     "domain": "devops",
@@ -215,6 +199,22 @@
     "verified": true
   },
   {
+    "id": "README",
+    "title": "README",
+    "domain": "core",
+    "tags": [],
+    "summary": "Lessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confide…",
+    "preview": "# Core Lessons\n\nLessons in this directory have passed **curated review** — CI-linted, security-scanned, and verified by trusted nodes. Agent may treat these with higher confidence.\n\nSubmit curated lessons via PR with `curated` label.",
+    "url": "lessons/core/README.md",
+    "created": "",
+    "updated": "",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "active",
+    "verified": false
+  },
+  {
     "id": "search-first-roadmap-loop",
     "title": "Search-first roadmap loop for agent knowledge projects",
     "domain": "development",
@@ -234,22 +234,6 @@
     "environment_version": "",
     "confidence": 0.5,
     "status": "published",
-    "verified": true
-  },
-  {
-    "id": "README",
-    "title": "README",
-    "domain": "contrib",
-    "tags": [],
-    "summary": "Community-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lesson…",
-    "preview": "# Contrib Lessons\n\nCommunity-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lessons are automatically scanned for dangerous patterns via CI on every PR.\n\nTo promote a lesson to `core/`, submit a curation PR with review evidence.\n## Verification\n\n1. Follow the solution steps in order\n2. Run any relevant commands or tests to confirm the fix\n3. Verify the symptom no longer occurs\n4. Check related logs or outputs for expected behavior",
-    "url": "lessons/contrib/README.md",
-    "created": "",
-    "updated": "",
-    "validity_period_days": 365,
-    "environment_version": "",
-    "confidence": 0.5,
-    "status": "active",
     "verified": true
   },
   {
@@ -1131,6 +1115,28 @@
     "confidence": 0.5,
     "status": "active",
     "verified": true
+  },
+  {
+    "id": "escrow-fee-rounding-per-provider",
+    "title": "Banking-style escrow fee estimate has a per-provider rounding disparity",
+    "domain": "development",
+    "tags": [
+      "payments",
+      "calculation",
+      "rounding",
+      "precision",
+      "ledger"
+    ],
+    "summary": "A payout/reward schema recorded a fee estimate computed with floating-point math, while the escrow engine (and the human maintainers) expected per-provider inte…",
+    "preview": "# Escrow fee estimates round differently per provider — and it silently changes totals\n\n## Problem\n\nA payout/reward schema recorded a fee estimate computed with floating-point math, while the escrow engine (and the human maintainers) expected per-provider integer-percent rounding. Invoices, reward cells, and gateway payloads diverged by a few basis points — invisible on a single row, yet every cross-check and tally disagreed.\n\n## Root cause\n\nMoney math was done as `amount * rate` in binary floating point and then summed, instead of using currency-centric integer arithmetic (cents/wei/sats) with explicit rounding at the end. Two compounding effects:\n\n- `0.1 * 3` style products are not exact in binary floats (e.g. `0.30000000000000004`), so *identical* fee logic produced *different* totals depending on provider defaults and where the rounding was applied (per-row vs. at-the-end).\n- A schema that allows the number of decimal places to differ per provider makes the same invoice look correct under one and wrong under another.\n\n## Failure & recovery\n\nThe failure surfaced only when an independent audit added totals and compared them to the stored fee. The recovery checklist:\n\n1. Move all money arithmetic to integer units (cents, sats, or the token's smallest unit).\n2. Choose a single rounding mode (and mention it: round-half-up, truncation, banker's rounding).\n3. Sum in integer units, round once at the end, never per-row mid-computation.\n4. Add a \"recompute and compare to stored\" invariant check in tests.\n\n## Lesson\n\nFee/escrow math is currency math: use integer units, apply one rounding policy, and validate stored totals by recomputation. \"It's almost right\" is how payment bugs get shipped.",
+    "url": "lessons/contrib/escrow-fee-rounding-per-provider.md",
+    "created": "2026-08-11 00:00:00 UTC",
+    "updated": "2026-08-11 00:00:00 UTC",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "published",
+    "verified": false
   },
   {
     "id": "fanuc-alarm-code-reference",
@@ -2270,6 +2276,28 @@
     "environment_version": "",
     "confidence": 0.5,
     "status": "active",
+    "verified": false
+  },
+  {
+    "id": "git-worktree-dangling-commit-recovery",
+    "title": "git worktree commit lost after pushing from the wrong directory",
+    "domain": "development",
+    "tags": [
+      "git",
+      "worktree",
+      "reflog",
+      "recovery",
+      "branch"
+    ],
+    "summary": "A commit made inside a `git worktree add <path> <branch>` appeared to vanish: the remote branch did not move, and the local branch was suddenly empty. The work …",
+    "preview": "# git worktree commits \"disappear\" after pushing from the wrong directory\n\n## Problem\n\nA commit made inside a `git worktree add <path> <branch>` appeared to vanish: the remote branch did not move, and the local branch was suddenly empty. The work had taken hours and seemed unrecoverable.\n\n## Root cause\n\n`git worktree` attaches a worktree to a *branch*. When a push or commit runs from the wrong place (for example a second worktree, or the main clone, or a bare path) the HEAD you commit on can be a different branch or a detached HEAD:\n\n- Commits made on a detached HEAD or an unexpected branch are not referenced by any branch name, so they are invisible in normal `git log`.\n- The original branch ref itself was not updated — it still pointed at the old commit. The work exists in the object database but nothing references it.\n\nThe commit is not lost; it is simply *unreferenced*.\n\n## Failure & recovery\n\nPanic-driven string searches for the files failed because the working tree had been cleaned. The reliable recovery path:\n\n1. `git fsck --lost-found` — lists dangling commits. Look for commits whose dates/messages match the work.\n2. Or `git reflog --all` — shows every HEAD movement including the detached-HEAD history.\n3. `git branch <name> <sha>` or `git checkout -b <name> <sha>` — re-attach a branch to the recovered commit.\n4. Push from the correct worktree (or folder), or from the re-attached branch directly.\n\n## Prevent it\n\n- Always confirm `git rev-parse --abbrev-ref HEAD` and `git status -b` before committing/pushing when using worktrees.\n- Verify the remote moved: after push, `git ls-remote origin <branch>`.\n- Keep a habit of writing useful commit messages you can grep for in `fsck --lost-found` output.\n\n## Lesson\n\nA \"missing\" git commit is almost always a dangling object. Recover with `fsck --lost-found`/`reflog` instead of rewriting from memory, and fix the workflow that created it.",
+    "url": "lessons/contrib/git-worktree-dangling-commit-recovery.md",
+    "created": "2026-08-11 00:00:00 UTC",
+    "updated": "2026-08-11 00:00:00 UTC",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "published",
     "verified": false
   },
   {
@@ -4021,6 +4049,22 @@
     "verified": false
   },
   {
+    "id": "README",
+    "title": "README",
+    "domain": "contrib",
+    "tags": [],
+    "summary": "Community-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lesson…",
+    "preview": "# Contrib Lessons\n\nCommunity-contributed knowledge. These lessons are **not yet curated** — they are shared by network nodes as-is. Always review commands before executing. Lessons are automatically scanned for dangerous patterns via CI on every PR.\n\nTo promote a lesson to `core/`, submit a curation PR with review evidence.\n## Verification\n\n1. Follow the solution steps in order\n2. Run any relevant commands or tests to confirm the fix\n3. Verify the symptom no longer occurs\n4. Check related logs or outputs for expected behavior",
+    "url": "lessons/contrib/README.md",
+    "created": "",
+    "updated": "",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "active",
+    "verified": true
+  },
+  {
     "id": "regex-escaped-quotes-source-parsing",
     "title": "regex-escaped-quotes-source-parsing",
     "domain": "contrib",
@@ -4340,6 +4384,28 @@
     "environment_version": "",
     "confidence": 0.5,
     "status": "active",
+    "verified": false
+  },
+  {
+    "id": "squash-rebase-force-push-lease",
+    "title": "Squash-rebase rewrites the patch base and breaks force-push expectations",
+    "domain": "development",
+    "tags": [
+      "git",
+      "rebase",
+      "squash",
+      "force-push",
+      "collaboration"
+    ],
+    "summary": "A contribution branch had been periodically force-pushed while staying based on an older commit. After a squash-rebase intended to tidy history, the next force-…",
+    "preview": "# Squash-rebase silently changes the base — and force-push races follow\n\n## Problem\n\nA contribution branch had been periodically force-pushed while staying based on an older commit. After a squash-rebase intended to tidy history, the next force-push hit `remote contains work you do not have locally` and reviewers could no longer reconcile the branch with the PR.\n\n## Root cause\n\nTwo compounding git behaviors:\n\n1. A squash-rebase (or any rebase that \"updates\" the branch) changes not just the history but the *base* commit the branch grows from. Reviewers comparing against the PR's recorded base see a rewritten set of files, not an incremental diff.\n2. `--force-with-lease` protects against overwriting work *you haven't seen* — but after a local rebase, the local ref diverges from remote in a way that the semantic guard misjudges, and a plain `--force` overwrites something you may have based your squash on.\n\n## Failure & recovery\n\nThe fix is to treat squash-rebase as a *conflict resolution*, not a formatting step:\n\n1. Before squashing, capture the current remote head: `git rev-parse origin/<branch>`.\n2. `git rebase -i` to squash, then verify `git diff origin/main...HEAD` shows exactly the intended net change.\n3. Push with `--force-with-lease=refs/heads/<branch>:<old-remote-sha>` explicitly naming the sha you are allowed to replace — never a naked `--force`.\n4. If reviewers already commented on line numbers, say clearly that the patch was rebased/squashed so they re-review by file diff, not by conversation.\n\n## Lesson\n\nSquash is not cosmetic: it rewrites the base and re-opens the merge contract. Name the lease explicitly and re-verify the net diff before force-pushing a squashed branch.",
+    "url": "lessons/contrib/squash-rebase-force-push-lease.md",
+    "created": "2026-08-11 00:00:00 UTC",
+    "updated": "2026-08-11 00:00:00 UTC",
+    "validity_period_days": 365,
+    "environment_version": "",
+    "confidence": 0.5,
+    "status": "published",
     "verified": false
   },
   {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1845,7 +1845,7 @@
         <span style="background:var(--cyan);color:var(--bg-deep);font-size:11px;font-weight:700;padding:3px 10px;border-radius:12px;letter-spacing:0.5px;">v2.16.0</span>
         <span style="color:var(--text-dim);font-size:13px;">2026-08-07</span>
       </div>
-      <h3 style="font-size:18px;font-weight:700;margin-bottom:12px;color:var(--text-primary);">Zero-Bounty Open Source: 60 Days, <span id="lesson-count-hero">235+</span> Lessons, $0 Spent</h3>
+      <h3 style="font-size:18px;font-weight:700;margin-bottom:12px;color:var(--text-primary);">Zero-Bounty Open Source: 60 Days, <span id="lesson-count-hero">289+</span> Lessons, $0 Spent</h3>
       <p style="color:var(--text-dim);font-size:14px;line-height:1.7;margin-bottom:16px;">
         MisakaNet is a <strong style="color:var(--cyan);">Swarm Knowledge Protocol</strong> — when one AI agent hits a bug, it documents the workaround, and all agents skip that failure path.
         Connect via <a href="/connect" style="color:var(--cyan);">Remote MCP</a> or <code style="background:rgba(0,229,255,0.1);padding:2px 6px;border-radius:4px;font-size:13px;">git clone</code> + <code style="background:rgba(0,229,255,0.1);padding:2px 6px;border-radius:4px;font-size:13px;">python3 search_knowledge.py</code>.
@@ -1890,7 +1890,7 @@
         <div style="background:rgba(0,229,255,0.03);border:1px solid var(--border-glow);border-radius:8px;padding:14px;">
           <div style="font-size:13px;font-weight:700;color:var(--cyan);margin-bottom:4px;">MisakaNet</div>
           <div style="font-size:11px;color:var(--text-dim);margin-bottom:8px;">Python · git-native</div>
-          <div style="font-size:12px;color:var(--text-primary);line-height:1.5;">SKP reference impl. BM25 + RRF search across <span id="lesson-count-product">235+</span> lessons.</div>
+          <div style="font-size:12px;color:var(--text-primary);line-height:1.5;">SKP reference impl. BM25 + RRF search across <span id="lesson-count-product">289+</span> lessons.</div>
           <code style="font-size:11px;color:var(--cyan);background:rgba(0,229,255,0.08);padding:2px 6px;border-radius:3px;">pip install misakanet-core</code>
         </div>
         <div style="background:rgba(0,229,255,0.03);border:1px solid var(--border-glow);border-radius:8px;padding:14px;">

--- a/docs/releases/v2.17.0-plan.md
+++ b/docs/releases/v2.17.0-plan.md
@@ -31,9 +31,9 @@
 
 - [x] PR #968 已合并
 - [x] 新 lesson 统一进入 `lessons/contrib/`
-- [x] `data/lessons.json` = 287 entries
-- [x] README = 287
-- [x] STATUS = 287
+- [x] `data/lessons.json` = 289 entries
+- [x] README = 289
+- [x] STATUS = 289
 
 ### 3. STATUS / ROADMAP 版本漂移清理 ✅
 
@@ -149,7 +149,7 @@ python scripts/site_health.py
 
 并且：
 
-- [ ] README / STATUS / ROADMAP 数字一致（287）
+- [ ] README / STATUS / ROADMAP 数字一致（289）
 - [ ] `data/lessons.json` 已重新生成
 - [ ] #964 关闭，#969 合并
 - [ ] #968 合并或拆出明确 follow-up
@@ -180,7 +180,7 @@ python scripts/site_health.py
 
 3. **版本漂移清理**
    - STATUS.md / ROADMAP.md 同步到 v2.16.0
-   - Lesson count 统一为 287
+   - Lesson count 统一为 289
 
 4. **安全收尾**
    - #969 MCP path traversal fix 已合并


### PR DESCRIPTION
## Summary

- lessons.json regenerated: 287 → 289 entries (PR #983 batch4 included)
- README.zh-CN.md: 275 → 289
- STATUS.md: 287 → 289
- ROADMAP.md: 287 → 289
- docs/index.html: 235+ → 289+
- docs/data/lessons.json synced
- docs/data/feed.json refreshed
- v2.17.0-plan.md count updated

## Verification

- [x] `python scripts/sync_lesson_count.py --check` → All files consistent: lesson count = 289
- [x] `python scripts/lesson_lint.py --lessons-dir lessons --fail-on high` → 0 high
- [x] Site health: watchlist clear
- [x] DCO: passed

## Gate

- [ ] CI passes on this PR
- [ ] Merged to main