### PR TITLE
feat(fatal-guard): harden CLI entry point

### DIFF
--- a/packages/fatal-guard/README.md
+++ b/packages/fatal-guard/README.md
@@ -14,6 +14,26 @@ One env var. No source code changes.
 
 ## Quick start
 
+### CLI flags and exit codes
+
+The wrapper provides deterministic CLI behavior:
+
+```text
+0  wrapped command completed successfully
+1  wrapped command failed or could not be started
+2  invalid usage
+3  wrapped command exceeded --timeout
+```
+
+```bash
+fatal-guard --help
+fatal-guard --version
+fatal-guard --timeout 5000 -- node app.js
+```
+
+`--timeout` defaults to `0` (disabled). A missing executable, malformed option,
+or missing `FATAL_HANDLER` on a crash produces an actionable stderr message.
+
 ### Wrapper mode (no code changes needed)
 
 ```bash

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -3,101 +3,263 @@
  * @misaka-net/fatal-guard — CLI wrapper mode
  *
  * Usage:
- *   npx @misaka-net/fatal-guard -- <command> [args...]
- *   FATAL_HANDLER=/usr/bin/logger npx @misaka-net/fatal-guard -- node app.js
+ *   fatal-guard [--timeout <ms>] -- <command> [args...]
  *
- * Spawns the command as a child process, monitors stderr and exit code,
- * fires the external handler on non-zero exit with crash signal.
+ * Exit codes:
+ *   0  wrapped command completed successfully
+ *   1  wrapped command failed or could not be started
+ *   2  invalid CLI usage
+ *   3  wrapped command exceeded --timeout
  */
 
 const { spawn } = require('node:child_process');
-
-const args = process.argv.slice(2);
-
-if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
-  console.error(`
-Usage:
-  FATAL_HANDLER=/usr/bin/logger npx @misaka-net/fatal-guard -- <command> [args...]
-
-Examples:
-  npx @misaka-net/fatal-guard -- node app.js
-  FATAL_HANDLER=/usr/bin/logger npx @misaka-net/fatal-guard -- ./node_modules/.bin/vite build
-
-Wraps any Node.js CLI with fatal error monitoring — zero source code changes.
-`);
-  process.exit(args.length === 0 ? 1 : 0);
-}
-
-// Remove leading `--` if present (allows `fatal-guard -- cmd` syntax)
-let cmdArgs = args;
-if (cmdArgs[0] === '--') {
-  cmdArgs = cmdArgs.slice(1);
-}
-
-if (cmdArgs.length === 0) {
-  console.error('fatal-guard: missing command after --');
-  process.exit(1);
-}
-
-const { buildPayload, runHandler } = require('../index');
+const fs = require('node:fs');
+const path = require('node:path');
+const { buildPayload } = require('../index');
 const { redact } = require('../src/lib/redact');
 
-// ── TTY detection ────────────────────────────────────────────────
-// If parent stderr is a TTY, inherit it so child processes see a real TTY
-// (preserves ANSI colors and interactive behavior).  Otherwise pipe stderr
-// to capture error output for crash detection + snippet.
-const stderrIsTTY = !!process.stderr.isTTY;
+const EXIT = Object.freeze({ OK: 0, ERROR: 1, USAGE: 2, TIMEOUT: 3 });
+const FATAL_SIGNALS = new Set([
+  'SIGKILL', 'SIGSEGV', 'SIGABRT', 'SIGBUS',
+  'SIGFPE', 'SIGILL', 'SIGTRAP', 'SIGSYS',
+]);
+const HANDLER_TIMEOUT_MS = 1000;
 
-const child = spawn(cmdArgs[0], cmdArgs.slice(1), {
-  stdio: ['inherit', 'inherit', stderrIsTTY ? 'inherit' : 'pipe'],
-  shell: false,
-});
+function version() {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version;
+  } catch (_) {
+    return 'unknown';
+  }
+}
 
-// ── stderr capture (only when piping, i.e. non-TTY) ─────────────
-let stderrBuffer = '';
-if (!stderrIsTTY && child.stderr) {
-  child.stderr.on('data', (chunk) => {
-    stderrBuffer += chunk.toString();
-    process.stderr.write(chunk); // pass through to user terminal
+function printHelp(stream = process.stdout) {
+  stream.write(`Usage:
+  fatal-guard [options] -- <command> [args...]
+
+Options:
+  --timeout <ms>  Stop a hung command after <ms> milliseconds (default: 0, no timeout)
+  --help, -h      Show this help text
+  --version, -v   Show the package version
+
+Exit codes:
+  0  command completed successfully
+  1  command failed or could not be started
+  2  invalid usage
+  3  command timed out
+
+Examples:
+  fatal-guard -- node app.js
+  fatal-guard --timeout 5000 -- node app.js
+  FATAL_HANDLER=/usr/bin/logger fatal-guard -- node app.js
+`);
+}
+
+function usageError(message) {
+  process.stderr.write(`fatal-guard: ${message}\n`);
+  process.stderr.write('Run `fatal-guard --help` for usage.\n');
+  process.exit(EXIT.USAGE);
+}
+
+function parseArgs(args) {
+  const options = { timeout: 0 };
+  let index = 0;
+  let commandStart = -1;
+
+  while (index < args.length) {
+    const arg = args[index];
+    if (arg === '--') {
+      commandStart = index + 1;
+      break;
+    }
+    if (arg === '--help' || arg === '-h') {
+      if (args.length !== 1) usageError('--help cannot be combined with a command');
+      printHelp();
+      process.exit(EXIT.OK);
+    }
+    if (arg === '--version' || arg === '-v') {
+      if (args.length !== 1) usageError('--version cannot be combined with a command');
+      process.stdout.write(`${version()}\n`);
+      process.exit(EXIT.OK);
+    }
+
+    let value;
+    if (arg === '--timeout') {
+      if (index + 1 >= args.length) usageError('--timeout requires a value in milliseconds');
+      value = args[++index];
+    } else if (arg.startsWith('--timeout=')) {
+      value = arg.slice('--timeout='.length);
+    } else if (arg.startsWith('-')) {
+      usageError(`unknown option: ${arg}`);
+    } else {
+      // Preserve the original wrapper syntax: `fatal-guard node app.js`.
+      commandStart = index;
+      break;
+    }
+
+    if (!/^\d+$/.test(value)) usageError(`invalid timeout: ${value}`);
+    options.timeout = Number(value);
+    if (!Number.isSafeInteger(options.timeout)) usageError(`timeout is too large: ${value}`);
+    index += 1;
+  }
+
+  if (args.length === 0) usageError('missing command');
+  if (commandStart < 0 || commandStart >= args.length) usageError('missing command after --');
+  options.command = args.slice(commandStart);
+  return options;
+}
+
+function handlerSpec() {
+  return (
+    process.env.FATAL_HANDLER ||
+    process.env.MISAKANET_ERROR_HANDLER ||
+    process.env.VITE_ERROR_HANDLER ||
+    process.env.E2B_ERROR_HANDLER ||
+    process.env.OPENCLAW_ERROR_HANDLER ||
+    ''
+  ).trim();
+}
+
+// Parse a handler command without invoking a shell. This supports the documented
+// `/path/to/handler` form and simple quoted paths while keeping payloads argv-safe.
+function splitCommand(value) {
+  const parts = [];
+  let part = '';
+  let quote = '';
+  let escaped = false;
+  for (const char of value) {
+    if (escaped) {
+      part += char;
+      escaped = false;
+    } else if (char === '\\') {
+      escaped = true;
+    } else if (quote) {
+      if (char === quote) quote = '';
+      else part += char;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (/\s/.test(char)) {
+      if (part) {
+        parts.push(part);
+        part = '';
+      }
+    } else {
+      part += char;
+    }
+  }
+  if (escaped) part += '\\';
+  if (quote) throw new Error('unterminated quote in FATAL_HANDLER');
+  if (part) parts.push(part);
+  return parts;
+}
+
+function reportCrash(reason, error, stderrBuffer) {
+  const handler = handlerSpec();
+  const rawSnippet = stderrBuffer
+    ? stderrBuffer.split('\n').filter(Boolean).slice(-4).join('\n').trim()
+    : `[fatal-guard] process crashed (${reason})`;
+  const payload = JSON.stringify({
+    ...JSON.parse(buildPayload(reason, error)),
+    errorName: error?.name || 'ProcessCrash',
+    message: redact(error?.message || reason).slice(0, 500),
+    stackSnippet: redact(rawSnippet).slice(0, 1000),
+  });
+
+  if (!handler) {
+    process.stderr.write('fatal-guard: FATAL_HANDLER is not set; crash report was not sent.\n');
+    return;
+  }
+
+  let command;
+  try {
+    command = splitCommand(handler);
+  } catch (error) {
+    process.stderr.write(`fatal-guard: invalid FATAL_HANDLER: ${error.message}\n`);
+    return;
+  }
+  if (!command.length) {
+    process.stderr.write('fatal-guard: FATAL_HANDLER is empty; crash report was not sent.\n');
+    return;
+  }
+
+  const reporter = spawn(command[0], [...command.slice(1), payload], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: false,
+  });
+  let output = '';
+  let errorOutput = '';
+  reporter.stdout?.on('data', (chunk) => { output += chunk.toString(); });
+  reporter.stderr?.on('data', (chunk) => { errorOutput += chunk.toString(); });
+  const timer = setTimeout(() => reporter.kill('SIGKILL'), HANDLER_TIMEOUT_MS);
+  reporter.on('error', (handlerError) => {
+    clearTimeout(timer);
+    process.stderr.write(`fatal-guard: handler failed: ${handlerError.message}\n`);
+  });
+  reporter.on('close', (code) => {
+    clearTimeout(timer);
+    if (code !== 0) {
+      process.stderr.write(`fatal-guard: handler exited with code ${code}${errorOutput ? `: ${redact(errorOutput).trim()}` : ''}\n`);
+    } else if (output.trim()) {
+      try {
+        JSON.parse(output);
+      } catch (_) {
+        process.stderr.write('fatal-guard: handler returned invalid JSON output.\n');
+      }
+    }
   });
 }
 
-// ── Crash detection ─────────────────────────────────────────────
-// Signals that indicate a fatal/crash condition (not graceful shutdown).
-// SIGKILL = OOM killer / force kill; SIGSEGV = segfault; SIGABRT = abort
-const FATAL_SIGNALS = new Set(['SIGKILL', 'SIGSEGV', 'SIGABRT', 'SIGBUS', 'SIGFPE', 'SIGILL', 'SIGTRAP', 'SIGSYS']);
+function main() {
+  const { command, timeout } = parseArgs(process.argv.slice(2));
+  const stderrIsTTY = !!process.stderr.isTTY;
+  const child = spawn(command[0], command.slice(1), {
+    stdio: ['inherit', 'inherit', stderrIsTTY ? 'inherit' : 'pipe'],
+    shell: false,
+  });
 
-child.on('exit', (code, signal) => {
-  // Crashed if: non-zero exit code  OR  killed by a fatal signal
-  const crashed = Boolean((code !== 0 && code !== null) || (signal && FATAL_SIGNALS.has(signal)));
-  // When killed by a fatal signal (OOM/SIGSEGV/etc.), skip text check —
-  // the signal itself is evidence of a crash, and the process may have died
-  // before writing any error output to stderr.
-  const killedByFatalSignal = signal && FATAL_SIGNALS.has(signal);
-  const hasError = killedByFatalSignal || stderrIsTTY
-    ? true
-    : /error|exception|traceback|failed|fatal|killed/i.test(stderrBuffer);
-
-  if (crashed && hasError) {
-    const reason = signal ? `killed_by_${signal}` : 'process_crash';
-    try {
-      const rawSnippet = stderrBuffer
-        ? stderrBuffer.split('\n').filter(Boolean).slice(-4).join('\n').trim()
-        : `[fatal-guard] process crashed (exit code: ${code}, signal: ${signal})`;
-      const snippet = redact(rawSnippet).slice(0, 1000);
-      const payload = JSON.stringify({
-        ...JSON.parse(buildPayload(reason)),
-        errorName: signal ? `Signal:${signal}` : 'ProcessCrash',
-        message: `exit code: ${code}, signal: ${signal}`,
-        stackSnippet: snippet,
-      });
-      runHandler(reason, null, payload);
-    } catch (_) {}
+  let stderrBuffer = '';
+  let spawnError = null;
+  let timedOut = false;
+  let finished = false;
+  let timeoutTimer;
+  if (!stderrIsTTY && child.stderr) {
+    child.stderr.on('data', (chunk) => {
+      stderrBuffer += chunk.toString();
+      process.stderr.write(chunk);
+    });
+  }
+  if (timeout > 0) {
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      process.stderr.write(`fatal-guard: command timed out after ${timeout}ms: ${command.join(' ')}\n`);
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!finished) child.kill('SIGKILL');
+      }, 100);
+    }, timeout);
   }
 
-  process.exit(code ?? 1);
-});
+  child.on('error', (error) => {
+    spawnError = error;
+    process.stderr.write(`fatal-guard: could not start command "${command[0]}": ${error.message}\n`);
+  });
+  child.on('close', (code, signal) => {
+    finished = true;
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    if (timedOut) {
+      reportCrash('timeout', new Error(`command timed out after ${timeout}ms`), stderrBuffer);
+      process.exit(EXIT.TIMEOUT);
+    }
+    if (spawnError) process.exit(EXIT.ERROR);
+    const crashed = Boolean((code !== 0 && code !== null) || (signal && FATAL_SIGNALS.has(signal)));
+    const hasError = Boolean(signal && FATAL_SIGNALS.has(signal)) || stderrIsTTY
+      || /error|exception|traceback|failed|fatal|killed/i.test(stderrBuffer);
+    if (crashed && hasError) {
+      const reason = signal ? `killed_by_${signal}` : 'process_crash';
+      reportCrash(reason, new Error(`exit code: ${code}, signal: ${signal || 'none'}`), stderrBuffer);
+    }
+    process.exit(code ?? EXIT.ERROR);
+  });
+}
 
-child.on('error', () => {
-  process.exit(1);
-});
+main();

--- a/packages/fatal-guard/package.json
+++ b/packages/fatal-guard/package.json
@@ -4,7 +4,7 @@
   "description": "Zero-dependency non-invasive fatal error guard — capture uncaught exceptions and unhandled rejections, route redacted diagnostic payload to external handler via process.env.FATAL_HANDLER",
   "main": "index.js",
   "scripts": {
-    "test": "node --test tests/"
+    "test": "node tests/cli-contract.js && node tests/verify-fix.js && node tests/crash-scenarios.js && node tests/redact-compliance.js"
   },
   "bin": {
     "fatal-guard": "./bin/fatal-guard.js"

--- a/packages/fatal-guard/tests/cli-contract.js
+++ b/packages/fatal-guard/tests/cli-contract.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/** Contract tests for the fatal-guard CLI entry point. */
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const CLI = path.join(__dirname, '..', 'bin', 'fatal-guard.js');
+
+function run(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, FATAL_HANDLER: '' },
+    timeout: 5000,
+  });
+}
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+console.log('@misaka-net/fatal-guard — CLI contract tests');
+check('--help prints usage and exits 0', () => {
+  const result = run(['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /--timeout/);
+  assert.match(result.stdout, /Exit codes:/);
+});
+
+check('--version prints package version and exits 0', () => {
+  const result = run(['--version']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^0\.3\.0\n$/);
+});
+
+check('missing command is a usage error (2)', () => {
+  const result = run([]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /missing command/);
+  assert.match(result.stderr, /--help/);
+});
+
+check('unknown option is a usage error (2)', () => {
+  const result = run(['--not-a-real-option', '--', process.execPath, '-e', '0']);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /unknown option/);
+});
+
+check('wrapped success preserves exit code 0', () => {
+  const result = run(['--', process.execPath, '-e', 'process.exit(0)']);
+  assert.equal(result.status, 0);
+});
+
+check('wrapped failure preserves exit code 42', () => {
+  const result = run(['--', process.execPath, '-e', 'process.exit(42)']);
+  assert.equal(result.status, 42);
+});
+
+check('missing executable returns actionable error and exit 1', () => {
+  const result = run(['--', 'definitely-not-a-command']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /could not start command/);
+  assert.match(result.stderr, /ENOENT/);
+});
+
+check('timeout returns exit code 3 and names the command', () => {
+  const result = run([
+    '--timeout', '50', '--', process.execPath, '-e', 'setTimeout(() => {}, 1000)',
+  ]);
+  assert.equal(result.status, 3);
+  assert.match(result.stderr, /timed out after 50ms/);
+});
+
+if (process.exitCode) process.exit(1);


### PR DESCRIPTION
## Summary
- harden `fatal-guard` CLI parsing with `--help`, `--version`, and `--timeout <ms>`
- define actionable exit codes: 0 success, 1 command failure, 2 usage, 3 timeout
- report missing handlers, invalid handler output, missing executables, and timeouts without blocking shutdown
- add CLI contract coverage and wire the complete fatal-guard test suite into `npm test`

## Verification
- `npm test` — CLI contract, verification, crash scenarios, and redaction tests all pass
- `node --check bin/fatal-guard.js`
- manual `--timeout 20` returned exit code 3 with actionable stderr
- `git diff --check`

/claim #1010