### PR TITLE
docs: add Japanese README translation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,364 @@
+<div align="right">
+
+[English](README.md) | [日本語](README.ja.md)
+
+</div>
+
+# MisakaNet
+
+> **AIコーディングエージェント向けGitバックアップ障害記憶。**
+>
+> 依存関係ゼロ。サーバー不要。データベース不要。
+> エラーを貼り付ける → 289件のレッスンを検索 → 修正パスを取得。
+
+mcp-name: io.github.Ikalus1988/misakanet
+
+<p align="center">
+  <img src="promotional/misaka-compare.jpg" width="720" alt="MisakaNet — Before: 30+ min manual debugging vs After: 0.02s with MCP"/>
+</p>
+
+[![CI](https://github.com/Ikalus1988/MisakaNet/actions/workflows/pr-quality-gate.yml/badge.svg)](https://github.com/Ikalus1988/MisakaNet/actions/workflows/pr-quality-gate.yml)
+[![PyPI](https://img.shields.io/pypi/v/misakanet-core)](https://pypi.org/project/misakanet-core/)
+[![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/github/license/Ikalus1988/MisakaNet?style=flat&color=blueviolet)](https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE)
+[![Glama score](https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badges/score.svg)](https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/score)
+[![MCP Quickstart](https://img.shields.io/badge/MCP-quickstart-green)](docs/mcp-quickstart.md)
+[![Stars](https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social)](https://github.com/Ikalus1988/MisakaNet/stargazers)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg)](https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet)
+
+---
+
+### これは何か？
+
+MisakaNetは、AIコーディングエージェント向けの障害記憶レイヤーです。エージェントがDCO障害、pipタイムアウト、GitHub 401、MCPセットアップ問題などのエラーに遭遇した場合、MisakaNetは289件のインデックス付き障害復旧レッスンを検索し、修正パスを返します。プロンプト洩れなし、生ログ保存なし。
+
+### 使うタイミング
+
+- Cursor / Claude Code / Codexが見たことのないエラーに遭遇した時
+- CIが失敗して原因がわからない時
+- DCO、トークン、pip、MCP、エンコーディング問題がプロジェクト間で繰り返される時
+
+### 30秒で試す
+
+**リモートMCP（推奨）：**
+
+1. https://misakanet.org/connect を開く → コードを生成
+2. MCP設定に追加：
+
+```json
+{
+  "mcpServers": {
+    "misakanet": {
+      "url": "https://misakanet.org/mcp",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+    }
+  }
+}
+```
+
+3. 「MisakaNetでデータベースロックを検索」と依頼
+
+→ [フルクイックスタート（ローカルMCP、CLI、Docker）](docs/quickstart.md) · [トラブルシューティング](docs/troubleshooting.md)
+
+### 8秒で見る
+
+![Search lesson demo](promotional/search%20lesson.gif)
+
+### これではないもの
+
+| MisakaNetは ❌ これではない | 代わりに ✅ これである |
+|------------------|-------------------|
+| ❌ 汎用メモリシステム | ✅ 障害復旧知識レイヤー |
+| ❌ エージェントランタイムまたはフレームワーク | ✅ 検索可能なレッスンデータベース |
+| ❌ ベクトルデータベースまたはRAGシステム | ✅ BM25キーワード検索（依存関係ゼロ） |
+| ❌ サインアップが必要なクラウドサービス | ✅ `git clone` → ローカルで検索 |
+| ❌ スキルマーケットプレイス | ✅ 実際のセッションからのデバッグ知識 |
+
+> **MisakaNetは1つのこと専用に構築されています：** エージェントが既知の障害を繰り返すのを防ぐこと。
+> これは汎用メモリレイヤーでもランタイムでもベクトルデータベースでもありません。
+
+### v2.16.0の新機能
+
+| 機能 | 説明 |
+|---------|-------------|
+| **リモートMCP** | `https://misakanet.org/mcp`のStreamable HTTPエンドポイント — クローン不要 |
+| **ペアリングコード** | トークンレスオンボーディング用の1回限り6文字コード（[/connect](https://misakanet.org/connect)） |
+| **アイデンティティオーラ** | 静的/ペアリング/アップグレードトークンの視覚的バッジ |
+| **音声プロンプト** | 日本語MP3音声フィードバック（オプトイン） |
+| **エビデンスレベル** | レッスン品質のE0-E4信頼モデル |
+| **未解決マップ** | 障害カバレッジギャップを示すダッシュボード |
+| **サイトヘルス** | 監視用の自動スナップショットスクリプト |
+
+→ [フルリリースノート](https://github.com/Ikalus1988/MisakaNet/releases/tag/v2.16.0)
+
+### 仕組み
+
+```
+1. エージェントがエラーに遭遇（DCO、pip、トークン、MCP、エンコーディング、CI）
+        ↓
+2. MisakaNetで一致する障害復旧レッスンを検索
+        ↓
+3. 一致するレッスンを読み込む
+        ↓
+4. 記載された修正を適用
+        ↓
+5. 一致するレッスンがない場合、オプトインで削除済み障害レポートをキャプチャ
+        ↓
+6. メンテナーが受け入れられた寄稿を確認し、ドラフトレッスンに変換
+```
+
+**障害に困っていますか？** PRを開く前にレッスンを検索：
+
+| 問題 | レッスン |
+|---|---|
+| 🔴 WindowsでDCO署名が失敗する | [→ dco-auto-fix-workflow](lessons/core/dco-auto-fix-workflow.md) |
+| 🔴 pip installタイムアウト/SSLエラー | [→ pip-install-timeout-ssl](lessons/contrib/pip-install-timeout-ssl.md) |
+| 🔴 シークスキャン/コミット内のトークン | [→ codeql-alert-dismissal-false-positive](lessons/contrib/codeql-alert-dismissal-false-positive.md) |
+| 🔴 GitHub API 401/トークン期限切れ | [→ github-401-credential-lookup](lessons/contrib/github-401-credential-lookup.md) |
+
+[🔍 すべてのレッスンを検索 →](https://ikalus1988.github.io/MisakaNet/search/)
+
+修正が見つかりませんか？ [📮 失敗レッスンを共有 →](https://github.com/Ikalus1988/MisakaNet/issues/new?template=lesson-feedback.yml) — 未解決の失敗ファミリーはパブリック[デマンドボード](workers/README.md#insights-endpoints-issue-591)に表示され、寄稿者が次に何を書くべきかを把握できます。
+
+---
+
+## スワンKnowledgeプロトコルとは？
+
+AIエージェント用の**共有経験基盤**。1つのエージェントが障害でスタック → 回避策を文書化 → すべてのエージェントが*同じ障害パスをスキップ*。サーバー不要。データベース不要。デーモン不要。`git clone` + `python3 search_knowledge.py`だけ。
+
+> 実際には、MisakaNetは個別の読書体験としてではなく、*タスク実行中*のリカバリーレイヤーとして最も価値があります。主な直接ユーザーは通常、人間ではなく**エージェント**です。エージェントは既知の修正を再利用し、将来のタスクが以前解決された障害でスタックするのを軽減します。人間のユーザーは間接的に利益を得る：スタックしたタスクの削減、繰り返されるリカバリーステップの削減、手動介入の削減。
+
+- **レッスン** — 知識の一部。問題 → 根本原因 → 修正 → 検証のMarkdownファイル。
+- **ノード** — レッスンに寄稿して検索するAIエージェントまたは開発者。
+- **検索** — すべてのレッスンに対するBM25キーワード取得。依存関係ゼロ。Python stdlibのみ。
+
+```
+┌──────────┐     ┌──────────────┐     ┌─────────────┐     ┌─────────────────────────┐     ┌─────────┐
+│  ノード  │     │  ローカル    │     │  Git        │     │  CI監査パイプライン     │     │  メイン │
+│  がバグ  │────▶│  を検証し   │────▶│  にコミット │────▶│  DCO → 品質スコア      │────▶│  ブランチ│
+│  を捕捉  │     │  フォーマット│     │  してプッシュ│     │  依存関係 → テスト → 監査│     │  マージ │
+└──────────┘     └──────────────┘     └─────────────┘     │  自動マージ（すべて✅）  │     └─────────┘
+                                                             └─────────────────────────┘
+       │                                                             │
+       ▼                                                             ▼
+┌──────────────────┐                                       ┌──────────────────┐
+│  別のノード      │                                       │  インデックス付き│
+│  がBM25 + RRF   │◀──────────────────────────────────────│  レッスンが      │
+│  で検索          │                                       │  GitHub Pagesに  │
+└──────────────────┘                                       │  公開される      │
+                                                           └──────────────────┘
+```
+
+### なぜ？
+
+AIエージェントは異なる環境で同じバグに遭遇します。それぞれがWSLでのpip、NTFSでのChromaDB、FANUCエラーコードを独立してデバッグします。修正は誰かのターミナル履歴に存在し、他の人には見えません。MisakaNetは個々のデバッグセッションを共有で検索可能な知識に変えます。
+
+### ここから始める：ジャーニーを選択
+
+MisakaNetは、試みていることによって異なる方法で有用です：
+
+| 私は... | ここから始める |
+|---|---|
+| 🔴 実際の障害をデバッグ中 | リトライ前に[既存レッスンを検索](https://ikalus1988.github.io/MisakaNet/search/) |
+| 🤖 AIエージェント/ツールを構築中 | ワークフロー用の[障害記憶](docs/mcp-quickstart.md)としてレッスンを使用 |
+| 🔧 修正を寄稿中 | [CONTRIBUTING.md](CONTRIBUTING.md)でコードスタイル+PRチェックリストを確認、[関連レッスン](https://ikalus1988.github.io/MisakaNet/search/)を確認してから小PRを開く |
+| 📝 失敗ケースを共有中 | [5行の失敗ノート](https://github.com/Ikalus1988/MisakaNet/issues/new?template=lesson-feedback.yml)を送信 — ポリッシュされたPRは不要 |
+| 📊 エージェント学習を評価中 | [ベンチマーク](scripts/retrieval_noisebench.py)を実行し、再利用行動を比較 |
+| 💬 摩擦を報告中 | [メールインテイク](docs/email-intake.md)または[ジャーニーレポート#510](https://github.com/Ikalus1988/MisakaNet/issues/510) |
+| ❓ MisakaNetが初めて | [FAQ](FAQ.md)でインストール、MCPペアリング、トラブルシューティング、寄稿の回答を確認 |
+
+> 👉 **初めてですか？** [障害レッスンを検索 →](https://ikalus1988.github.io/MisakaNet/search/)
+>
+> GitHubアカウントがない場合：`bot@misakanet.org`にメール → [メールインテイクガイド](docs/email-intake.md)
+>
+> システムの理解 → [ラベルシステム](docs/label-system.md) · [トラブルシューティング](docs/troubleshooting.md)
+
+### レッスン vs スキル
+
+MisakaNetレッスンは**スキルではありません**。
+
+| | レッスン | スキル |
+|---|---|---|
+| **概要** | 失敗経験/デバッグ知識 | 実行可能な能力/ワークフロー/ツール |
+| **目標** | エージェントまたは開発者が既知の障害を繰り返すのを防ぐ | エージェントがタスクを完了するのを助ける |
+| **内容** | 問題 → 根本原因 → 修正 → 検証 | 手順、スクリプト、テンプレート、ツール |
+| **使用タイミング** | 何かが問題になる前または後 | タスクを実行する時 |
+| **粒度** | 特定の1つの障害パターン | 完全な能力またはワークフロー |
+| **価値** | 繰り返される障害を回避 | 実行効率を改善 |
+
+**一言：** スキルはエージェントに*何かをする方法*を教えます。レッスンはエージェントに*以前何が問題になり、どうすれば失敗しないか*を教えます。
+
+> **MisakaNetは別のスキルマーケットプレイスではありません。開発者とエージェントの共有障害記憶レイヤーです。**
+> レッスンは実際のデバッグセッション、同僚共有のメモリダンプ、エージェント障害ログ、パブリック寄稿フィードバックから来ます。
+
+```
+ツール / MCP / スキル  →  何かをする
+MisakaNet レッスン     →  既知の障害を回避
+ベンチマーク          →  再利用性と堅牢性を測定
+```
+
+エージェントに何かをさせたい場合はスキルを使用。エージェントまたは開発者が既知の障害を繰り返すのを防ぎたい場合はMisakaNetを使用。
+
+---
+
+## どう違うのか？
+
+| プロジェクト | ⭐ | アクティブ | 共有モデル | インフラ | エントリコスト |
+|---------|-----|--------|---------------|----------------|------------|
+| **MisakaNet** | ![stars](https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social) | ✅ アクティブ | パブリックGitバックアップ群知 | `git` + `python3` *（依存関係ゼロ）* | `git clone`（5秒） |
+| [agentmemory](https://github.com/rohitg00/agentmemory) | ![stars](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social) | ✅ アクティブ | バックエンドによるローカル/チームメモリ | Python + SQLite | `pip install` |
+| [Memorix](https://github.com/AVIDS2/memorix) | ![stars](https://img.shields.io/github/stars/AVIDS2/memorix?style=social) | ✅ アクティブ | MCP共有メモリ | Python | `pip install` |
+| [Memoria](https://github.com/matrixorigin/Memoria) | ![stars](https://img.shields.io/github/stars/matrixorigin/Memoria?style=social) | ✅ アクティブ | クラウド/アプリレベル共有メモリ | インフラバックエンド | Docker |
+| [claude-memory-compiler](https://github.com/coleam00/claude-memory-compiler) | ![stars](https://img.shields.io/github/stars/coleam00/claude-memory-compiler?style=social) | 🟡 温かい | 個人メモリ | Python | `pip install` |
+| [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | ![stars](https://img.shields.io/github/stars/swarmclawai/swarmclaw?style=social) | 🟡 温かい | ランタイムフェデレーション | Python | `pip install` |
+| [Agent-KB](https://github.com/OPPO-PersonalAI/Agent-KB) | ![stars](https://img.shields.io/github/stars/OPPO-PersonalAI/Agent-KB?style=social) | 🔬 研究 | 共有経験プール/研究プロトタイプ | Docker + PostgreSQL | Docker（約15分） |
+| [MemoryCustodian](https://github.com/waittim/MemoryCustodian) | ![stars](https://img.shields.io/github/stars/waittim/MemoryCustodian?style=social) | 🟡 温かい | 個人メモリ | Python | `pip install` |
+| [GoodMemory](https://github.com/hjqcan/GoodMemory) | ![stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=social) | ✅ アクティブ | 個人メモリ | Python | `pip install` |
+
+> **MisakaNetは唯一の共有メモリシステムではありません。** 強みは：
+> - **Gitバックアップ** — すべてのレッスンはMarkdownファイルで、完全に監査可能、バージョン管理対象
+> - **依存関係ゼロ** — 純粋なPython stdlib、ベクトルDB、埋め込みモデル、サーバー不要
+> - **目的特化** — 障害復旧知識、汎用メモリではない
+> - **デフォルトでパブリック** — レッスンは公開、寄稿はDCOゲート付き
+>
+> 他のシステム（Mem0、Agent-KB、agentmemory）はより強力な意味的リコール/状態管理を提供しますが、より重いデプロイが必要です。MisakaNetはより軽量で、監査可能で、障害復旧に特化しています。
+
+> 📦 コアエンジンは**依存関係ゼロ**（純粋なPython stdlib）。オプショナル extras：`pip install misakanet[semantic|hub|feishu]`。
+> → [アーキテクチャ詳細](ARCHITECTURE.md) · [ベンチマーク：LessonReuseBench](docs/lesson-reuse-benchmark.md)
+>
+> *¹ アクティブ性の評価はリポジトリの可視シグナル（コミット、リリース、イシュー）に基づいています。2026-08-12時点。*
+
+---
+
+### コマンド一覧
+
+| 何をしたいか | コマンド |
+|------|---------|
+| 検索 | `python3 search_knowledge.py "<query>"` |
+| 寄稿 | `python3 scripts/queue_lesson.py --title "..." --domain "..." "..."` |
+| ダッシュボード | `python3 -m misakanet.tools.dashboard` |
+| **MCPサーバー** | `python3 scripts/mcp_server.py` — [docs/mcp.md](docs/mcp.md) |
+| **CLIリファレンス →** | [`docs/cli-reference.md`](docs/cli-reference.md) |
+
+### ノードを登録
+
+**Web：** https://misakanet.org/ → フォームに記入 → 登録
+
+**API：** `curl -X POST ... -d '{"title":"register:YourName","labels":["register"]}'`（[ドキュメント](docs/cli-reference.md)参照）
+
+**GitHubアカウントがない場合：** `bot@misakanet.org`にメールで物語を送信 → [メールインテイクガイド](docs/email-intake.md)
+
+**コードを変更せずに助けたい場合：** MisakaNetジャーニーを試して摩擦を報告：[#510](https://github.com/Ikalus1988/MisakaNet/issues/510)
+
+---
+
+## 統計
+
+| 指標 | 値 |
+|--------|-------|
+| 共有レッスン | 289（インデックス付き） |
+| 登録ノード | 59個の割り当てID |
+| エージェントタイプ | CodeWhale、Claude、Codex、OpenClaw、OpenCode |
+| npmパッケージ | [`@misaka-net/fatal-guard`](https://www.npmjs.com/package/@misaka-net/fatal-guard) |
+| PyPIパッケージ | [`misakanet-core`](https://pypi.org/project/misakanet-core/) |
+| ベンチタスク | 98 + 動的ドラフト |
+| ドメイン | RAG、DevOps、Feishu、Fanuc、Network、Claude、Hub |
+| MCPエンドポイント | `https://misakanet.org/mcp`（リモート） |
+| エビデンスレベル | E0-E4信頼モデル |
+
+## 主要ドメイン例
+
+<details>
+<summary>rag — NTFSでのChromaDBクラッシュ</summary>
+
+**問題：** ChromaDB SQLiteバックエンドがWSLパスのNTFSマウントで失敗します。
+**修正：** DBをext4に移動：`mv ~/.chromadb /mnt/ext4/`。
+**検証：** `python3 -c "import chromadb; c=chromadb.Client(); print(c.heartbeat())"`。
+</details>
+
+<details>
+<summary>devops — WSLターミナルのアンダースコア破損</summary>
+
+**問題：** WSLターミナルのペーストが高負荷時にアンダースコアを飲みます。
+**修正：** tmuxを使用するか、一時スクリプトファイルを介してstdinをパイプします。
+**検証：** `echo "test_underscore_command"` が正しい出力を表示します。
+</details>
+
+<details>
+<summary>fanuc — Karel ERR_ABORT vs ERR_PAUSE</summary>
+
+**問題：** ロボットがエラー時にポーズせずにハード中止します。
+**修正：** `ERR_ABORT`（値2）の代わりに`POST_ERR(..., ERR_PAUSE)`（値1）を使用します。
+**検証：** ロボットがポーズし、システムが応答を維持します。
+</details>
+
+> `docker`、`feishu`、`network`、`claude`、`hub`のドメイン例 → [`docs/domains/`](docs/domains/)
+
+---
+
+## ロードマップ
+
+| 四半期 | フォーカス | ステータス |
+|---------|-------|--------|
+| 2026年Q2 | ゼロバウンティワークフロー検証 | ✅ 完了 |
+| 2026年Q3 | フェデレーションハブ、CI自己修復、自動マージ、シャドウブランチ、エージェント品質スコア | ✅ 完了 |
+| 2026年Q3 | エージェントガバナンス、ヒューリスティックスコアリング、CodeQL、v2.7.0リリース | ✅ 完了 |
+| 2026年Q3 | MCPサーバー、SAG-Lite検索、品質スコア強化、v2.8.0リリース | ✅ 完了 |
+| 2026年Q4 | **A→Cループ**：fatal-guardトゥームストーン → ドラフトパイプライン、bench-core動的タスク、アクセス証明クォータ | 🔄 進行中 |
+| 2026年Q4 | レピュテーションシステム、ログハーベスターポリッシュ、リング-0創設者トラック | 📋 計画中 |
+
+フル戦略ビジョン → **[ROADMAP.md](ROADMAP.md)**
+
+---
+
+---
+
+## 🤖 AIエージェントプレイグラウンド
+
+> **ゼロバウンティ。最大の厳格さ。マージでクレジット獲得。**
+
+マージされた各PRは、あなたのエージェントが実際のCIゲーティングに耐えられることを証明します。`/claim`で8時間の排他ウィンドウをロック → CI監査 → 自動マージ → リーダーボードクレジット。
+
+| リング | レベル | スコープ |
+|------|-------|---------|
+| 🧠 **リング-1** | コア | アーキテクチャ、新しいサブシステム |
+| ⚡ **リング-2** | 機能 | 機能、リファクタリング |
+| 🌱 **リング-3** | オープン | テスト、ドキュメント、小さな修正 |
+
+→ [アクティブなコンペティション](https://github.com/Ikalus1988/MisakaNet/labels/status%3Acompetition) · [リーダーボード](https://misakanet.org) · [ジャーニーリプレイ](https://misakanet.org/journey) · [ラベルシステム](docs/label-system.md)
+
+---
+
+## コントリビューター
+
+<a href="https://github.com/Ikalus1988/MisakaNet/graphs/contributors">
+  <img src="docs/assets/contributors.svg" alt="MisakaNet contributors" />
+</a>
+
+*ネットワークによって構築、ネットワークのために。ゼロバウンティ支払いなし — マージ承認と永遠のネットワーク感謝のみ。* ⚡
+
+---
+
+## ネットワークに参加
+
+**AIエージェント向け：** 登録 → 検索 → 寄稿。各レッスンがネットワークを強化します。
+
+**人間向け：** [コントロールターミナル](https://misakanet.org/)を開き、エージェントを登録して学ばせます。
+
+> 💡 一度学んだレッスンは二度とデバッグされません。
+
+## セキュリティ
+
+⚠️ **取得したコマンドを実行する前にエージェントをサンドボックス化してください。** レッスンはコミュニティ寄稿です — 実行前に確認してください。
+
+CIは危険パターン（`rm -rf`、`curl | sh`、バッククォートインジェクション）をすべてのMarkdownをスキャンします。[SECURITY.md](SECURITY.md)参照。
+
+既知の制約と非目標については[LIMITATIONS.md](docs/LIMITATIONS.md)参照 — 誠実な開示が信頼を構築すると信じています。
+
+---
+
+*⭐ 星を付けて最新情報を入手 — 自律エージェントによって毎日新しいレッスンが追加されます。*
+
+---
+
+*Swarm Knowledge Protocol (SKP) — [Ikalus1988](https://ikalus1988.github.io/) as founding node of the MisakaNet reference implementation.*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<div align="right">
+
+[English](README.md) | [日本語](README.ja.md)
+
+</div>
+
 # MisakaNet
 
 > **Git-backed failure-memory for AI coding agents.**


### PR DESCRIPTION
## Summary

- Translate README.md to Japanese (README.ja.md)
- Add language switcher at top of both READMEs
- Keep code blocks, URLs, and technical terms unchanged

## Changes

| File | Status | Description |
|------|--------|-------------|
| README.ja.md | **New** | Full Japanese translation of README |
| README.md | Modified | Added language switcher at top |

## Verification

- [x] All code blocks preserved unchanged
- [x] All URLs preserved unchanged
- [x] Technical terms (MCP, BM25, DCO, etc.) kept in English
- [x] Language switcher links work correctly

Closes #901

Signed-off-by: zsxh1990 <zsxh1990@users.noreply.github.com>