### PR TITLE
feat(search): configure hybrid BM25 and vector weights

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -7,6 +7,12 @@
 # 复制本文件为 config.yaml 并填入实际值
 # config.yaml 已在 .gitignore 中，不会提交到 Git
 
+# ── Retrieval ranking ──
+# BM25 remains available when the optional vector backend is not installed.
+retrieval:
+  bm25_weight: 0.5
+  vector_weight: 0.5
+
 # ── Hub 基本信息 ──
 hub:
   name: "misaka-hub"              # Hub 实例名称（唯一标识）
@@ -51,3 +57,8 @@ master:
   keyring_service: "misakanet-master"
   token_ttl_hours: 24
   audit_log_days: 90
+# Retrieval ranking defaults. BM25 remains available when the optional vector
+# backend is not installed; hosted deployments can tune the blend per query.
+retrieval:
+  bm25_weight: 0.5
+  vector_weight: 0.5

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,6 +43,7 @@ python3 search_knowledge.py "database locked" --json --top=3 | jq '.[].path'
 | `python3 scripts/new_lesson.py` | Interactive lesson generator |
 | `python3 scripts/queue_lesson.py` | Queue a lesson via CLI args |
 | `python3 scripts/tombstone_to_draft.py --from-file <f>` | fatal-guard tombstone → draft lesson |
+| `python3 search_knowledge.py <query> --bm25-weight <n> --vector-weight <n>` | tune hybrid retrieval weights |
 | `python3 scripts/bench_orchestrator.py [--include-drafts]` | Agent benchmark runner (Phase B/C) |
 | `python3 scripts/contribute.py --wizard` | 7-step interactive lesson creation wizard |
 | `python3 scripts/check_worker_secrets.py` | Scan workers/ for hardcoded secrets |

--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -3,6 +3,8 @@ BM25 核心算法委托给 misakanet-core 包。
 """
 
 import json
+import math
+import os
 import re
 import sqlite3
 import sys
@@ -26,6 +28,8 @@ WEIGHT_TITLE_EXACT = 0.8
 WEIGHT_TITLE_PARTIAL = 0.4
 WEIGHT_HAS_REF = 0.12
 MAX_METADATA = 1.0
+DEFAULT_BM25_WEIGHT = 0.5
+DEFAULT_VECTOR_WEIGHT = 0.5
 
 # Feature #532: domain synonym query expansion.
 _SYNONYM_MAP: dict[str, list[str]] = {
@@ -265,16 +269,20 @@ def _doc_cache_id(doc: CachedDoc) -> str:
 
 def _search_cached(
     query: str, docs: list[CachedDoc], titles_only: bool = False, broad_only: bool = False,
-    rerank: bool = False,
+    rerank: bool = False, bm25_weight: float = DEFAULT_BM25_WEIGHT,
+    vector_weight: float = DEFAULT_VECTOR_WEIGHT,
 ) -> list[tuple[float, CachedDoc]]:
     """L1缓存 — 相同 query 直接返回上次结果。"""
-    key = f"{query}_{titles_only}_{broad_only}_{rerank}"
+    key = f"{query}_{titles_only}_{broad_only}_{rerank}_{bm25_weight}_{vector_weight}"
     if key in _L1_CACHE:
         doc_map = {_doc_cache_id(d): d for d in docs}
         result = [(s, doc_map[fid]) for s, fid in _L1_CACHE[key] if fid in doc_map]
         if len(result) == len(_L1_CACHE[key]):
             return result
-    result = _rank_docs_impl(query, docs, titles_only, broad_only, rerank=rerank)
+    result = _rank_docs_impl(
+        query, docs, titles_only, broad_only, rerank=rerank,
+        bm25_weight=bm25_weight, vector_weight=vector_weight,
+    )
     _L1_CACHE[key] = [(s, _doc_cache_id(d)) for s, d in result[:20]]
     if len(_L1_CACHE) > _L1_MAX:
         del _L1_CACHE[next(iter(_L1_CACHE))]
@@ -322,6 +330,33 @@ def _compute_bm25_scores(query: str, docs: list[CachedDoc]) -> list[float]:
     # Map results back to original order
     result_scores = {r.doc_id: r.score for r in results}
     return [result_scores.get(d.filename, 0.0) for d in docs]
+
+
+def _compute_vector_scores(query: str, docs: list[CachedDoc]) -> list[float]:
+    """Compute cosine similarities through the optional embedding backend.
+
+    The backend is intentionally lazy: installations without semantic-search
+    dependencies receive zero vector scores and continue with BM25. This
+    keeps the default CLI usable while allowing hosted deployments to opt into
+    real hybrid retrieval through the same ranking function.
+    """
+    if not docs:
+        return []
+    try:
+        from hub.storage.vector_store import generate_embedding
+
+        query_embedding = generate_embedding(query)
+        doc_embeddings = [generate_embedding(f"{doc.title}\n{doc.content[:4000]}") for doc in docs]
+    except (ImportError, RuntimeError, OSError, ValueError):
+        return [0.0] * len(docs)
+
+    def cosine(left, right):
+        numerator = sum(a * b for a, b in zip(left, right))
+        left_norm = math.sqrt(sum(a * a for a in left))
+        right_norm = math.sqrt(sum(b * b for b in right))
+        return numerator / (left_norm * right_norm) if left_norm and right_norm else 0.0
+
+    return [cosine(query_embedding, embedding) for embedding in doc_embeddings]
 
 
 def _metadata_bonus(query: str, doc: CachedDoc) -> float:
@@ -424,7 +459,8 @@ def _expand_query(query: str) -> str:
 
 def _rank_docs_impl(
     query: str, docs: list[CachedDoc], titles_only: bool = False, broad_only: bool = False,
-    rerank: bool = False,
+    rerank: bool = False, bm25_weight: float = DEFAULT_BM25_WEIGHT,
+    vector_weight: float = DEFAULT_VECTOR_WEIGHT, vector_scores: list[float] | None = None,
 ) -> list[tuple[float, CachedDoc]]:
     if not docs:
         return []
@@ -434,12 +470,16 @@ def _rank_docs_impl(
         visible = [d for d in docs if not d.is_draft]
         if visible:
             docs = visible
+    bm25_weight, vector_weight = _validate_search_weights(bm25_weight, vector_weight)
     expanded_query = _expand_query(query)
     bm25_raw = _compute_bm25_scores(expanded_query, docs)
     bm25_norm = _normalize(bm25_raw)
+    vector_raw = vector_scores if vector_scores is not None else _compute_vector_scores(query, docs)
+    vector_norm = _normalize(vector_raw)
     scored = [
         (
-            0.65 * bm25_norm[i]
+            bm25_weight * bm25_norm[i]
+            + vector_weight * vector_norm[i]
             + 0.20 * _metadata_bonus(query, d)
             + 0.15 * d.score_baseline
             + _compute_boost(d),
@@ -771,6 +811,52 @@ def _score_breakdown(query: str, doc: CachedDoc) -> dict:
         "baseline": round(float(doc.score_baseline), 6),
         "boost": {key: round(float(value), 6) for key, value in boost_parts},
     }
+
+
+def load_search_weights(config_path: str | Path | None = None) -> tuple[float, float]:
+    """Resolve retrieval weights from env or a small YAML/JSON config file."""
+    path_value = config_path or os.environ.get("MISAKANET_CONFIG", "config.yaml")
+    path = Path(path_value)
+    values: dict[str, float] = {}
+    if path.exists():
+        try:
+            if path.suffix.lower() == ".json":
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                section = raw.get("retrieval", {}) if isinstance(raw, dict) else {}
+                values = {key: float(section[key]) for key in ("bm25_weight", "vector_weight") if key in section}
+            else:
+                in_retrieval = False
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    stripped = line.strip()
+                    if not stripped or stripped.startswith("#"):
+                        continue
+                    if stripped == "retrieval:":
+                        in_retrieval = True
+                        continue
+                    if in_retrieval and not line.startswith((" ", "\t")):
+                        in_retrieval = False
+                    if in_retrieval and ":" in stripped:
+                        key, raw_value = (part.strip() for part in stripped.split(":", 1))
+                        if key in ("bm25_weight", "vector_weight"):
+                            values[key] = float(raw_value)
+        except (OSError, ValueError, json.JSONDecodeError):
+            values = {}
+    bm25 = float(os.environ.get("MISAKANET_BM25_WEIGHT", values.get("bm25_weight", DEFAULT_BM25_WEIGHT)))
+    vector = float(os.environ.get("MISAKANET_VECTOR_WEIGHT", values.get("vector_weight", DEFAULT_VECTOR_WEIGHT)))
+    return _validate_search_weights(bm25, vector)
+
+
+def _validate_search_weights(bm25_weight: float, vector_weight: float) -> tuple[float, float]:
+    """Validate and normalize the hybrid retrieval weights."""
+    try:
+        bm25 = float(bm25_weight)
+        vector = float(vector_weight)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("search weights must be numeric") from exc
+    if bm25 < 0 or vector < 0 or bm25 + vector <= 0:
+        raise ValueError("search weights must be non-negative and not both zero")
+    total = bm25 + vector
+    return bm25 / total, vector / total
 
 
 def _get_related_lessons(

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -61,12 +61,28 @@ except ImportError:
 try:
     from misakanet.search.engine import (
         LESSONS,
+        load_search_weights,
         _load_docs_cached,
         _search_cached,
     )
     HAS_BM25 = True
 except ImportError:
     HAS_BM25 = False
+
+    def load_search_weights():
+        """Keep the MCP fallback usable when optional BM25 deps are absent."""
+        return 0.5, 0.5
+
+    def _validate_search_weights(bm25_weight, vector_weight):
+        try:
+            bm25 = float(bm25_weight)
+            vector = float(vector_weight)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("search weights must be numeric") from exc
+        if bm25 < 0 or vector < 0 or bm25 + vector <= 0:
+            raise ValueError("search weights must be non-negative and not both zero")
+        total = bm25 + vector
+        return bm25 / total, vector / total
 
 
 def _fallback_search(query: str, domain: str = None, top: int = 5) -> list | None:
@@ -142,6 +158,13 @@ def handle_search(args: dict) -> dict:
     domain = args.get("domain")
     tags = args.get("tags")
     top = args.get("top", 5)
+    try:
+        configured_bm25, configured_vector = load_search_weights()
+        bm25_weight = float(args.get("bm25_weight", configured_bm25))
+        vector_weight = float(args.get("vector_weight", configured_vector))
+        bm25_weight, vector_weight = _validate_search_weights(bm25_weight, vector_weight)
+    except (TypeError, ValueError) as exc:
+        return {"error": f"invalid retrieval weights: {exc}", "voice": "failure-warning"}
 
     if not query:
         return {
@@ -156,13 +179,16 @@ def handle_search(args: dict) -> dict:
             "voice": "failure-warning",
         }
 
-    if HAS_SAG:
+    custom_weights = "bm25_weight" in args or "vector_weight" in args
+    if HAS_SAG and not custom_weights:
         results = sag_search(SAG_DB, query, domain=domain, top=top)
         voice = "lesson-found" if results else "failure-warning"
         return {"results": results, "source": "sag-lite", "voice": voice}
     elif HAS_BM25:
         docs = _load_docs_cached(LESSONS, is_lesson=True)
-        scored = _search_cached(query, docs)
+        scored = _search_cached(
+            query, docs, bm25_weight=bm25_weight, vector_weight=vector_weight,
+        )
         results = []
         for score, doc in scored[:top]:
             results.append({
@@ -171,6 +197,10 @@ def handle_search(args: dict) -> dict:
                 "score": round(score, 3),
                 "domain": doc.domain,
                 "status": doc.status,
+                "retrieval": {
+                    "bm25_weight": round(bm25_weight, 6),
+                    "vector_weight": round(vector_weight, 6),
+                },
             })
         voice = "lesson-found" if results else "failure-warning"
         return {"results": results, "source": "bm25", "voice": voice}
@@ -542,6 +572,8 @@ TOOLS = [
                 "query": {"type": "string", "description": "Required redacted error message, keyword, or topic (for example: 'pip install timeout' or 'DCO sign-off failed')."},
                 "domain": {"type": "string", "description": "Optional domain filter such as devops, python, network, feishu, rag, fanuc, or mcp."},
                 "top": {"type": "integer", "description": "Maximum ranked results to return. Defaults to 5; keep small for MCP context and latency."},
+                "bm25_weight": {"type": "number", "minimum": 0, "description": "Optional BM25 blend weight; normalized with vector_weight."},
+                "vector_weight": {"type": "number", "minimum": 0, "description": "Optional semantic-vector blend weight; normalized with bm25_weight."},
             },
             "required": ["query"],
         },

--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -266,7 +266,9 @@ def _edit_distance(s1: str, s2: str) -> int:
 
 
 def _typo_retry_search(
-    query: str, docs: list, titles_only: bool, broad_only: bool, top_k: int
+    query: str, docs: list, titles_only: bool, broad_only: bool, top_k: int,
+    bm25_weight: float = DEFAULT_BM25_WEIGHT,
+    vector_weight: float = DEFAULT_VECTOR_WEIGHT,
 ) -> tuple[list[tuple[float, object]], str]:
     """Retry search with edit-distance fuzzy matching on title keywords.
 
@@ -311,7 +313,10 @@ def _typo_retry_search(
 
     corrected_query = " ".join(corrected_tokens)
     from misakanet.search.engine import _rank_docs_impl
-    ranked = _rank_docs_impl(corrected_query, docs, titles_only, broad_only)
+    ranked = _rank_docs_impl(
+        corrected_query, docs, titles_only, broad_only,
+        bm25_weight=bm25_weight, vector_weight=vector_weight,
+    )
     filtered = [(s, d) for s, d in ranked if s >= 0.1]
     if not filtered:
         return [], query
@@ -618,6 +623,14 @@ def main():
     domain: Optional[str] = None
     status_filter: Optional[str] = None
     tags_filter: list[str] = []
+    try:
+        bm25_weight, vector_weight = load_search_weights()
+    except ValueError as exc:
+        if json_output:
+            _print_json_error(str(exc))
+        else:
+            print(f"Invalid retrieval weights: {exc}", file=sys.stderr)
+        sys.exit(1)
     search_args = positional_args[1:]
     for i, arg in enumerate(search_args):
         if arg == "--ref":
@@ -646,6 +659,14 @@ def main():
             lang = search_args[i + 1]
         elif arg == "--semantic":
             use_semantic = True
+        elif arg.startswith("--bm25-weight="):
+            bm25_weight = float(arg.split("=", 1)[1])
+        elif arg == "--bm25-weight" and i + 1 < len(search_args):
+            bm25_weight = float(search_args[i + 1])
+        elif arg.startswith("--vector-weight="):
+            vector_weight = float(arg.split("=", 1)[1])
+        elif arg == "--vector-weight" and i + 1 < len(search_args):
+            vector_weight = float(search_args[i + 1])
         elif arg == "--rerank":
             use_rerank = True
         elif arg.startswith("--domain="):
@@ -675,6 +696,14 @@ def main():
             env_filter = arg.split("=", 1)[1].lower()
         elif arg == "--env" and i + 1 < len(search_args):
             env_filter = search_args[i + 1].lower()
+    try:
+        bm25_weight, vector_weight = _validate_search_weights(bm25_weight, vector_weight)
+    except ValueError as exc:
+        if json_output:
+            _print_json_error(str(exc))
+        else:
+            print(f"Invalid retrieval weights: {exc}", file=sys.stderr)
+        sys.exit(1)
     # ── 轻量配额检查 ──
     from misakanet.profile import check_quota as _check_quota
     allowed, quota_msg = _check_quota()
@@ -758,7 +787,10 @@ def main():
     if json_output:
         all_docs = lessons_docs + ref_docs
         with contextlib.redirect_stdout(io.StringIO()):
-            ranked = _rank_docs(query, all_docs, titles_only, broad_only)
+            ranked = _rank_docs(
+                query, all_docs, titles_only, broad_only,
+                bm25_weight=bm25_weight, vector_weight=vector_weight,
+            )
         results = [
             _json_result(score, doc, query=query, verbose=verbose)
             for score, doc in ranked
@@ -767,7 +799,8 @@ def main():
         # Feature #314: Typo tolerance for JSON mode
         if not results and not strict:
             typo_results, corrected = _typo_retry_search(
-                query, all_docs, titles_only, broad_only, top_k
+                query, all_docs, titles_only, broad_only, top_k,
+                bm25_weight=bm25_weight, vector_weight=vector_weight,
             )
             if typo_results:
                 results = [
@@ -808,7 +841,10 @@ def main():
     
     all_docs = lessons_docs + ref_docs
     if lessons_docs:
-        ranked = _rank_docs(query, lessons_docs, titles_only, broad_only, rerank=use_rerank)
+        ranked = _rank_docs(
+            query, lessons_docs, titles_only, broad_only, rerank=use_rerank,
+            bm25_weight=bm25_weight, vector_weight=vector_weight,
+        )
         # Only show results above threshold
         filtered = [(s, d) for s, d in ranked if s >= MIN_SCORE_THRESHOLD]
         for _score, doc in filtered[:top_k]:
@@ -821,7 +857,10 @@ def main():
                                all_docs=all_docs)
         found_any = found_any or found
     if ref_docs:
-        ranked = _rank_docs(query, ref_docs, titles_only, broad_only=False, rerank=use_rerank)
+        ranked = _rank_docs(
+            query, ref_docs, titles_only, broad_only=False, rerank=use_rerank,
+            bm25_weight=bm25_weight, vector_weight=vector_weight,
+        )
         # Only show results above threshold
         filtered = [(s, d) for s, d in ranked if s >= MIN_SCORE_THRESHOLD]
         for _score, doc in filtered[:top_k]:
@@ -838,7 +877,8 @@ def main():
         # Feature #314: Typo tolerance — retry with edit distance ≤2
         all_docs_for_typo = lessons_docs + ref_docs
         typo_results, corrected = _typo_retry_search(
-            query, all_docs_for_typo, titles_only, broad_only, top_k
+            query, all_docs_for_typo, titles_only, broad_only, top_k,
+            bm25_weight=bm25_weight, vector_weight=vector_weight,
         )
         if typo_results:
             print(f"\n  🔍 Showing results for '{corrected}' (searched: '{query}')\n")

--- a/tests/test_search_weights.py
+++ b/tests/test_search_weights.py
@@ -1,0 +1,49 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+engine = importlib.import_module("misakanet.search.engine")
+
+
+def _doc(name, content, title=""):
+    return engine.CachedDoc(
+        filename=f"{name}.md",
+        filepath=REPO / "lessons" / "core" / f"{name}.md",
+        content=content,
+        title=title or name,
+        status="published",
+    )
+
+
+def test_weights_are_normalized():
+    assert engine._validate_search_weights(2, 1) == (pytest.approx(2 / 3), pytest.approx(1 / 3))
+
+
+@pytest.mark.parametrize("weights", [(0, 0), (-1, 1), ("bad", 1)])
+def test_invalid_weights_fail_closed(weights):
+    with pytest.raises(ValueError):
+        engine._validate_search_weights(*weights)
+
+
+def test_vector_weight_can_change_ranking_without_model_dependency(monkeypatch):
+    first = _doc("first", "database timeout", "first")
+    second = _doc("second", "database timeout", "second")
+    monkeypatch.setattr(engine, "_compute_bm25_scores", lambda query, docs: [1.0, 0.0])
+    ranked = engine._rank_docs_impl(
+        "query", [first, second], bm25_weight=0, vector_weight=1,
+        vector_scores=[0.1, 0.9],
+    )
+    assert ranked[0][1] is second
+
+
+def test_config_file_controls_weights(tmp_path, monkeypatch):
+    config = tmp_path / "config.yaml"
+    config.write_text("retrieval:\n  bm25_weight: 0.8\n  vector_weight: 0.2\n", encoding="utf-8")
+    monkeypatch.delenv("MISAKANET_BM25_WEIGHT", raising=False)
+    monkeypatch.delenv("MISAKANET_VECTOR_WEIGHT", raising=False)
+    assert engine.load_search_weights(config) == (pytest.approx(0.8), pytest.approx(0.2))


### PR DESCRIPTION
## Summary

- Add configurable BM25/vector blending with normalized non-negative weights and defaults of `0.5/0.5`.
- Load weights from `config.yaml`/JSON or environment overrides and expose CLI flags.
- Add lazy semantic cosine scoring with a graceful BM25-only fallback when the optional embedding backend is unavailable.
- Include weight parameters in the cache key and expose runtime weights through the MCP search tool.
- Add config, CLI documentation, and ranking/validation tests.

Closes #1001

## Validation

- `python3 -m py_compile misakanet/search/engine.py search_knowledge.py scripts/mcp_server.py tests/test_search_weights.py`
- Hybrid ranking test with injected vector scores passed.
- MCP rejects zero/invalid weight pairs and remains usable without optional BM25 dependencies.
- `git diff --check`

The local environment does not have `misakanet-core` or `pytest`; CI will run the full dependency-backed suite.
