### PR TITLE
fix(fatal-guard): support Windows command launchers

### DIFF
--- a/.github/workflows/fatal-guard.yml
+++ b/.github/workflows/fatal-guard.yml
@@ -14,7 +14,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     # paths filters already gate push/PR; keep workflow_dispatch always runnable.
     # Avoid a job-level if that can leave 0 jobs and mark the workflow as failed.
     defaults:
@@ -30,9 +34,7 @@ jobs:
 
       - name: Check zero dependencies
         run: |
-          DEPS=$(node -e "const p=require('./package.json');console.log(p.dependencies?Object.keys(p.dependencies).length:0)")
-          echo "dependencies: $DEPS"
-          [ "$DEPS" = "0" ] || { echo "FAIL: expected 0 dependencies"; exit 1; }
+          node -e "const p=require('./package.json'); const n=Object.keys(p.dependencies||{}).length; console.log('dependencies:', n); if (n !== 0) process.exit(1)"
 
       - name: Test module loads without error
         run: |
@@ -68,4 +70,7 @@ jobs:
 
       - name: Test TypeScript declaration exists
         run: |
-          test -f index.d.ts && node -e "require('fs').readFileSync('index.d.ts','utf-8').includes('FatalPayload')" && echo 'PASS: index.d.ts' || echo 'FAIL: missing index.d.ts'
+          node -e "const fs=require('fs'); if (!fs.existsSync('index.d.ts') || !fs.readFileSync('index.d.ts','utf8').includes('FatalPayload')) process.exit(1); console.log('PASS: index.d.ts')"
+
+      - name: Run package tests
+        run: npm test

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -11,6 +11,7 @@
  */
 
 const { spawn } = require('node:child_process');
+const { buildSpawnSpec } = require('../src/lib/spawn-command');
 
 const args = process.argv.slice(2);
 
@@ -48,9 +49,11 @@ const { redact } = require('../src/lib/redact');
 // to capture error output for crash detection + snippet.
 const stderrIsTTY = !!process.stderr.isTTY;
 
-const child = spawn(cmdArgs[0], cmdArgs.slice(1), {
+const invocation = buildSpawnSpec(cmdArgs[0], cmdArgs.slice(1));
+const child = spawn(invocation.command, invocation.args, {
   stdio: ['inherit', 'inherit', stderrIsTTY ? 'inherit' : 'pipe'],
   shell: false,
+  ...invocation.options,
 });
 
 // ── stderr capture (only when piping, i.e. non-TTY) ─────────────

--- a/packages/fatal-guard/index.js
+++ b/packages/fatal-guard/index.js
@@ -19,6 +19,7 @@
 
 const { spawn } = require('node:child_process');
 const { redact } = require('./src/lib/redact');
+const { buildSpawnSpec } = require('./src/lib/spawn-command');
 
 /**
  * @typedef {Object} FatalPayload
@@ -79,10 +80,12 @@ function runHandler(reason, error, customPayload) {
 
   try {
     const payload = customPayload || buildPayload(reason, error);
-    const child = spawn(handler, [payload], {
+    const invocation = buildSpawnSpec(handler, [payload]);
+    const child = spawn(invocation.command, invocation.args, {
       stdio: 'ignore',
       detached: true,
       shell: false,
+      ...invocation.options,
     });
     child.on('error', () => {});
     child.unref();

--- a/packages/fatal-guard/package.json
+++ b/packages/fatal-guard/package.json
@@ -4,7 +4,7 @@
   "description": "Zero-dependency non-invasive fatal error guard — capture uncaught exceptions and unhandled rejections, route redacted diagnostic payload to external handler via process.env.FATAL_HANDLER",
   "main": "index.js",
   "scripts": {
-    "test": "node --test tests/"
+    "test": "node --test tests/windows-compat.test.js && node tests/redact-compliance.js && node tests/verify-fix.js"
   },
   "bin": {
     "fatal-guard": "./bin/fatal-guard.js"
@@ -20,6 +20,7 @@
     "bin/fatal-guard.js",
     "src/lib/redact.js",
     "src/lib/resolve-handler.js",
+    "src/lib/spawn-command.js",
     "README.md"
   ],
   "repository": {

--- a/packages/fatal-guard/register.js
+++ b/packages/fatal-guard/register.js
@@ -24,6 +24,7 @@
 
 const { spawn } = require('node:child_process');
 const { redact } = require('./src/lib/redact');
+const { buildSpawnSpec } = require('./src/lib/spawn-command');
 
 /** Payload builder with diagnostic fields */
 function buildPayload(reason, error) {
@@ -58,10 +59,12 @@ function runHandler(reason, error) {
 
   try {
     const payload = buildPayload(reason, error);
-    const child = spawn(handler, [payload], {
+    const invocation = buildSpawnSpec(handler, [payload]);
+    const child = spawn(invocation.command, invocation.args, {
       stdio: 'ignore',
       detached: true,
       shell: false,
+      ...invocation.options,
     });
     child.on('error', () => { /* swallow — handler failure must not block */ });
     child.unref();

--- a/packages/fatal-guard/src/lib/spawn-command.js
+++ b/packages/fatal-guard/src/lib/spawn-command.js
@@ -1,0 +1,29 @@
+/**
+ * Build a shell-free child-process invocation for Unix and Windows.
+ *
+ * Windows `.cmd`/`.bat` files are not directly executable with CreateProcess.
+ * Routing only those extensions through ComSpec keeps normal commands on the
+ * safe direct-spawn path while preserving PATH lookup for PowerShell/cmd
+ * workflows used by the CLI.
+ */
+
+function quoteWindowsArg(value) {
+  const text = String(value);
+  if (!/[\s"&|<>^]/.test(text)) return text;
+  return `"${text.replace(/["^]/g, (match) => `^${match}`)}"`;
+}
+
+function buildSpawnSpec(command, args = []) {
+  const isWindowsScript = process.platform === 'win32' && /\.(?:cmd|bat)$/i.test(command);
+  if (!isWindowsScript) {
+    return { command, args, options: {} };
+  }
+  const shellCommand = [command, ...args].map(quoteWindowsArg).join(' ');
+  return {
+    command: process.env.ComSpec || 'cmd.exe',
+    args: ['/d', '/s', '/c', shellCommand],
+    options: { windowsHide: true },
+  };
+}
+
+module.exports = { buildSpawnSpec, quoteWindowsArg };

--- a/packages/fatal-guard/tests/windows-compat.test.js
+++ b/packages/fatal-guard/tests/windows-compat.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const { mkdtemp, writeFile, rm, chmod } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { test } = require('node:test');
+const { buildSpawnSpec } = require('../src/lib/spawn-command');
+
+const WRAPPER = path.join(__dirname, '..', 'bin', 'fatal-guard.js');
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal, stderr }));
+  });
+}
+
+test('normal executables keep direct shell-free spawning', () => {
+  const spec = buildSpawnSpec(process.execPath, ['-e', 'process.exit(0)']);
+  assert.equal(spec.command, process.execPath);
+  assert.deepEqual(spec.args, ['-e', 'process.exit(0)']);
+  assert.deepEqual(spec.options, {});
+});
+
+test('Windows command scripts are routed through ComSpec without a shell option', async () => {
+  if (process.platform !== 'win32') return;
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'fatal-guard-cmd-'));
+  try {
+    const script = path.join(tmp, 'fail.cmd');
+    await writeFile(script, '@echo off\r\nexit /b 7\r\n');
+    await chmod(script, 0o755);
+    const result = await run(process.execPath, [WRAPPER, '--', script]);
+    assert.equal(result.code, 7, result.stderr);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add a shared shell-free spawn spec that routes only `.cmd`/`.bat` handlers through `ComSpec` on Windows.
- Apply the same command resolution to the wrapper, preload register, and external handler paths.
- Add platform-aware tests and run the package CI on both Ubuntu and Windows.
- Include the new helper in the published npm package and keep the zero-dependency check.

Closes #1009

## Validation

- `npm test` in `packages/fatal-guard` passes locally.
- `node --test tests/windows-compat.test.js` covers direct executables and Windows-only command scripts.
- `git diff --check`

The Windows-specific execution branch is skipped on non-Windows runners and is exercised by the new CI matrix.
