### PR TITLE
test(fatal-guard): add cross-platform crash smoke

### DIFF
--- a/.github/workflows/fatal-guard.yml
+++ b/.github/workflows/fatal-guard.yml
@@ -14,7 +14,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     # paths filters already gate push/PR; keep workflow_dispatch always runnable.
     # Avoid a job-level if that can leave 0 jobs and mark the workflow as failed.
     defaults:
@@ -30,9 +34,7 @@ jobs:
 
       - name: Check zero dependencies
         run: |
-          DEPS=$(node -e "const p=require('./package.json');console.log(p.dependencies?Object.keys(p.dependencies).length:0)")
-          echo "dependencies: $DEPS"
-          [ "$DEPS" = "0" ] || { echo "FAIL: expected 0 dependencies"; exit 1; }
+          node -e "const p=require('./package.json'); const n=Object.keys(p.dependencies||{}).length; console.log('dependencies:', n); if (n !== 0) process.exit(1)"
 
       - name: Test module loads without error
         run: |
@@ -40,32 +42,12 @@ jobs:
 
       - name: Test uncaughtException invokes handler
         run: |
-          FATAL_HANDLER=/usr/bin/logger timeout 5 node -r ./register -e "
-            setTimeout(() => { throw new Error('ci-test'); }, 50);
-          " 2>&1 | grep -q 'fatal-guard uncaughtException' && echo 'PASS: uncaughtException' || echo 'FAIL'
+          node --test tests/smoke.test.js
 
-      - name: Test — handler receives payload
+      - name: Test legacy verification suite
         run: |
-          PAYLOAD_FILE=$(mktemp)
-          cat > /tmp/test-handler.sh << 'HANDLER'
-          #!/bin/bash
-          echo "$1" > "$PAYLOAD_FILE"
-          HANDLER
-          chmod +x /tmp/test-handler.sh
-          export PAYLOAD_FILE
-          FATAL_HANDLER=/tmp/test-handler.sh timeout 5 node -r ./register -e "
-            setTimeout(() => { throw new Error('ci-payload-test'); }, 50);
-          " 2>&1 || true
-          sleep 1
-          if [ -f "$PAYLOAD_FILE" ] && grep -q 'schemaVersion' "$PAYLOAD_FILE" && grep -q 'uncaught_exception' "$PAYLOAD_FILE"; then
-            echo 'PASS: handler received payload'
-            cat "$PAYLOAD_FILE"
-          else
-            echo 'FAIL: no payload received'
-            [ -f "$PAYLOAD_FILE" ] && cat "$PAYLOAD_FILE"
-          fi
-          rm -f "$PAYLOAD_FILE" /tmp/test-handler.sh
+          node tests/verify-fix.js
 
       - name: Test TypeScript declaration exists
         run: |
-          test -f index.d.ts && node -e "require('fs').readFileSync('index.d.ts','utf-8').includes('FatalPayload')" && echo 'PASS: index.d.ts' || echo 'FAIL: missing index.d.ts'
+          node -e "const fs=require('fs'); if (!fs.existsSync('index.d.ts') || !fs.readFileSync('index.d.ts','utf8').includes('FatalPayload')) process.exit(1); console.log('PASS: index.d.ts')"

--- a/packages/fatal-guard/README.md
+++ b/packages/fatal-guard/README.md
@@ -8,6 +8,17 @@ npm i @misaka-net/fatal-guard
 FATAL_HANDLER=/usr/bin/logger node -r @misaka-net/fatal-guard/register ./app.js
 ```
 
+For handlers that need an explicit executable plus arguments (useful on
+Windows where a `.js` file is not directly spawnable), set
+`FATAL_HANDLER_ARGS` to a JSON string array. The payload is appended as the
+last argument and the child is still started with `shell: false`:
+
+```bash
+FATAL_HANDLER=node \
+FATAL_HANDLER_ARGS='["/opt/bin/record-fatal.js"]' \
+node -r @misaka-net/fatal-guard/register ./app.js
+```
+
 One env var. No source code changes.
 
 ---

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -90,6 +90,9 @@ child.on('exit', (code, signal) => {
         errorName: signal ? `Signal:${signal}` : 'ProcessCrash',
         message: `exit code: ${code}, signal: ${signal}`,
         stackSnippet: snippet,
+        exit_code: code ?? 1,
+        signal: signal || '',
+        snippet,
       });
       runHandler(reason, null, payload);
     } catch (_) {}

--- a/packages/fatal-guard/index.js
+++ b/packages/fatal-guard/index.js
@@ -79,7 +79,16 @@ function runHandler(reason, error, customPayload) {
 
   try {
     const payload = customPayload || buildPayload(reason, error);
-    const child = spawn(handler, [payload], {
+    let handlerArgs = [];
+    if (process.env.FATAL_HANDLER_ARGS) {
+      try {
+        const parsed = JSON.parse(process.env.FATAL_HANDLER_ARGS);
+        if (Array.isArray(parsed) && parsed.every((arg) => typeof arg === 'string')) {
+          handlerArgs = parsed;
+        }
+      } catch (_) {}
+    }
+    const child = spawn(handler, [...handlerArgs, payload], {
       stdio: 'ignore',
       detached: true,
       shell: false,

--- a/packages/fatal-guard/package.json
+++ b/packages/fatal-guard/package.json
@@ -4,7 +4,7 @@
   "description": "Zero-dependency non-invasive fatal error guard — capture uncaught exceptions and unhandled rejections, route redacted diagnostic payload to external handler via process.env.FATAL_HANDLER",
   "main": "index.js",
   "scripts": {
-    "test": "node --test tests/"
+    "test": "node --test tests/smoke.test.js && node tests/redact-compliance.js && node tests/verify-fix.js"
   },
   "bin": {
     "fatal-guard": "./bin/fatal-guard.js"

--- a/packages/fatal-guard/register.js
+++ b/packages/fatal-guard/register.js
@@ -58,7 +58,16 @@ function runHandler(reason, error) {
 
   try {
     const payload = buildPayload(reason, error);
-    const child = spawn(handler, [payload], {
+    let handlerArgs = [];
+    if (process.env.FATAL_HANDLER_ARGS) {
+      try {
+        const parsed = JSON.parse(process.env.FATAL_HANDLER_ARGS);
+        if (Array.isArray(parsed) && parsed.every((arg) => typeof arg === 'string')) {
+          handlerArgs = parsed;
+        }
+      } catch (_) {}
+    }
+    const child = spawn(handler, [...handlerArgs, payload], {
       stdio: 'ignore',
       detached: true,
       shell: false,

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -1,0 +1,75 @@
+const assert = require('node:assert/strict');
+const { mkdtemp, readFile, rm, writeFile, chmod } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { test } = require('node:test');
+
+const PACKAGE_ROOT = path.join(__dirname, '..');
+const WRAPPER = path.join(PACKAGE_ROOT, 'bin', 'fatal-guard.js');
+const CONVERTER = path.join(PACKAGE_ROOT, '..', '..', 'scripts', 'tombstone_to_draft.py');
+const PYTHON = process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { ...options, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+test('crash smoke captures a four-field tombstone and converts it to a draft', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'fatal-guard-smoke-'));
+  try {
+    const payloadFile = path.join(tmp, 'tombstone.json');
+    const handler = path.join(tmp, 'record-handler.js');
+    await writeFile(handler, [
+      '#!/usr/bin/env node',
+      "require('node:fs').writeFileSync(process.env.PAYLOAD_FILE, process.argv.at(-1));",
+    ].join('\n') + '\n');
+    await chmod(handler, 0o755);
+
+    const result = await run(process.execPath, [WRAPPER, '--', process.execPath, '-e',
+      "setTimeout(() => { throw new Error('smoke crash'); }, 10);"], {
+      env: {
+        ...process.env,
+        FATAL_HANDLER: process.execPath,
+        FATAL_HANDLER_ARGS: JSON.stringify([handler]),
+        PAYLOAD_FILE: payloadFile,
+      },
+    });
+    assert.equal(result.code, 1, result.stderr);
+
+    // The handler is detached by design; poll briefly instead of sleeping a
+    // fixed interval so the test remains fast on both Linux and Windows.
+    let payload;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      try {
+        payload = JSON.parse(await readFile(payloadFile, 'utf8'));
+        break;
+      } catch (_) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    assert.ok(payload, 'fatal handler did not write a payload');
+    for (const field of ['schemaVersion', 'reason', 'timestamp', 'pid']) {
+      assert.ok(Object.hasOwn(payload, field), `missing ${field}`);
+    }
+    assert.equal(payload.schemaVersion, 1);
+    assert.equal(payload.reason, 'process_crash');
+    assert.equal(payload.exit_code, 1);
+
+    const draft = await run(PYTHON, [CONVERTER, '--from-file', payloadFile, '--dry-run'], {
+      cwd: path.join(PACKAGE_ROOT, '..', '..'),
+    });
+    assert.equal(draft.code, 0, draft.stderr);
+    assert.match(draft.stdout, /\[DRY RUN\]/);
+    assert.match(draft.stdout, /Root Cause|根因/);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add a real child-process crash smoke test that captures and validates the four required tombstone fields.
- Include `exit_code`/`signal`/`snippet` in wrapper tombstones so `tombstone_to_draft.py --dry-run` can consume them.
- Add a portable `FATAL_HANDLER_ARGS` escape hatch for executable-plus-script handlers without enabling a shell.
- Replace the permissive Linux-only CI snippets with a Linux + Windows matrix and a failing smoke gate.
- Repair the package test command and keep the existing redaction/verification suites in the gate.

Closes #1011

## Validation

- `npm test` in `packages/fatal-guard` (smoke, redaction, and verification suites pass).
- `git diff --check`

The smoke test invokes `scripts/tombstone_to_draft.py --dry-run` and asserts generated markdown sections.
