### PR TITLE
feat(bench): reproducible runs with seed and regression diff

### DIFF
--- a/bench/self-healing/README.md
+++ b/bench/self-healing/README.md
@@ -193,7 +193,20 @@ python3 bench/self-healing/run_benchmark.py --baseline
 
 # Run a single task
 python3 bench/self-healing/run_benchmark.py --task dco-signoff
+
+# Reproducible task order and retained run history
+python3 bench/self-healing/run_benchmark.py --seed 42 --history-limit 10
+
+# Compare a new run with a retained run id
+python3 bench/self-healing/run_benchmark.py --seed 42 --compare 20260813T120000Z --json
+
+# Compare any two saved result files directly
+python3 bench/self-healing/diff.py bench/history/old/results.json bench/history/new/results.json --json
 ```
+
+Each run is written to `bench/history/<run_id>/results.json`. The history
+directory keeps the newest N runs (10 by default), records the seed and task
+order, and reports outcome, slower, and more-expensive regressions.
 
 ## Results Template
 

--- a/bench/self-healing/diff.py
+++ b/bench/self-healing/diff.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Compare two self-healing benchmark result documents.
+
+The report distinguishes changed outcomes from performance regressions so a
+run can be reviewed without manually diffing large JSON files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _tasks(document):
+    rows = document.get("tasks", document.get("results", []))
+    return {row.get("task_id", row.get("task")): row for row in rows}
+
+
+def compare_documents(baseline, candidate):
+    """Return outcome, speed, and cost changes between two runs."""
+    before = _tasks(baseline)
+    after = _tasks(candidate)
+    changed = []
+    regressions = []
+    for task_id in sorted(set(before) | set(after)):
+        old = before.get(task_id)
+        new = after.get(task_id)
+        if old is None or new is None:
+            changed.append({"task_id": task_id, "change": "added" if old is None else "removed"})
+            continue
+        old_outcome = old.get("outcome", "success" if old.get("success") else "failure")
+        new_outcome = new.get("outcome", "success" if new.get("success") else "failure")
+        old_ms = float(old.get("duration_ms", old.get("time_seconds", 0) * 1000))
+        new_ms = float(new.get("duration_ms", new.get("time_seconds", 0) * 1000))
+        old_cost = float(old.get("cost_usd", 0))
+        new_cost = float(new.get("cost_usd", 0))
+        if old_outcome != new_outcome:
+            changed.append({
+                "task_id": task_id,
+                "before": old_outcome,
+                "after": new_outcome,
+            })
+        if old_outcome == "success" and new_outcome != "success":
+            regressions.append({"task_id": task_id, "kind": "outcome", "before": old_outcome, "after": new_outcome})
+        if new_ms > old_ms * 1.2 and new_ms - old_ms >= 1:
+            regressions.append({"task_id": task_id, "kind": "slower", "before_ms": old_ms, "after_ms": new_ms})
+        if new_cost > old_cost and new_cost > 0:
+            regressions.append({"task_id": task_id, "kind": "more_expensive", "before_usd": old_cost, "after_usd": new_cost})
+
+    old_rate = baseline.get("summary", {}).get("success_rate")
+    new_rate = candidate.get("summary", {}).get("success_rate")
+    return {
+        "baseline_run_id": baseline.get("run_id", "unknown"),
+        "candidate_run_id": candidate.get("run_id", "unknown"),
+        "changed_outcomes": changed,
+        "regressions": regressions,
+        "summary": (
+            f"{len(changed)} outcome changes; {len(regressions)} regressions; "
+            f"success rate {old_rate!s} -> {new_rate!s}"
+        ),
+    }
+
+
+def compare_files(baseline_path, candidate_path):
+    """Load two result JSON files and compare them."""
+    baseline = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
+    candidate = json.loads(Path(candidate_path).read_text(encoding="utf-8"))
+    return compare_documents(baseline, candidate)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args()
+    report = compare_files(args.baseline, args.candidate)
+    print(json.dumps(report, indent=2) if args.json else report["summary"])
+    return 1 if report["regressions"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/self-healing/run_benchmark.py
+++ b/bench/self-healing/run_benchmark.py
@@ -7,10 +7,17 @@ attempts, and time to heal for agents with vs without MisakaNet knowledge.
 
 import argparse
 import json
+import random
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_HISTORY_DIR = REPO_ROOT / "bench" / "history"
+DEFAULT_HISTORY_LIMIT = 10
 
 TASKS = {
     "dco-signoff": {
@@ -91,22 +98,31 @@ def query_misakanet(query):
         return ""
 
 
-def run_benchmark(with_misakanet=True, task_filter=None):
+def _ordered_tasks(task_filter=None, seed=None):
+    """Return the selected tasks in a reproducible order when seeded."""
+    selected = [
+        (task_id, task)
+        for task_id, task in TASKS.items()
+        if not task_filter or task_id == task_filter
+    ]
+    if seed is not None:
+        random.Random(seed).shuffle(selected)
+    return selected
+
+
+def run_benchmark(with_misakanet=True, task_filter=None, seed=None):
     """Run the full benchmark suite."""
     results = []
-    tasks_to_run = (
-        {k: v for k, v in TASKS.items() if k == task_filter}
-        if task_filter
-        else TASKS
-    )
+    tasks_to_run = _ordered_tasks(task_filter=task_filter, seed=seed)
 
     print(f"\n{'='*60}")
     print(f"Agent Self-Healing Benchmark")
     print(f"Mode: {'WITH MisakaNet' if with_misakanet else 'BASELINE (no MK)'}")
     print(f"Tasks: {len(tasks_to_run)}")
+    print(f"Seed: {seed if seed is not None else 'none (declaration order)'}")
     print(f"{'='*60}\n")
 
-    for task_id, task in tasks_to_run.items():
+    for task_id, task in tasks_to_run:
         print(f"\n--- Task: {task['name']} ---")
         print(f"    Failure: {task['failure']}")
 
@@ -144,6 +160,84 @@ def run_benchmark(with_misakanet=True, task_filter=None):
     return results
 
 
+def build_result(results, *, seed=None, with_misakanet=True, run_id=None,
+                 started_at=None):
+    """Build a comparable, self-describing result document."""
+    tasks = [
+        {
+            "task_id": row["task"],
+            "name": row["name"],
+            "category": TASKS[row["task"]]["category"],
+            "outcome": "success" if row["success"] else "failure",
+            "attempts": row["attempts"],
+            "duration_ms": round(row["time_seconds"] * 1000, 3),
+            "cost_usd": 0.0,
+            "lessons_used": [TASKS[row["task"]]["category"]] if row["with_mk"] else [],
+            "error": None if row["success"] else TASKS[row["task"]]["failure"],
+        }
+        for row in results
+    ]
+    passed = sum(task["outcome"] == "success" for task in tasks)
+    total = len(tasks)
+    return {
+        "run_id": run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+        "started_at": started_at or datetime.now(timezone.utc).isoformat(),
+        "seed": seed,
+        "mode": "with-misakanet" if with_misakanet else "baseline",
+        "tasks": tasks,
+        "summary": {
+            "total_tasks": total,
+            "success_rate": round(passed / total, 6) if total else 0.0,
+            "mean_attempts": round(sum(task["attempts"] for task in tasks) / total, 3) if total else 0.0,
+            "mean_duration_ms": round(sum(task["duration_ms"] for task in tasks) / total, 3) if total else 0.0,
+            "total_cost_usd": 0.0,
+        },
+    }
+
+
+def _history_results(history_dir):
+    """Return stored result files, newest first, ignoring partial runs."""
+    history_dir = Path(history_dir)
+    return sorted(
+        (path for path in history_dir.glob("*/results.json") if path.is_file()),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+
+
+def save_history(result, history_dir=DEFAULT_HISTORY_DIR, limit=DEFAULT_HISTORY_LIMIT):
+    """Persist a run and prune older run directories to the requested limit."""
+    history_dir = Path(history_dir)
+    run_dir = history_dir / result["run_id"]
+    run_dir.mkdir(parents=True, exist_ok=True)
+    result_path = run_dir / "results.json"
+    result_path.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    stored = _history_results(history_dir)
+    for stale in stored[max(1, int(limit)):]:
+        try:
+            stale.unlink()
+            stale.parent.rmdir()
+        except OSError:
+            # A partially populated run directory is left for inspection.
+            continue
+    return result_path
+
+
+def resolve_history_result(reference, history_dir=DEFAULT_HISTORY_DIR):
+    """Resolve a run id, directory, or explicit JSON path."""
+    candidate = Path(reference).expanduser()
+    if candidate.is_file():
+        return candidate
+    if candidate.is_dir() and (candidate / "results.json").is_file():
+        return candidate / "results.json"
+    base = Path(history_dir)
+    for path in (base / str(reference) / "results.json", base / f"{reference}.json"):
+        if path.is_file():
+            return path
+    raise FileNotFoundError(f"no benchmark run found for {reference!r}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Agent Self-Healing Benchmark")
     parser.add_argument(
@@ -156,13 +250,30 @@ def main():
     )
     parser.add_argument("--task", help="Run a single task by ID (e.g., dco-signoff)")
     parser.add_argument("--json", action="store_true", help="Output results as JSON")
+    parser.add_argument("--seed", type=int, help="Deterministically shuffle task order")
+    parser.add_argument("--compare", help="Compare this run with a stored run id or results.json")
+    parser.add_argument("--history-dir", type=Path, default=DEFAULT_HISTORY_DIR,
+                        help="Directory for retained run history")
+    parser.add_argument("--history-limit", type=int, default=DEFAULT_HISTORY_LIMIT,
+                        help="Number of recent runs to retain (default: 10)")
     args = parser.parse_args()
 
     with_mk = not args.baseline
-    results = run_benchmark(with_misakanet=with_mk, task_filter=args.task)
+    started_at = datetime.now(timezone.utc).isoformat()
+    results = run_benchmark(with_misakanet=with_mk, task_filter=args.task, seed=args.seed)
+    result = build_result(results, seed=args.seed, with_misakanet=with_mk, started_at=started_at)
+    result_path = save_history(result, args.history_dir, args.history_limit)
+    print(f"Saved run: {result_path}")
 
     if args.json:
-        print(json.dumps(results, indent=2))
+        print(json.dumps(result, indent=2))
+
+    if args.compare:
+        from diff import compare_files
+
+        baseline_path = resolve_history_result(args.compare, args.history_dir)
+        comparison = compare_files(baseline_path, result_path)
+        print(json.dumps(comparison, indent=2) if args.json else comparison["summary"])
 
     return 0
 

--- a/tests/test_benchmark_reproducibility.py
+++ b/tests/test_benchmark_reproducibility.py
@@ -1,0 +1,55 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "bench" / "self-healing" / "run_benchmark.py"
+DIFF_SCRIPT = SCRIPT.with_name("diff.py")
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_seed_repeats_task_order():
+    runner = _load(SCRIPT, "benchmark_runner")
+    first = [task_id for task_id, _ in runner._ordered_tasks(seed=42)]
+    second = [task_id for task_id, _ in runner._ordered_tasks(seed=42)]
+    other = [task_id for task_id, _ in runner._ordered_tasks(seed=7)]
+    assert first == second
+    assert first != other
+
+
+def test_history_prunes_old_runs(tmp_path):
+    runner = _load(SCRIPT, "benchmark_runner_history")
+    for run_id in ("run-a", "run-b", "run-c"):
+        result = runner.build_result([], run_id=run_id, seed=1)
+        runner.save_history(result, tmp_path, limit=2)
+    assert (tmp_path / "run-c" / "results.json").exists()
+    assert len(list(tmp_path.glob("*/results.json"))) == 2
+
+
+def test_diff_flags_success_to_failure_and_slowdown():
+    diff = _load(DIFF_SCRIPT, "benchmark_diff")
+    before = {
+        "run_id": "old",
+        "summary": {"success_rate": 1.0},
+        "tasks": [{"task_id": "a", "outcome": "success", "duration_ms": 10, "cost_usd": 0}],
+    }
+    after = {
+        "run_id": "new",
+        "summary": {"success_rate": 0.0},
+        "tasks": [{"task_id": "a", "outcome": "failure", "duration_ms": 20, "cost_usd": 1}],
+    }
+    report = diff.compare_documents(before, after)
+    assert report["changed_outcomes"] == [{"task_id": "a", "before": "success", "after": "failure"}]
+    assert {item["kind"] for item in report["regressions"]} == {"outcome", "slower", "more_expensive"}
+
+
+def test_saved_result_is_json(tmp_path):
+    runner = _load(SCRIPT, "benchmark_runner_json")
+    path = runner.save_history(runner.build_result([], run_id="json-run", seed=9), tmp_path)
+    assert json.loads(path.read_text(encoding="utf-8"))["seed"] == 9


### PR DESCRIPTION
## Summary

- Add deterministic task ordering via `--seed` and persist it in every run document.
- Retain the newest N runs under `bench/history/<run_id>/results.json` with configurable pruning.
- Add `bench/self-healing/diff.py` to report outcome changes, success regressions, slower tasks, and increased cost.
- Add `--compare`, `--history-dir`, and `--history-limit` CLI options.
- Document the workflow and cover ordering, retention, JSON persistence, and regression detection.

Closes #1018

## Validation

- `python3 -m py_compile bench/self-healing/run_benchmark.py bench/self-healing/diff.py`
- Manual integration checks passed for seeded ordering, history pruning, and success-to-failure regression reporting.
- `git diff --check`

`pytest` was not installed in the local runtime; the test module is included for CI.
