### PR TITLE
feat(bench): add five canonical failure fixtures

### DIFF
--- a/bench/fixtures/README.md
+++ b/bench/fixtures/README.md
@@ -1,0 +1,19 @@
+# Canonical benchmark fixtures
+
+This directory contains five deterministic failure scenarios for benchmark and
+self-healing-agent tests. Every fixture has the same contract:
+
+- `setup.sh <workdir>` creates the failure state and exits successfully.
+- `expected.json` describes the failure, expected outcome, and verification.
+- `teardown.sh <workdir>` removes the state created by setup.
+
+The scripts never write outside the work directory supplied by the caller.
+The fixture loader is available at `bench/phase-b/orchestrator.py`:
+
+```bash
+python3 bench/phase-b/orchestrator.py --list
+python3 bench/phase-b/orchestrator.py --fixture dco-signoff --json
+```
+
+The fixtures are intentionally small and local-only: no network, credentials,
+or external services are required.

--- a/bench/fixtures/dco-signoff/expected.json
+++ b/bench/fixtures/dco-signoff/expected.json
@@ -1,0 +1,15 @@
+{
+  "scenario": "dco-signoff",
+  "title": "DCO sign-off missing from a commit",
+  "failure": {
+    "type": "missing_dco_trailer",
+    "evidence": "The latest commit has no Signed-off-by trailer."
+  },
+  "expected_fix": "Amend or recreate the commit with git commit --signoff, then verify the trailer.",
+  "expected_outcome": "success",
+  "verifier": {
+    "type": "file_content",
+    "path": "commit-message.txt",
+    "must_not_contain": "Signed-off-by:"
+  }
+}

--- a/bench/fixtures/dco-signoff/setup.sh
+++ b/bench/fixtures/dco-signoff/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: setup.sh WORKDIR}
+rm -rf -- "$workdir"
+mkdir -p "$workdir/repo"
+
+git -C "$workdir/repo" init -q
+git -C "$workdir/repo" config user.name "Fixture Author"
+git -C "$workdir/repo" config user.email "fixture@example.invalid"
+printf 'fixture\n' > "$workdir/repo/README.md"
+git -C "$workdir/repo" add README.md
+git -C "$workdir/repo" -c commit.gpgsign=false commit -q -m 'fixture commit without DCO sign-off'
+
+git -C "$workdir/repo" log -1 --format='%B' > "$workdir/commit-message.txt"

--- a/bench/fixtures/dco-signoff/teardown.sh
+++ b/bench/fixtures/dco-signoff/teardown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: teardown.sh WORKDIR}
+rm -rf -- "$workdir"

--- a/bench/fixtures/git-merge-conflict/expected.json
+++ b/bench/fixtures/git-merge-conflict/expected.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "git-merge-conflict",
+  "title": "Git merge conflict on the same file",
+  "failure": {
+    "type": "merge_conflict",
+    "path": "repo/config.txt",
+    "evidence": "git status reports an unmerged path and the file contains conflict markers."
+  },
+  "expected_fix": "Resolve the conflict markers, stage the resolved file, and complete the merge commit.",
+  "expected_outcome": "success_with_human_input",
+  "verifier": {
+    "type": "file_content",
+    "path": "repo/config.txt",
+    "must_contain": "<<<<<<< HEAD"
+  }
+}

--- a/bench/fixtures/git-merge-conflict/setup.sh
+++ b/bench/fixtures/git-merge-conflict/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: setup.sh WORKDIR}
+rm -rf -- "$workdir"
+mkdir -p "$workdir/repo"
+
+git -C "$workdir/repo" init -q
+git -C "$workdir/repo" config user.name "Fixture Author"
+git -C "$workdir/repo" config user.email "fixture@example.invalid"
+printf 'original\n' > "$workdir/repo/config.txt"
+git -C "$workdir/repo" add config.txt
+git -C "$workdir/repo" -c commit.gpgsign=false commit -q -m 'fixture base commit'
+git -C "$workdir/repo" switch -q -c conflicting-change
+printf 'change from branch\n' > "$workdir/repo/config.txt"
+git -C "$workdir/repo" add config.txt
+git -C "$workdir/repo" -c commit.gpgsign=false commit -q -m 'conflicting branch change'
+git -C "$workdir/repo" switch -q master 2>/dev/null || git -C "$workdir/repo" switch -q main
+printf 'change from base\n' > "$workdir/repo/config.txt"
+git -C "$workdir/repo" add config.txt
+git -C "$workdir/repo" -c commit.gpgsign=false commit -q -m 'base branch change'
+git -C "$workdir/repo" merge conflicting-change >/dev/null 2>&1 || true

--- a/bench/fixtures/git-merge-conflict/teardown.sh
+++ b/bench/fixtures/git-merge-conflict/teardown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: teardown.sh WORKDIR}
+rm -rf -- "$workdir"

--- a/bench/fixtures/mcp-invalid-json/expected.json
+++ b/bench/fixtures/mcp-invalid-json/expected.json
@@ -1,0 +1,17 @@
+{
+  "scenario": "mcp-invalid-json",
+  "title": "MCP server receives malformed JSON",
+  "failure": {
+    "type": "JSONDecodeError",
+    "input": "invalid-input.json",
+    "command": "python3 server.py < invalid-input.json",
+    "exit_code": 1
+  },
+  "expected_fix": "Send syntactically valid JSON-RPC input before invoking the MCP server.",
+  "expected_outcome": "success",
+  "verifier": {
+    "type": "command_exit",
+    "command": "python3 server.py < invalid-input.json",
+    "expected_exit_code": 1
+  }
+}

--- a/bench/fixtures/mcp-invalid-json/setup.sh
+++ b/bench/fixtures/mcp-invalid-json/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: setup.sh WORKDIR}
+rm -rf -- "$workdir"
+mkdir -p "$workdir"
+cat > "$workdir/server.py" <<'PY'
+import json
+import sys
+
+request = json.loads(sys.stdin.read())
+if request.get("jsonrpc") != "2.0":
+    raise ValueError("invalid JSON-RPC request")
+print(json.dumps({"jsonrpc": "2.0", "id": request.get("id"), "result": {}}))
+PY
+printf '%s\n' '{"jsonrpc": "2.0",' > "$workdir/invalid-input.json"
+printf '%s\n' '{"jsonrpc": "2.0", "id": 1, "method": "initialize"}' > "$workdir/valid-input.json"

--- a/bench/fixtures/mcp-invalid-json/teardown.sh
+++ b/bench/fixtures/mcp-invalid-json/teardown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: teardown.sh WORKDIR}
+rm -rf -- "$workdir"

--- a/bench/fixtures/python-import-error/expected.json
+++ b/bench/fixtures/python-import-error/expected.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "python-import-error",
+  "title": "Python import error for a missing module",
+  "failure": {
+    "type": "ModuleNotFoundError",
+    "command": "python3 app.py",
+    "exit_code": 1
+  },
+  "expected_fix": "Install the dependency or replace the import with the intended available module.",
+  "expected_outcome": "success",
+  "verifier": {
+    "type": "command_exit",
+    "command": "python3 app.py",
+    "expected_exit_code": 1
+  }
+}

--- a/bench/fixtures/python-import-error/setup.sh
+++ b/bench/fixtures/python-import-error/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: setup.sh WORKDIR}
+rm -rf -- "$workdir"
+mkdir -p "$workdir"
+cat > "$workdir/app.py" <<'PY'
+import module_that_does_not_exist
+
+print("unreachable")
+PY

--- a/bench/fixtures/python-import-error/teardown.sh
+++ b/bench/fixtures/python-import-error/teardown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: teardown.sh WORKDIR}
+rm -rf -- "$workdir"

--- a/bench/fixtures/timeout-hang/expected.json
+++ b/bench/fixtures/timeout-hang/expected.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "timeout-hang",
+  "title": "Process hangs until the benchmark timeout",
+  "failure": {
+    "type": "timeout",
+    "command": "python3 hang.py",
+    "timeout_seconds": 1
+  },
+  "expected_fix": "Add a bounded timeout or terminate the hung process and report the timeout explicitly.",
+  "expected_outcome": "timeout",
+  "verifier": {
+    "type": "process_timeout",
+    "command": "python3 hang.py",
+    "timeout_seconds": 1
+  }
+}

--- a/bench/fixtures/timeout-hang/setup.sh
+++ b/bench/fixtures/timeout-hang/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: setup.sh WORKDIR}
+rm -rf -- "$workdir"
+mkdir -p "$workdir"
+cat > "$workdir/hang.py" <<'PY'
+while True:
+    pass
+PY

--- a/bench/fixtures/timeout-hang/teardown.sh
+++ b/bench/fixtures/timeout-hang/teardown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir=${1:?usage: teardown.sh WORKDIR}
+rm -rf -- "$workdir"

--- a/bench/phase-b/orchestrator.py
+++ b/bench/phase-b/orchestrator.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Load and verify the five canonical self-healing benchmark fixtures.
+
+The fixture format is deliberately data-first: expected.json documents the
+failure and verifier, while setup.sh and teardown.sh own the temporary state.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+REQUIRED_EXPECTED_FIELDS = {"scenario", "title", "failure", "expected_fix", "expected_outcome", "verifier"}
+EXPECTED_OUTCOMES = {"success", "success_with_human_input", "timeout"}
+VERIFIER_TYPES = {"command_exit", "file_content", "process_timeout"}
+
+
+def fixture_names() -> list[str]:
+    return sorted(path.name for path in FIXTURES_DIR.iterdir() if path.is_dir())
+
+
+def load_fixture(name: str) -> dict[str, Any]:
+    if name not in fixture_names():
+        raise ValueError(f"unknown fixture {name!r}; choose from: {', '.join(fixture_names())}")
+    path = FIXTURES_DIR / name
+    expected_path = path / "expected.json"
+    setup_path = path / "setup.sh"
+    teardown_path = path / "teardown.sh"
+    if not expected_path.is_file() or not setup_path.is_file() or not teardown_path.is_file():
+        raise ValueError(f"fixture {name!r} must contain setup.sh, expected.json, and teardown.sh")
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    missing = REQUIRED_EXPECTED_FIELDS - expected.keys()
+    if missing:
+        raise ValueError(f"fixture {name!r} missing expected.json fields: {sorted(missing)}")
+    verifier = expected["verifier"]
+    if verifier.get("type") not in VERIFIER_TYPES:
+        raise ValueError(f"fixture {name!r} has unsupported verifier type {verifier.get('type')!r}")
+    if expected["expected_outcome"] not in EXPECTED_OUTCOMES:
+        raise ValueError(f"fixture {name!r} has unsupported expected outcome")
+    return {"name": name, "path": str(path), "expected": expected}
+
+
+def _run(command: str, workdir: Path, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, shell=True, cwd=workdir, text=True, capture_output=True, timeout=timeout)
+
+
+def verify_fixture(name: str) -> dict[str, Any]:
+    fixture = load_fixture(name)
+    path = Path(fixture["path"])
+    expected = fixture["expected"]
+    workdir = Path(tempfile.mkdtemp(prefix=f"misakanet-fixture-{name}-"))
+    try:
+        setup = subprocess.run([str(path / "setup.sh"), str(workdir)], text=True, capture_output=True, timeout=10)
+        if setup.returncode:
+            return {"fixture": name, "status": "FAIL", "reason": "setup failed", "output": setup.stderr}
+
+        verifier = expected["verifier"]
+        verifier_type = verifier["type"]
+        if verifier_type == "file_content":
+            target = workdir / verifier["path"]
+            content = target.read_text(encoding="utf-8") if target.exists() else ""
+            if "must_contain" in verifier:
+                ok = verifier["must_contain"] in content
+            else:
+                ok = verifier["must_not_contain"] not in content
+            detail = f"checked {target}"
+        elif verifier_type == "command_exit":
+            result = _run(verifier["command"], workdir, 10)
+            ok = result.returncode == verifier["expected_exit_code"]
+            detail = f"exit={result.returncode}, expected={verifier['expected_exit_code']}"
+        else:
+            try:
+                result = _run(verifier["command"], workdir, verifier["timeout_seconds"])
+                ok = False
+                detail = f"process exited with code {result.returncode} before timeout"
+            except subprocess.TimeoutExpired:
+                ok = True
+                detail = f"timed out at {verifier['timeout_seconds']}s as expected"
+
+        return {"fixture": name, "status": "PASS" if ok else "FAIL", "detail": detail}
+    finally:
+        subprocess.run([str(path / "teardown.sh"), str(workdir)], text=True, capture_output=True, timeout=10)
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="list fixture names")
+    parser.add_argument("--fixture", choices=fixture_names(), help="load and verify one fixture")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable output")
+    args = parser.parse_args()
+
+    if args.list:
+        result: Any = [load_fixture(name)["expected"] | {"name": name} for name in fixture_names()]
+    elif args.fixture:
+        result = verify_fixture(args.fixture)
+    else:
+        result = [verify_fixture(name) for name in fixture_names()]
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    elif args.list:
+        for item in result:
+            print(f"{item['name']}: {item['title']}")
+    elif isinstance(result, list):
+        for item in result:
+            print(f"{item['status']} {item['fixture']}: {item.get('detail', item.get('reason', ''))}")
+    else:
+        print(f"{result['status']} {result['fixture']}: {result.get('detail', result.get('reason', ''))}")
+    return 0 if (args.list or all(item["status"] == "PASS" for item in (result if isinstance(result, list) else [result]))) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_fixtures.py
+++ b/tests/test_benchmark_fixtures.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Tests for canonical benchmark fixtures and the Phase-B loader."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+ORCHESTRATOR = REPO / "bench" / "phase-b" / "orchestrator.py"
+FIXTURES = REPO / "bench" / "fixtures"
+EXPECTED_NAMES = {
+    "dco-signoff",
+    "python-import-error",
+    "mcp-invalid-json",
+    "git-merge-conflict",
+    "timeout-hang",
+}
+
+
+def test_fixture_contracts_are_complete():
+    names = {p.name for p in FIXTURES.iterdir() if p.is_dir()}
+    assert names == EXPECTED_NAMES
+    for name in names:
+        path = FIXTURES / name
+        assert (path / "setup.sh").is_file()
+        assert (path / "teardown.sh").is_file()
+        expected = json.loads((path / "expected.json").read_text(encoding="utf-8"))
+        assert expected["scenario"] == name
+        assert expected["expected_fix"]
+        assert expected["expected_outcome"] in {"success", "success_with_human_input", "timeout"}
+        assert expected["verifier"]["type"] in {"command_exit", "file_content", "process_timeout"}
+        if expected["verifier"]["type"] == "file_content":
+            assert "must_contain" in expected["verifier"] or "must_not_contain" in expected["verifier"]
+
+
+def test_orchestrator_lists_all_fixtures():
+    result = subprocess.run(
+        [sys.executable, str(ORCHESTRATOR), "--list", "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    listed = {item["name"] for item in json.loads(result.stdout)}
+    assert listed == EXPECTED_NAMES
+
+
+def test_each_fixture_verifies():
+    result = subprocess.run(
+        [sys.executable, str(ORCHESTRATOR), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    reports = json.loads(result.stdout)
+    assert {report["fixture"] for report in reports} == EXPECTED_NAMES
+    assert all(report["status"] == "PASS" for report in reports), reports


### PR DESCRIPTION
## Summary
- add five deterministic canonical failure fixtures under `bench/fixtures/`
- add the Phase-B fixture loader/verifier at `bench/phase-b/orchestrator.py`
- add contract and end-to-end tests for fixture discovery and verification

## Verification
- `python3 bench/phase-b/orchestrator.py --json` — 5/5 PASS
- `python3 -m pytest -q tests/test_benchmark_fixtures.py tests/test_benchmark_tasks.py` — 11 passed
- `bash -n bench/fixtures/*/*.sh`
- `git diff --check`

/claim #1017