### PR TITLE
feat(ci): add PyPI release workflow for wheel and sdist

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,49 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Adds automated PyPI publishing workflow triggered on version tags.

## Changes

- New workflow: 
- Trigger:  tag push
- Build: wheel + sdist via 
- Publish: PyPI trusted publisher (OIDC, no token needed)

## Setup Required

Repo owner needs to:
1. Create  environment in Settings → Environments
2. Configure PyPI trusted publisher for this repo

## Testing

Workflow can be tested by pushing a tag:
```bash
git tag v2.17.0
git push origin v2.17.0
```

Closes #1003