### PR TITLE
feat(search): explain ranking evidence

### DIFF
--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -54,6 +54,9 @@
   .fold-toggle .arrow { transition: transform 0.2s; }
   .fold-toggle.open .arrow { transform: rotate(90deg); }
   .match-explain { font-size: 11px; color: var(--text-muted); margin-top: 4px; line-height: 1.5; }
+  .score-explain { font-size: 11px; color: var(--text-muted); margin-top: 8px; line-height: 1.55; }
+  .score-explain summary { cursor: pointer; color: var(--text-soft); }
+  .score-explain code { color: #8bd5ff; }
   .result-id { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.02em; color: var(--text-muted); }
   .result-summary { font-family: var(--font-ui); font-size: 13px; color: var(--text-soft); font-weight: 400; line-height: 1.65; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
   .result-tags { font-size: 11px; color: var(--text-muted); margin-top: 6px; }
@@ -291,6 +294,25 @@ function search(q) {
   }).filter(l => l.score > 0).sort((a,b) => b.score - a.score).slice(0, 20);
 }
 
+function explainResult(r, q) {
+  const terms = q.toLowerCase().split(/\s+/).filter(Boolean);
+  const title = (r.title || '').toLowerCase();
+  const domain = (r.domain || '').toLowerCase();
+  const tags = (r.tags || []).join(' ').toLowerCase();
+  const summary = (r.summary || '').toLowerCase();
+  const matched = terms.filter(term => (title + ' ' + domain + ' ' + tags + ' ' + summary).includes(term));
+  const entities = [];
+  if (terms.some(term => title.includes(term))) entities.push('title');
+  if (terms.some(term => domain.includes(term))) entities.push('domain');
+  if (terms.some(term => tags.includes(term))) entities.push('tags');
+  const coverage = terms.length ? matched.length / terms.length : 0;
+  return {
+    matched: matched.length ? matched.join(', ') : 'none',
+    entities: entities.length ? entities.join(', ') : 'content only',
+    coverage: Math.round(coverage * 100),
+  };
+}
+
 function updateUrl(q, lessonId) {
   const url = new URL(location);
   if (q) url.searchParams.set('q', q);
@@ -522,6 +544,7 @@ function render(results, q) {
     const badge = inferBadge(r);
     const confBadge = r._confidence === 'high' ? 'badge-high' : r._confidence === 'low' ? 'badge-low' : 'badge-medium';
     const ev = evidenceInfo(r.evidence_level);
+    const signals = explainResult(r, q);
     const showTitle = takeaway !== title;
     return '<div class="result" tabindex="0" data-index="' + r._index + '" data-id="' + id + '">' +
       '<div class="result-meta">' +
@@ -534,6 +557,11 @@ function render(results, q) {
       (showTitle ? '<div class="result-id">' + id + '</div>' : '') +
       '<div class="result-summary">' + summary + '</div>' +
       (tags ? '<div class="result-tags">' + tags + '</div>' : '') +
+      '<details class="score-explain"><summary>Why this matched</summary>' +
+        '<div>matched terms: <code>' + escapeHTML(signals.matched) + '</code></div>' +
+        '<div>entity fields: <code>' + escapeHTML(signals.entities) + '</code></div>' +
+        '<div>keyword coverage: <code>' + signals.coverage + '%</code> · score: <code>' + Number(r.score || 0).toFixed(3) + '</code></div>' +
+      '</details>' +
       '<div class="result-actions">' +
         '<button class="btn-primary" type="button" data-action="preview">' + t('readLesson') + '</button>' +
         '<a class="btn-secondary" href="' + escapeHTML(url) + '" target="_blank" rel="noopener">' + t('openGitHub') + '</a>' +

--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -3,6 +3,7 @@ BM25 核心算法委托给 misakanet-core 包。
 """
 
 import json
+import math
 import re
 import sqlite3
 import sys
@@ -761,15 +762,76 @@ def _get_why_matched(match_reasons: str) -> dict:
     }
 
 
-def _score_breakdown(query: str, doc: CachedDoc) -> dict:
+def _term_tfidf(query: str, doc: CachedDoc, docs: list[CachedDoc] | None = None) -> list[dict]:
+    """Return transparent per-term TF/IDF contributions for an explanation."""
+    corpus = docs or [doc]
+    query_terms = list(dict.fromkeys(_tokenize(query)))
+    tokenized = [_tokenize(item.content) for item in corpus]
+    total_docs = max(len(tokenized), 1)
+    doc_index = next((index for index, item in enumerate(corpus) if item.filename == doc.filename), 0)
+    doc_tokens = tokenized[doc_index]
+    details = []
+    for term in query_terms:
+        tf = doc_tokens.count(term)
+        if not tf:
+            continue
+        document_frequency = sum(term in tokens for tokens in tokenized)
+        idf = math.log((total_docs + 1) / (document_frequency + 1)) + 1
+        details.append({"term": term, "term_frequency": tf,
+                       "document_frequency": document_frequency,
+                       "tfidf": round(tf * idf, 6)})
+    return details
+
+
+def _entity_matches(query: str, doc: CachedDoc) -> dict[str, list[str]]:
+    terms = set(_tokenize(query))
+    matches = {}
+    for field, value in (("title", doc.title), ("domain", doc.domain), ("tags", " ".join(map(str, doc.tags)))):
+        found = [term for term in _tokenize(value) if term in terms]
+        if found:
+            matches[field] = list(dict.fromkeys(found))
+    return matches
+
+
+def _vector_similarity(query: str, doc: CachedDoc) -> float | None:
+    """Return optional cosine similarity, or None when vectors are unavailable."""
+    try:
+        from hub.storage.vector_store import generate_embedding
+        query_embedding = generate_embedding(query)
+        doc_embedding = generate_embedding(f"{doc.title}\n{doc.content[:4000]}")
+        numerator = sum(a * b for a, b in zip(query_embedding, doc_embedding))
+        left_norm = math.sqrt(sum(a * a for a in query_embedding))
+        right_norm = math.sqrt(sum(b * b for b in doc_embedding))
+        return round(numerator / (left_norm * right_norm), 6) if left_norm and right_norm else 0.0
+    except (ImportError, RuntimeError, OSError, ValueError):
+        return None
+
+
+def _score_breakdown(query: str, doc: CachedDoc, docs: list[CachedDoc] | None = None) -> dict:
+    """Return field-level ranking evidence for CLI/API explain modes."""
     bm25 = _compute_bm25_scores(query, [doc])[0]
     meta_parts = _metadata_bonus_breakdown(query, doc)
     boost_parts = _compute_boost_breakdown(doc)
+    vector = _vector_similarity(query, doc)
+    metadata_total = sum(value for _, value in meta_parts)
+    boost_total = sum(value for _, value in boost_parts)
     return {
         "bm25": round(float(bm25), 6),
+        "bm25_terms": _term_tfidf(query, doc, docs),
+        "vector_similarity": vector,
+        "entity_matches": _entity_matches(query, doc),
+        "hybrid": {
+            "bm25_component": round(0.65 * float(bm25), 6),
+            "metadata_component": round(0.20 * metadata_total, 6),
+            "baseline_component": round(0.15 * float(doc.score_baseline), 6),
+            "boost_component": round(boost_total, 6),
+            "vector_component": vector,
+        },
         "metadata": {key: round(float(value), 6) for key, value in meta_parts},
+        "metadata_total": round(metadata_total, 6),
         "baseline": round(float(doc.score_baseline), 6),
         "boost": {key: round(float(value), 6) for key, value in boost_parts},
+        "boost_total": round(boost_total, 6),
     }
 
 
@@ -838,24 +900,32 @@ def _format_output(
             print(f"  {'':>25} (matched: {match_reason})")
         # Feature: --explain score breakdown (#303)
         if explain and query:
-            bm25 = _compute_bm25_scores(query, [doc])[0]
-            meta_parts = _metadata_bonus_breakdown(query, doc)
-            meta_total = sum(v for _, v in meta_parts)
-            baseline = doc.score_baseline
-            boost_parts = _compute_boost_breakdown(doc)
-            boost_total = sum(v for _, v in boost_parts)
+            breakdown = _score_breakdown(query, doc, docs=all_docs)
             tag_str = ", ".join(doc.tags[:5]) if doc.tags else "—"
 
-            print(f"  {'':>25} ↳ BM25: {bm25:.3f}")
-            if meta_parts:
-                meta_detail = ", ".join(f"{k}(+{v:.2f})" for k, v in meta_parts)
-                print(f"  {'':>25}   Meta: {meta_total:.3f} = {meta_detail}")
+            vector_label = f"{breakdown['vector_similarity']:.3f}" if breakdown['vector_similarity'] is not None else "unavailable"
+            print(f"  {'':>25} ↳ Hybrid components: BM25 {breakdown['hybrid']['bm25_component']:.3f}; "
+                  f"metadata {breakdown['hybrid']['metadata_component']:.3f}; "
+                  f"vector {vector_label}")
+            if breakdown["bm25_terms"]:
+                terms = ", ".join(
+                    f"{item['term']} tf={item['term_frequency']} tfidf={item['tfidf']:.2f}"
+                    for item in breakdown["bm25_terms"]
+                )
+                print(f"  {'':>25}   Terms: {terms}")
+            else:
+                print(f"  {'':>25}   Terms: none")
+            if breakdown["entity_matches"]:
+                print(f"  {'':>25}   Entities: {breakdown['entity_matches']}")
+            if breakdown["metadata"]:
+                meta_detail = ", ".join(f"{key}(+{value:.2f})" for key, value in breakdown["metadata"].items())
+                print(f"  {'':>25}   Meta: {breakdown['metadata_total']:.3f} = {meta_detail}")
             else:
                 print(f"  {'':>25}   Meta: 0.000")
-            print(f"  {'':>25}   Base: {baseline:.3f}")
-            if boost_parts:
-                boost_detail = ", ".join(f"{k}({v:+.2f})" for k, v in boost_parts)
-                print(f"  {'':>25}   Boost: {boost_total:+.2f} = {boost_detail}")
+            print(f"  {'':>25}   Base: {breakdown['baseline']:.3f}")
+            if breakdown["boost"]:
+                boost_detail = ", ".join(f"{key}({value:+.2f})" for key, value in breakdown["boost"].items())
+                print(f"  {'':>25}   Boost: {breakdown['boost_total']:+.2f} = {boost_detail}")
             else:
                 print(f"  {'':>25}   Boost: +0.00")
             print(f"  {'':>25}   Tags: {tag_str}")

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -142,6 +142,7 @@ def handle_search(args: dict) -> dict:
     domain = args.get("domain")
     tags = args.get("tags")
     top = args.get("top", 5)
+    explain = bool(args.get("explain", False))
 
     if not query:
         return {
@@ -156,7 +157,7 @@ def handle_search(args: dict) -> dict:
             "voice": "failure-warning",
         }
 
-    if HAS_SAG:
+    if HAS_SAG and not explain:
         results = sag_search(SAG_DB, query, domain=domain, top=top)
         voice = "lesson-found" if results else "failure-warning"
         return {"results": results, "source": "sag-lite", "voice": voice}
@@ -164,14 +165,18 @@ def handle_search(args: dict) -> dict:
         docs = _load_docs_cached(LESSONS, is_lesson=True)
         scored = _search_cached(query, docs)
         results = []
+        from misakanet.search.engine import _score_breakdown
         for score, doc in scored[:top]:
-            results.append({
+            result = {
                 "title": doc.title,
                 "path": str(doc.filepath),
                 "score": round(score, 3),
                 "domain": doc.domain,
                 "status": doc.status,
-            })
+            }
+            if explain:
+                result["score_breakdown"] = _score_breakdown(query, doc, docs=docs)
+            results.append(result)
         voice = "lesson-found" if results else "failure-warning"
         return {"results": results, "source": "bm25", "voice": voice}
     else:
@@ -529,7 +534,9 @@ TOOLS = [
             "Search MisakaNet's public failure-lesson index by error text, keyword, or topic. "
             "Use when you need to discover relevant lessons and do not already know a lesson ID. "
             "Input semantics: query is required; domain optionally filters by lesson domain; top limits "
-            "ranked results and defaults to 5. Output schema: JSON with results[] and source; each "
+            "ranked results and defaults to 5. Set explain=true to return matched terms, TF-IDF, "
+            "entity matches, vector similarity, and hybrid score components. Output schema: JSON "
+            "with results[] and source; each "
             "result is a ranked lesson summary that may include path, title, domain/status, score/rank, "
             "and match details depending on the active index. Error cases: missing query, unavailable "
             "search index, or no matches (empty results). Side effects: none. Auth: none. Rate limits: "
@@ -542,6 +549,7 @@ TOOLS = [
                 "query": {"type": "string", "description": "Required redacted error message, keyword, or topic (for example: 'pip install timeout' or 'DCO sign-off failed')."},
                 "domain": {"type": "string", "description": "Optional domain filter such as devops, python, network, feishu, rag, fanuc, or mcp."},
                 "top": {"type": "integer", "description": "Maximum ranked results to return. Defaults to 5; keep small for MCP context and latency."},
+                "explain": {"type": "boolean", "description": "Include score evidence for each result; vector similarity is null when the optional backend is unavailable."},
             },
             "required": ["query"],
         },

--- a/tests/test_search_explanations.py
+++ b/tests/test_search_explanations.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from misakanet.search import engine
+
+
+def _doc(name, content, title="", domain=""):
+    return engine.CachedDoc(
+        filename=f"{name}.md",
+        filepath=REPO / "lessons" / "core" / f"{name}.md",
+        content=content,
+        title=title or name,
+        domain=domain,
+        tags=["timeout"],
+        status="published",
+    )
+
+
+def test_breakdown_exposes_terms_entities_and_hybrid_components(monkeypatch):
+    doc = _doc("pip-timeout", "pip timeout timeout proxy", "pip timeout", "python")
+    other = _doc("other", "proxy guidance", "other", "devops")
+    monkeypatch.setattr(engine, "_compute_bm25_scores", lambda query, docs: [0.75])
+    monkeypatch.setattr(engine, "_vector_similarity", lambda query, item: 0.42)
+
+    breakdown = engine._score_breakdown("pip timeout", doc, docs=[doc, other])
+
+    assert breakdown["bm25"] == pytest.approx(0.75)
+    assert breakdown["vector_similarity"] == pytest.approx(0.42)
+    assert breakdown["entity_matches"]["title"] == ["pip", "timeout"]
+    assert "domain" not in breakdown["entity_matches"]
+    assert {term["term"] for term in breakdown["bm25_terms"]} == {"pip", "timeout"}
+    assert set(breakdown["hybrid"]) == {
+        "bm25_component", "metadata_component", "baseline_component",
+        "boost_component", "vector_component",
+    }
+
+
+def test_vector_explanation_fails_explicitly_when_backend_unavailable(monkeypatch):
+    doc = _doc("plain", "keyword", "plain")
+    monkeypatch.setattr(engine, "_compute_bm25_scores", lambda query, docs: [0.1])
+    monkeypatch.setattr(engine, "_vector_similarity", lambda query, item: None)
+    breakdown = engine._score_breakdown("keyword", doc)
+    assert breakdown["vector_similarity"] is None
+    assert breakdown["hybrid"]["vector_component"] is None


### PR DESCRIPTION
## Summary

- Expand `--explain`/verbose search output with BM25 terms, term frequency/TF-IDF, matched entity fields, optional vector similarity, and hybrid components.
- Add the same evidence to the local MCP `misakanet_search` tool through `explain: true`.
- Keep the semantic field explicit (`null` when the optional vector backend is unavailable) instead of hiding degradation.
- Add a collapsible “Why this matched” panel to the public search UI with matched terms, entity fields, coverage, and score.
- Add tests for explanation shape and graceful vector-backend degradation.

Closes #1004

## Validation

- `python3 -m py_compile misakanet/search/engine.py search_knowledge.py scripts/mcp_server.py tests/test_search_explanations.py`
- Inline `docs/search/index.html` JavaScript parsed successfully with Node.
- Stubbed BM25/MCP integration returned the complete explanation payload.
- `git diff --check`

The local runtime lacks `misakanet-core` and `pytest`; CI will run the full dependency-backed suite.
