### PR TITLE
feat: add evidence level badge design system

### DIFF
--- a/docs/assets/badges/evidence-e0.svg
+++ b/docs/assets/badges/evidence-e0.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20" role="img" aria-labelledby="e0-title">
+  <title id="e0-title">Evidence Level E0: Unverified</title>
+  <defs>
+    <linearGradient id="e0Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#6b7280;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#4b5563;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="20" rx="4" fill="url(#e0Grad)"/>
+  <text x="50" y="14" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">E0: Unverified</text>
+</svg>

--- a/docs/assets/badges/evidence-e1.svg
+++ b/docs/assets/badges/evidence-e1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20" role="img" aria-labelledby="e1-title">
+  <title id="e1-title">Evidence Level E1: Self-reported</title>
+  <defs>
+    <linearGradient id="e1Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#dc2626;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="20" rx="4" fill="url(#e1Grad)"/>
+  <text x="50" y="14" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">E1: Self-reported</text>
+</svg>

--- a/docs/assets/badges/evidence-e2.svg
+++ b/docs/assets/badges/evidence-e2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20" role="img" aria-labelledby="e2-title">
+  <title id="e2-title">Evidence Level E2: Verified fix</title>
+  <defs>
+    <linearGradient id="e2Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d97706;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="20" rx="4" fill="url(#e2Grad)"/>
+  <text x="50" y="14" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">E2: Verified fix</text>
+</svg>

--- a/docs/assets/badges/evidence-e3.svg
+++ b/docs/assets/badges/evidence-e3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20" role="img" aria-labelledby="e3-title">
+  <title id="e3-title">Evidence Level E3: Peer-reviewed</title>
+  <defs>
+    <linearGradient id="e3Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#2563eb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="20" rx="4" fill="url(#e3Grad)"/>
+  <text x="50" y="14" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">E3: Peer-reviewed</text>
+</svg>

--- a/docs/assets/badges/evidence-e4.svg
+++ b/docs/assets/badges/evidence-e4.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20" role="img" aria-labelledby="e4-title">
+  <title id="e4-title">Evidence Level E4: Maintainer-verified</title>
+  <defs>
+    <linearGradient id="e4Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#10b981;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="20" rx="4" fill="url(#e4Grad)"/>
+  <text x="50" y="14" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">E4: Maintainer-verified</text>
+</svg>

--- a/docs/evidence-badges.md
+++ b/docs/evidence-badges.md
@@ -1,0 +1,41 @@
+# Evidence Level Badges
+
+MisakaNet uses an E0-E4 evidence level system to indicate the trust level of each lesson.
+
+## Badge Colors
+
+| Level | Badge | Color | Meaning |
+|-------|-------|-------|---------|
+| E0 | ![E0](assets/badges/evidence-e0.svg) | Gray | Unverified — lesson not yet validated |
+| E1 | ![E1](assets/badges/evidence-e1.svg) | Red | Self-reported — submitted by author without verification |
+| E2 | ![E2](assets/badges/evidence-e2.svg) | Orange | Verified fix — fix has been tested and confirmed |
+| E3 | ![E3](assets/badges/evidence-e3.svg) | Blue | Peer-reviewed — reviewed and approved by another contributor |
+| E4 | ![E4](assets/badges/evidence-e4.svg) | Green | Maintainer-verified — verified by a project maintainer |
+
+## Usage in Lessons
+
+Add the evidence level to your lesson's frontmatter:
+
+```yaml
+---
+evidence_level: E2
+---
+```
+
+## Badge Rendering
+
+Badges are automatically rendered in the lesson search results and detail pages.
+
+## Accessibility
+
+- All badges include `<title>` elements for screen readers
+- `role="img"` and `aria-labelledby` attributes are included
+- Color is not the only indicator — text labels are always present
+
+## Design Rationale
+
+- **Gray (E0):** Neutral, indicates unknown/unverified state
+- **Red (E1):** Warning color, indicates unverified self-report
+- **Orange (E2):** Caution color, indicates verified but not reviewed
+- **Blue (E3):** Trust color, indicates peer review
+- **Green (E4):** Success color, indicates maintainer verification


### PR DESCRIPTION
## Summary

- Create SVG badges for E0-E4 evidence levels
- Add documentation for badge system
- Color coding: E0(gray) → E4(green)
- Accessible: role=img, aria-labelledby, title elements
- Fix path resolution in documentation

## Changes

| File | Status | Description |
|------|--------|-------------|
| docs/assets/badges/evidence-e0.svg | **New** | E0: Unverified (gray) |
| docs/assets/badges/evidence-e1.svg | **New** | E1: Self-reported (red) |
| docs/assets/badges/evidence-e2.svg | **New** | E2: Verified fix (orange) |
| docs/assets/badges/evidence-e3.svg | **New** | E3: Peer-reviewed (blue) |
| docs/assets/badges/evidence-e4.svg | **New** | E4: Maintainer-verified (green) |
| docs/evidence-badges.md | **New** | Documentation for badge system |

## Accessibility

- All SVGs include title elements for screen readers
- role=img and aria-labelledby attributes are included
- Color is not the only indicator — text labels are always present

## Design Rationale

- Gray (E0): Neutral, indicates unknown/unverified state
- Red (E1): Warning color, indicates unverified self-report
- Orange (E2): Caution color, indicates verified but not reviewed
- Blue (E3): Trust color, indicates peer review
- Green (E4): Success color, indicates maintainer verification

Closes #906

Signed-off-by: zsxh1990 <zsxh1990@users.noreply.github.com>