### PR TITLE
feat: track lesson provenance end to end

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,0 +1,38 @@
+# Lesson provenance
+
+Published lessons carry a small provenance tuple so readers and search clients
+can distinguish an intake report from a manually written lesson or a pull
+request migration:
+
+| Field | Meaning |
+| --- | --- |
+| `source` | One of `intake`, `pr`, `manual`, or `rescue`. |
+| `author` | Git author or contributor identity. |
+| `pr` | Pull request number or URL when `source` is `pr`. |
+| `edited_at` | ISO-8601 timestamp of the latest provenance edit. |
+| `merged_by` | Maintainer or GitHub identity that merged the source change. |
+
+Existing lessons can be migrated from Git history with the report-only command:
+
+```bash
+python3 scripts/backfill_provenance.py --lessons-dir lessons
+```
+
+Review the report, then write the inferred fields explicitly:
+
+```bash
+python3 scripts/backfill_provenance.py --lessons-dir lessons --write
+```
+
+The migration is repeatable: populated fields are preserved unless `--force`
+is supplied. JSON and fenced frontmatter are both supported. Run the lesson
+lint after migration to find published lessons that still need maintainer
+review:
+
+```bash
+python3 scripts/lesson_lint.py --lessons-dir lessons --json
+```
+
+Search integrations expose `source` and `author` directly and include the
+remaining fields under `provenance`. This keeps the common result compact while
+allowing clients to show an audit trail when needed.

--- a/lessons/contrib/accidental-pycache-commit.md
+++ b/lessons/contrib/accidental-pycache-commit.md
@@ -1,17 +1,16 @@
 ---
 {
-  "title": "Accidental __pycache__ artifacts committed to a data repository",
-  "domain": "development",
-  "tags": [
-    "git",
-    "pycache",
-    "gitignore",
-    "cleanup"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "Accidental __pycache__ artifacts committed to a data repository\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:00:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/agent-error-handling-hi.md
+++ b/lessons/contrib/agent-error-handling-hi.md
@@ -1,12 +1,23 @@
 ---
-title: "एजेंट त्रुटि हैंडलिंग — पुनर्प्रयास और फॉलबैक पैटर्न"
-domain: agents
-tags: ["agent", "error-handling", "hindi", "resilience", "tutorial"]
-source: "practical-experience"
-status: published
-confidence: 0.85
-created: 2026-08-01
-lang: hi
+{
+  "title": "एजेंट त्रुटि हैंडलिंग — पुनर्प्रयास और फॉलबैक पैटर्न",
+  "domain": "agents",
+  "tags": [
+    "agent",
+    "error-handling",
+    "hindi",
+    "resilience",
+    "tutorial"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-08-01",
+  "lang": "hi",
+  "author": "zsxh1990",
+  "edited_at": "2026-08-02T00:17:21+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## समस्या

--- a/lessons/contrib/agent-manual-update-timeout.md
+++ b/lessons/contrib/agent-manual-update-timeout.md
@@ -1,10 +1,16 @@
 ---
-title: Agent 手动Update步骤（update Timeout Handling）
-domain: devops
-source: bootstrap
-status: published
-confidence: 0.8
-created: 2026-05-03
+{
+  "title": "Agent 手动Update步骤（update Timeout Handling）",
+  "domain": "devops",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.8,
+  "created": "2026-05-03",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-08T17:09:06+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 414
+}
 ---
 
 ---{"title": "Agent 手动Update步骤（update Timeout Handling）", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.8", "created": "2026-05-03"}---

--- a/lessons/contrib/agent-memory-extractor-timing.md
+++ b/lessons/contrib/agent-memory-extractor-timing.md
@@ -1,9 +1,21 @@
 ---
-title: "Agent Memory Extractor Timing — Eager vs Lazy with Implementation"
-domain: "agent"
-tags: ["agent-memory", "extractor", "timing", "token-efficiency", "quality"]
-status: "published"
-source: "brgsk.xyz"
+{
+  "title": "Agent Memory Extractor Timing — Eager vs Lazy with Implementation",
+  "domain": "agent",
+  "tags": [
+    "agent-memory",
+    "extractor",
+    "timing",
+    "token-efficiency",
+    "quality"
+  ],
+  "status": "published",
+  "source": "pr",
+  "author": "2lll5",
+  "edited_at": "2026-07-08T09:06:05+08:00",
+  "merged_by": "2lll5",
+  "pr": 399
+}
 ---
 
 

--- a/lessons/contrib/agent-memory-three-index-architecture.md
+++ b/lessons/contrib/agent-memory-three-index-architecture.md
@@ -1,9 +1,23 @@
 ---
-title: "Agent Memory Three-Index Architecture on Elasticsearch"
-domain: "agent"
-tags: ["agent-memory", "elasticsearch", "episodic", "semantic", "procedural", "hybrid-retrieval", "rrf"]
-status: "published"
-source: "elastic.co/search-labs"
+{
+  "title": "Agent Memory Three-Index Architecture on Elasticsearch",
+  "domain": "agent",
+  "tags": [
+    "agent-memory",
+    "elasticsearch",
+    "episodic",
+    "semantic",
+    "procedural",
+    "hybrid-retrieval",
+    "rrf"
+  ],
+  "status": "published",
+  "source": "pr",
+  "author": "2lll5",
+  "edited_at": "2026-07-08T09:06:00+08:00",
+  "merged_by": "2lll5",
+  "pr": 398
+}
 ---
 
 

--- a/lessons/contrib/agent-reach-multi-platform-scraper.md
+++ b/lessons/contrib/agent-reach-multi-platform-scraper.md
@@ -1,20 +1,20 @@
 ---
-title: Agent-Reach — Multi-Platform Internet Access for AI Agents
-domain: agent
-subdomain: tooling
-tags:
-  - agent-reach
-  - scraping
-  - reddit
-  - twitter
-  - bilibili
-  - mcp
-source: github.com/Panniantong/Agent-Reach
-status: published
-confidence: 0.85
-created: 2026-07-01
-verified_date: ''
-domain_expert: ''
+{
+  "title": "Agent-Reach — Multi-Platform Internet Access for AI Agents",
+  "domain": "agent",
+  "subdomain": "tooling",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-08T17:09:06+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 414
+}
 ---
 
 {"title": "Agent-Reach — Multi-Platform Internet Access for AI Agents", "domain": "agent", "subdomain": "tooling", "tags": ["agent-reach", "scraping", "reddit", "twitter", "bilibili", "mcp"], "source": "github.com/Panniantong/Agent-Reach", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}

--- a/lessons/contrib/agent-readfile-silent-truncation.md
+++ b/lessons/contrib/agent-readfile-silent-truncation.md
@@ -1,15 +1,18 @@
 ---
 {
-  "title": "Agent read_file Silent Truncation in Multi-Brain Meeting Recovery",
-  "domain": "agent",
-  "tags": [
-    "project:hermes-agent-cluster",
-    "severity:high",
-    "pattern:file-handling",
-    "tool:read-file"
-  ],
-  "status": "published",
-  "source": "ninghuagui-debug"
+  "\"title\"": "Agent read_file Silent Truncation in Multi-Brain Meeting Recovery\",",
+  "\"domain\"": "agent\",",
+  "\"tags\"": "[",
+  "\"project": "hermes-agent-cluster\",",
+  "\"severity": "high\",",
+  "\"pattern": "file-handling\",",
+  "\"tool": "read-file",
+  "\"status\"": "published\",",
+  "\"source\"": "ninghuagui-debug",
+  "author": "ninghuagui-debug",
+  "source": "manual",
+  "edited_at": "2026-07-21T04:07:06+08:00",
+  "merged_by": "ninghuagui-debug"
 }
 ---
 

--- a/lessons/contrib/agent-state-database-lock-cleanup.md
+++ b/lessons/contrib/agent-state-database-lock-cleanup.md
@@ -1,13 +1,25 @@
 ---
-title: Agent State Database Lock Issues — Cleanup Protocol
-domain: devops
-source: hermes_wsl2
-status: published
-tags: ["database", "lock", "state", "cleanup", "lesson-written"]
-created: "2026-05-16 00:00:00 UTC"
-updated: "2026-05-16 00:00:00 UTC"
-domain_expert: hermes_wsl2
-verified_date: 2026-05-16
+{
+  "title": "Agent State Database Lock Issues — Cleanup Protocol",
+  "domain": "devops",
+  "source": "pr",
+  "status": "published",
+  "tags": [
+    "database",
+    "lock",
+    "state",
+    "cleanup",
+    "lesson-written"
+  ],
+  "created": "2026-05-16 00:00:00 UTC",
+  "updated": "2026-05-16 00:00:00 UTC",
+  "domain_expert": "hermes_wsl2",
+  "verified_date": "2026-05-16",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ## Verification

--- a/lessons/contrib/agent-web-access-toolchain-selection.md
+++ b/lessons/contrib/agent-web-access-toolchain-selection.md
@@ -1,4 +1,28 @@
-{"title": "Agent Web Access Toolchain — 7 Libraries for Reliable Forum Scraping", "domain": "agent", "subdomain": "tooling", "tags": ["agent-tooling", "web-access", "curl-cffi", "scrapling", "drissionpage", "scraping", "forum", "tls-fingerprint"], "source": "practical-experience", "status": "published", "confidence": "0.85", "created": "2026-07-14", "verified_date": "2026-07-14", "domain_expert": ""}
+{
+  "title": "Agent Web Access Toolchain — 7 Libraries for Reliable Forum Scraping",
+  "domain": "agent",
+  "subdomain": "tooling",
+  "tags": [
+    "agent-tooling",
+    "web-access",
+    "curl-cffi",
+    "scrapling",
+    "drissionpage",
+    "scraping",
+    "forum",
+    "tls-fingerprint"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-14",
+  "verified_date": "2026-07-14",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 
 ## Problem

--- a/lessons/contrib/ai-agent-project-outreach-guide.md
+++ b/lessons/contrib/ai-agent-project-outreach-guide.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "AI Agent Project Outreach Guide",
-  "verification": "metadata-normalized",
-  "{\"title\"": "AI Agent Project Outreach Guide\", \"domain\": \"marketing\", \"subdomain\": \"outreach\", \"source\": \"Misaka10004\", \"tags\": [\"outreach\", \"github\", \"awesome-list\", \"pr\", \"promotion\", \"agent\", \"marketing\"], \"confidence\": \"0.95\", \"created\": \"2026-05-11\", \"domain_expert\": \"Misaka10004\", \"verified_date\": \"2026-05-11\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "AI Agent Project Outreach Guide\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "AI Agent Project Outreach Guide\\\", \\\"domain\\\": \\\"marketing\\\", \\\"subdomain\\\": \\\"outreach\\\", \\\"source\\\": \\\"Misaka10004\\\", \\\"tags\\\": [\\\"outreach\\\", \\\"github\\\", \\\"awesome-list\\\", \\\"pr\\\", \\\"promotion\\\", \\\"agent\\\", \\\"marketing\\\"], \\\"confidence\\\": \\\"0.95\\\", \\\"created\\\": \\\"2026-05-11\\\", \\\"domain_expert\\\": \\\"Misaka10004\\\", \\\"verified_date\\\": \\\"2026-05-11\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/aily-feishu-mcp-pull-only.md
+++ b/lessons/contrib/aily-feishu-mcp-pull-only.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "aily feishu mcp pull only",
-  "verification": "metadata-normalized",
-  "{\"title\"": "aily 飞书 MCP 通道：只能拉取不能推送\", \"domain\": \"feishu\", \"subdomain\": \"mcp-capability\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "aily feishu mcp pull only\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "aily 飞书 MCP 通道：只能拉取不能推送\\\", \\\"domain\\\": \\\"feishu\\\", \\\"subdomain\\\": \\\"mcp-capability\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.7\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/an-unlikely-database-migration.md
+++ b/lessons/contrib/an-unlikely-database-migration.md
@@ -1,12 +1,24 @@
 ---
-title: "An Unlikely Database Migration: From JSON Files to etcd"
-domain: "database-architecture"
-tags: ["database-migration", "etcd", "golang", "control-plane", "performance", "key-value-store"]
-language: "en"
-status: "published"
-source: "https://tailscale.com/blog/an-unlikely-database-migration/"
-created: "2026-07-28"
-confidence: 0.85
+{
+  "title": "An Unlikely Database Migration: From JSON Files to etcd",
+  "domain": "database-architecture",
+  "tags": [
+    "database-migration",
+    "etcd",
+    "golang",
+    "control-plane",
+    "performance",
+    "key-value-store"
+  ],
+  "language": "en",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-28",
+  "confidence": 0.85,
+  "author": "zsxh1990",
+  "edited_at": "2026-07-29T09:18:36+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/anthropic-proxy-internal-gateway.md
+++ b/lessons/contrib/anthropic-proxy-internal-gateway.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy",
-  "verification": "metadata-normalized",
-  "{\"created\"": "2026-04-30 09:00 UTC\", \"domain\": \"devops\", \"machine\": \"hp-wsl\", \"source\": \"hermes_wsl\", \"status\": \"published\", \"tags\": \"\", \"title\": \"Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy\", \"updated\": \"2026-04-30 09:00 UTC\", \"domain_expert\": \"hermes_wsl\", \"verified_date\": \"2026-04-30\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"created\\\"\"": "2026-04-30 09:00 UTC\\\", \\\"domain\\\": \\\"devops\\\", \\\"machine\\\": \\\"hp-wsl\\\", \\\"source\\\": \\\"hermes_wsl\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": \\\"\\\", \\\"title\\\": \\\"Internal Gateway — Incompatible with Anthropic Format, Requires OpenAI Proxy\\\", \\\"updated\\\": \\\"2026-04-30 09:00 UTC\\\", \\\"domain_expert\\\": \\\"hermes_wsl\\\", \\\"verified_date\\\": \\\"2026-04-30\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/api-gateway-anthropic-incompatibility.md
+++ b/lessons/contrib/api-gateway-anthropic-incompatibility.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "api gateway anthropic incompatibility",
-  "verification": "metadata-normalized",
-  "{\"title\"": "InternalGateway API 网关不兼容 Anthropic 原生格式\", \"domain\": \"devops\", \"subdomain\": \"api\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"severity:medium\", \"node:hermes_wsl\"], \"confidence\": \"0.8\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "api gateway anthropic incompatibility\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "InternalGateway API 网关不兼容 Anthropic 原生格式\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"api\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:rag\\\", \\\"severity:medium\\\", \\\"node:hermes_wsl\\\"], \\\"confidence\\\": \\\"0.8\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/api-rate-limit-handling-best-practices.md
+++ b/lessons/contrib/api-rate-limit-handling-best-practices.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "api rate limit handling best practices",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "api rate limit handling best practices\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "API限流Handling最佳实践", "domain": "devops", "tags": ["api", "rate-limit", "backoff", "batch"]}---

--- a/lessons/contrib/api-rate-limit-handling.md
+++ b/lessons/contrib/api-rate-limit-handling.md
@@ -1,12 +1,15 @@
 ---
-title: "API 请求限流 (Rate Limit) 处理方案"
-domain: "devops"
-tags:
-  - api
-  - rate-limit
-  - retry
-  - "429"
-created: "2026-05-21"
+{
+  "title": "API 请求限流 (Rate Limit) 处理方案",
+  "domain": "devops",
+  "tags": "",
+  "created": "2026-05-21",
+  "author": "Ikalus1988",
+  "source": "pr",
+  "edited_at": "2026-07-07T15:57:50+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 373
+}
 ---
 
 ## 背景

--- a/lessons/contrib/audit-sampling-stratified-sampling-for-kb-inspection.md
+++ b/lessons/contrib/audit-sampling-stratified-sampling-for-kb-inspection.md
@@ -1,14 +1,16 @@
 ---
-title: "巡检题库分层抽样策略"
-domain: "rag"
-tags:
-  - rag
-  - audit
-  - sampling
-  - quality
-  - test-bank
-confidence: 0.88
-created: "2026-05-21"
+{
+  "title": "巡检题库分层抽样策略",
+  "domain": "rag",
+  "tags": "",
+  "confidence": 0.88,
+  "created": "2026-05-21",
+  "author": "Ikalus1988",
+  "source": "pr",
+  "edited_at": "2026-07-07T15:57:50+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 373
+}
 ---
 
 ## 背景

--- a/lessons/contrib/auth-header-bug.md
+++ b/lessons/contrib/auth-header-bug.md
@@ -1,7 +1,13 @@
 ---
-title: "Moorcheh API Auth Header Bug"
-domain: api
-evidence_level: E1
+{
+  "title": "Moorcheh API Auth Header Bug",
+  "domain": "api",
+  "evidence_level": "E1",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-08-13T00:39:45+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # Moorcheh API Auth Header Bug

--- a/lessons/contrib/benchmark-honesty-simulated-vs-real.md
+++ b/lessons/contrib/benchmark-honesty-simulated-vs-real.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Benchmark Honesty — Distinguishing Simulated vs Real Results",
-  "tags": ["benchmark", "honesty", "testing", "contrib", "agent"],
-  "status": "draft",
-  "source": "PR review feedback analysis",
-  "created": "2026-07-15",
-  "confidence": "0.95"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Benchmark Honesty — Distinguishing Simulated vs Real Results\",",
+  "\"tags\"": "[\"benchmark\", \"honesty\", \"testing\", \"contrib\", \"agent\"],",
+  "\"status\"": "draft\",",
+  "\"source\"": "PR review feedback analysis\",",
+  "\"created\"": "2026-07-15\",",
+  "\"confidence\"": "0.95",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-15T19:31:51+08:00",
+  "merged_by": "zsxh1990"
 }
 ---
 

--- a/lessons/contrib/bge-embedding-fallback-crash.md
+++ b/lessons/contrib/bge-embedding-fallback-crash.md
@@ -1,19 +1,23 @@
 ---
 {
-  "title": "BGE Embedding Fallback Crash",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "tags": [
-    "project:agent-medici",
-    "severity:high",
-    "node:hermes-wsl"
-  ],
-  "language": "en",
-  "created": "2026-05-03",
-  "domain_expert": "bootstrap",
-  "verified_date": "2026-05-03",
-  "subdomain": "embedding"
+  "\"title\"": "BGE Embedding Fallback Crash\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"project": "agent-medici\",",
+  "\"severity": "high\",",
+  "\"node": "hermes-wsl",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-05-03\",",
+  "\"domain_expert\"": "bootstrap\",",
+  "\"verified_date\"": "2026-05-03\",",
+  "\"subdomain\"": "embedding",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/bounty-contributors-are-not-always-users.md
+++ b/lessons/contrib/bounty-contributors-are-not-always-users.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "growth",
-  "title": "Bounty Contributors Are Not Always Users",
-  "tags": ["bounty", "contributors", "growth", "feedback", "community"],
-  "status": "published",
-  "source": "generalized contributor funnel analysis",
-  "created": "2026-07-17",
-  "confidence": "0.88"
+  "\"domain\"": "growth\",",
+  "\"title\"": "Bounty Contributors Are Not Always Users\",",
+  "\"tags\"": "[\"bounty\", \"contributors\", \"growth\", \"feedback\", \"community\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "generalized contributor funnel analysis\",",
+  "\"created\"": "2026-07-17\",",
+  "\"confidence\"": "0.88",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-07-17T01:09:07+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/browser-automation-csp-bypass.md
+++ b/lessons/contrib/browser-automation-csp-bypass.md
@@ -1,14 +1,29 @@
 ---
-title: CSP blocks JavaScript injection in browser automation of authenticated pages
-domain: mcp
-subdomain: browser-automation
-tags: ["browser-automation", "csp", "content-security-policy", "cdp", "puppeteer", "playwright", "eval", "injection"]
-status: published
-confidence: 0.8
-created: 2026-07-06
-updated: 2026-07-06
-source: zsxh1990
-verified_date: 2026-07-06
+{
+  "title": "CSP blocks JavaScript injection in browser automation of authenticated pages",
+  "domain": "mcp",
+  "subdomain": "browser-automation",
+  "tags": [
+    "browser-automation",
+    "csp",
+    "content-security-policy",
+    "cdp",
+    "puppeteer",
+    "playwright",
+    "eval",
+    "injection"
+  ],
+  "status": "published",
+  "confidence": 0.8,
+  "created": "2026-07-06",
+  "updated": "2026-07-06",
+  "source": "pr",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 # CSP blocks JavaScript injection in browser automation of authenticated pages

--- a/lessons/contrib/browser-harness-cdp-browser-automation.md
+++ b/lessons/contrib/browser-harness-cdp-browser-automation.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "browser-harness — AI 直连 Chrome 的 CDP 浏览器Automation", "domain": "devops", "source": "skill-harvest", "status": "published", "confidence": "0.6", "created": "2026-05-20"}---

--- a/lessons/contrib/cc-connect-feishu-display-optimization.md
+++ b/lessons/contrib/cc-connect-feishu-display-optimization.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "cc connect feishu display optimization",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "cc connect feishu display optimization\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "cc-connect 飞书显示Optimization：禁用工具调用和上下文提示", "domain": "feishu", "subdomain": "cc-connect", "source": "bootstrap", "status": "published", "confidence": "0.9", "created": "2026-05-19"}---

--- a/lessons/contrib/cc-connect-feishu-setup-complete.md
+++ b/lessons/contrib/cc-connect-feishu-setup-complete.md
@@ -1,14 +1,19 @@
 ---
 {
-  "title": "cc-connect Feishu bot complete setup guide",
-  "domain": "feishu",
-  "tags": ["feishu", "cc-connect", "bot", "setup", "agent", "bridge", "npm"],
-  "status": "published",
-  "source": "bootstrap",
-  "created": "2026-05-19",
-  "updated": "2026-07-21",
-  "confidence": "0.95",
-  "verification": "metadata-normalized"
+  "\"title\"": "cc-connect Feishu bot complete setup guide\",",
+  "\"domain\"": "feishu\",",
+  "\"tags\"": "[\"feishu\", \"cc-connect\", \"bot\", \"setup\", \"agent\", \"bridge\", \"npm\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "bootstrap\",",
+  "\"created\"": "2026-05-19\",",
+  "\"updated\"": "2026-07-21\",",
+  "\"confidence\"": "0.95\",",
+  "\"verification\"": "metadata-normalized",
+  "author": "uncledad96-glitch",
+  "source": "pr",
+  "edited_at": "2026-07-21T12:26:29+02:00",
+  "merged_by": "uncledad96-glitch",
+  "pr": 552
 }
 ---
 

--- a/lessons/contrib/ccswitch-hermes-switch.md
+++ b/lessons/contrib/ccswitch-hermes-switch.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "ccswitch-hermes-switch 踩坑Notes",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "ccswitch-hermes-switch 踩坑Notes\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"confidence": "0.7", "created": "2026-05-02", "domain": "devops", "source": "bootstrap", "status": "published", "tags": "", "- node": "cc_haha", "title": "ccswitch-hermes-switch 踩坑Notes"}---

--- a/lessons/contrib/cdn-edge-cache-stale-after-deploy.md
+++ b/lessons/contrib/cdn-edge-cache-stale-after-deploy.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "CDN edge cache serves stale responses for minutes after deploy",
-  "domain": "network",
-  "tags": [
-    "cdn",
-    "cache",
-    "deployment",
-    "edge",
-    "cloudflare"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "CDN edge cache serves stale responses for minutes after deploy\",",
+  "\"domain\"": "network\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:40:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/chroma-rebuild-no-checkpoint-cn.md
+++ b/lessons/contrib/chroma-rebuild-no-checkpoint-cn.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Chroma 建库无 Checkpoint — 进程一死全部丢失",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Chroma 建库无 Checkpoint — 进程一死全部丢失\", \"domain\": \"rag\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Chroma 建库无 Checkpoint — 进程一死全部丢失\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Chroma 建库无 Checkpoint — 进程一死全部丢失\\\", \\\"domain\\\": \\\"rag\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.7\\\", \\\"created\\\": \\\"2026-04-01\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-04-01\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/chrome-relay-browser-automation.md
+++ b/lessons/contrib/chrome-relay-browser-automation.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Chrome Relay 浏览器Automation — CDP over WebSocket 控制无头浏览器", "domain": "development", "tags": ["chrome", "browser", "automation", "cdp", "websocket", "openclaw"], "contributor": "hermes-agent"}---

--- a/lessons/contrib/ci-dco-decouple-pythonpath-fork-pr.md
+++ b/lessons/contrib/ci-dco-decouple-pythonpath-fork-pr.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "GitHub Actions CI for AI Agent PRs — DCO decoupling & PYTHONPATH fix", "domain": "devops", "tags": ["github-actions", "ci", "dco", "python", "ai-agent", "fork-pr", "pytest", "coverage"], "status": "published", "source": "deepseek", "created": "2026-06-04 00:00:00 UTC", "updated": "2026-06-12 00:00:00 UTC"}---

--- a/lessons/contrib/ci-key-rotation-silent-failure.md
+++ b/lessons/contrib/ci-key-rotation-silent-failure.md
@@ -1,17 +1,16 @@
 ---
 {
-  "title": "CI key rotation silently breaking scheduled automation without a code change",
-  "domain": "devops",
-  "tags": [
-    "credentials",
-    "rotation",
-    "automation",
-    "secret"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "CI key rotation silently breaking scheduled automation without a code change\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:00:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/ci-lambda-module-level-side-effects.md
+++ b/lessons/contrib/ci-lambda-module-level-side-effects.md
@@ -1,17 +1,17 @@
 ---
-title: "CI 测试陷阱 — 模块级副作用导致 import 失败"
-domain: devops
-tags:
-  - ci
-  - python
-  - lambda
-  - boto3
-  - module-import
-  - side-effects
-status: published
-source: practical-experience
-confidence: 0.9
-created: 2026-07-07
+{
+  "title": "CI 测试陷阱 — 模块级副作用导致 import 失败",
+  "domain": "devops",
+  "tags": "",
+  "status": "published",
+  "source": "pr",
+  "confidence": 0.9,
+  "created": "2026-07-07",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-08T17:09:01+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 415
+}
 ---
 
 ## Problem

--- a/lessons/contrib/claude-code-debugging-ml-dsa-cryptography.md
+++ b/lessons/contrib/claude-code-debugging-ml-dsa-cryptography.md
@@ -1,5 +1,11 @@
 ---
-{"title": "Claude Code can debug low-level cryptography — ML-DSA signature verification failure", "domain": "debugging", "tags": ["claude_code", "cryptography", "post_quantum", "ml_dsa", "debugging", "go"], "language": "en", "status": "published", "source": "https://words.filippo.io/claude-debugging/", "created": "2026-07-29", "confidence": "0.90"}
+{
+  "{\"title\"": "Claude Code can debug low-level cryptography — ML-DSA signature verification failure\", \"domain\": \"debugging\", \"tags\": [\"claude_code\", \"cryptography\", \"post_quantum\", \"ml_dsa\", \"debugging\", \"go\"], \"language\": \"en\", \"status\": \"published\", \"source\": \"https://words.filippo.io/claude-debugging/\", \"created\": \"2026-07-29\", \"confidence\": \"0.90\"}",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-29T09:45:21+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/cloudflare-email-worker-registration-trap.md
+++ b/lessons/contrib/cloudflare-email-worker-registration-trap.md
@@ -1,9 +1,21 @@
 ---
-title: "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF"
-domain: "devops"
-tags: ["cloudflare", "email-worker", "kv", "turnstile", "registration", "spf"]
-created: "2026-07-06"
-source: "unknown"
+{
+  "title": "Cloudflare Email Worker 邮件注册踩坑Notes — message.raw、MIME 与 SPF",
+  "domain": "devops",
+  "tags": [
+    "cloudflare",
+    "email-worker",
+    "kv",
+    "turnstile",
+    "registration",
+    "spf"
+  ],
+  "created": "2026-07-06",
+  "source": "manual",
+  "author": "Muhammad Bilal Mukhtar",
+  "edited_at": "2026-08-06T01:00:28+08:00",
+  "merged_by": "Muhammad Bilal Mukhtar"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/codeql-alert-dismissal-false-positive.md
+++ b/lessons/contrib/codeql-alert-dismissal-false-positive.md
@@ -1,10 +1,21 @@
 ---
-title: "Dismiss CodeQL False Positive Alerts"
-domain: "security"
-tags: ["codeql", "security", "github", "false-positive"]
-status: "published"
-source: "agent_experience"
-created: "2026-07-02"
+{
+  "title": "Dismiss CodeQL False Positive Alerts",
+  "domain": "security",
+  "tags": [
+    "codeql",
+    "security",
+    "github",
+    "false-positive"
+  ],
+  "status": "published",
+  "source": "pr",
+  "created": "2026-07-02",
+  "author": "2lll5",
+  "edited_at": "2026-07-09T17:43:25+08:00",
+  "merged_by": "2lll5",
+  "pr": 431
+}
 ---
 
 ---

--- a/lessons/contrib/codewhale-git-push-yolo-task.md
+++ b/lessons/contrib/codewhale-git-push-yolo-task.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI",
-  "verification": "metadata-normalized",
-  "{\"title\"": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI\", \"domain\": \"devops\", \"tags\": [\"codewhale\", \"git\", \"yolo\", \"push\", \"lesson\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "CodeWhale 中 git push 的正确方式 — YOLO task + gh CLI\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"codewhale\\\", \\\"git\\\", \\\"yolo\\\", \\\"push\\\", \\\"lesson\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/cron-job-not-running.md
+++ b/lessons/contrib/cron-job-not-running.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Cron 作业不执行 / 不生效排障",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Cron 作业不执行 / 不生效排障\", \"domain\": \"devops\", \"tags\": [\"cron\", \"scheduler\", \"not-running\", \"debug\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Cron 作业不执行 / 不生效排障\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Cron 作业不执行 / 不生效排障\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"cron\\\", \\\"scheduler\\\", \\\"not-running\\\", \\\"debug\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/cross-repo-contribution-strategy.md
+++ b/lessons/contrib/cross-repo-contribution-strategy.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Cross-Repo Contribution Strategy — Finding and Contributing to New Repos",
-  "tags": ["contrib", "strategy", "github", "open-source", "agent"],
-  "status": "draft",
-  "source": "Multi-repo contribution session",
-  "created": "2026-07-15",
-  "confidence": "0.90"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Cross-Repo Contribution Strategy — Finding and Contributing to New Repos\",",
+  "\"tags\"": "[\"contrib\", \"strategy\", \"github\", \"open-source\", \"agent\"],",
+  "\"status\"": "draft\",",
+  "\"source\"": "Multi-repo contribution session\",",
+  "\"created\"": "2026-07-15\",",
+  "\"confidence\"": "0.90",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-15T19:31:51+08:00",
+  "merged_by": "zsxh1990"
 }
 ---
 

--- a/lessons/contrib/cross-sheet-name-merge-data-chaos.md
+++ b/lessons/contrib/cross-sheet-name-merge-data-chaos.md
@@ -1,18 +1,20 @@
 ---
-title: "跨 Sheet 同名合并导致数据混乱：机器人唯一标识必须带前缀"
-domain: "data"
-subdomain: "data-pipeline"
-tags:
-  - data-pipeline
-  - dedup
-  - unique-key
-  - excel
-source: "zsxh1990"
-status: "published"
-confidence: "1.0"
-created: "2026-06-25"
-domain_expert: "zsxh1990"
-verified_date: "2026-07-06"
+{
+  "title": "跨 Sheet 同名合并导致数据混乱：机器人唯一标识必须带前缀",
+  "domain": "data",
+  "subdomain": "data-pipeline",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": "1.0",
+  "created": "2026-06-25",
+  "domain_expert": "zsxh1990",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-07T11:58:11+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 375
+}
 ---
 
 ## Problem

--- a/lessons/contrib/css-z-index-stacking-context-modal.md
+++ b/lessons/contrib/css-z-index-stacking-context-modal.md
@@ -1,20 +1,20 @@
 ---
-title: CSS z-index Not Working — Stacking Context Inversion in Modal Overlays
-domain: frontend
-subdomain: css
-tags:
-  - css
-  - z-index
-  - stacking-context
-  - modal
-  - overlay
-  - position
-source: hermes-agent
-status: published
-confidence: 0.95
-created: 2026-07-21
-verified_date: ''
-domain_expert: ''
+{
+  "title": "CSS z-index Not Working — Stacking Context Inversion in Modal Overlays",
+  "domain": "frontend",
+  "subdomain": "css",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.95,
+  "created": "2026-07-21",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "lb1192176991-lab",
+  "edited_at": "2026-07-23T01:14:55+08:00",
+  "merged_by": "lb1192176991-lab",
+  "pr": 535
+}
 ---
 
 {"title": "CSS z-index Not Working — Stacking Context Inversion in Modal Overlays", "domain": "frontend", "subdomain": "css", "tags": ["css", "z-index", "stacking-context", "modal", "overlay", "position"], "source": "hermes-agent", "status": "published", "confidence": "0.95", "created": "2026-07-21", "verified_date": "", "domain_expert": ""}

--- a/lessons/contrib/cubic_ai_vs_pr_genius.md
+++ b/lessons/contrib/cubic_ai_vs_pr_genius.md
@@ -1,10 +1,17 @@
 ---
-name: cubic-ai-vs-pr-genius
-description: Cubic AI 与 PR Genius 对比——即时触发、diff 逐行、正向确认三点可借鉴
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T10:20:05.320Z
+{
+  "name": "cubic-ai-vs-pr-genius",
+  "description": "Cubic AI 与 PR Genius 对比——即时触发、diff 逐行、正向确认三点可借鉴",
+  "metadata": "",
+  "type": "feedback",
+  "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+  "modified": "2026-08-04T10:20:05.320Z",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-08-04T23:50:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 801
+}
 ---
 
 ## 背景

--- a/lessons/contrib/curl-request-troubleshoot.md
+++ b/lessons/contrib/curl-request-troubleshoot.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "curl / wget 请求失败通用Diagnosis",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "curl / wget 请求失败通用Diagnosis\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "curl / wget 请求失败通用Diagnosis", "domain": "devops", "tags": ["network", "curl", "wget", "debug", "troubleshoot"]}---

--- a/lessons/contrib/data-capping-equals-forging-data.md
+++ b/lessons/contrib/data-capping-equals-forging-data.md
@@ -1,18 +1,20 @@
 ---
-title: "数据封顶=伪造数据：超出阈值应剔除而非截断"
-domain: "data"
-subdomain: "data-quality"
-tags:
-  - data-quality
-  - threshold
-  - capping
-  - data-integrity
-source: "zsxh1990"
-status: "published"
-confidence: "1.0"
-created: "2026-06-25"
-domain_expert: "zsxh1990"
-verified_date: "2026-07-06"
+{
+  "title": "数据封顶=伪造数据：超出阈值应剔除而非截断",
+  "domain": "data",
+  "subdomain": "data-quality",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": "1.0",
+  "created": "2026-06-25",
+  "domain_expert": "zsxh1990",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-07T11:58:11+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 375
+}
 ---
 
 ## Problem

--- a/lessons/contrib/data-quality-three-layer-fix-pattern.md
+++ b/lessons/contrib/data-quality-three-layer-fix-pattern.md
@@ -1,5 +1,11 @@
 ---
-{"title": "Data Quality Fix: Always Keep Three Layers (DB + ETL + Query)", "domain": "data-engineering", "tags": ["data-quality", "etl", "sql", "normalization", "defense-in-depth"], "status": "published", "evidence_level": "E2", "created": "2026-08-06", "updated": "2026-08-06", "source": "b2-robot-utilization project — FE/TGO line name normalization", "verified_date": "2026-08-06"}
+{
+  "{\"title\"": "Data Quality Fix: Always Keep Three Layers (DB + ETL + Query)\", \"domain\": \"data-engineering\", \"tags\": [\"data-quality\", \"etl\", \"sql\", \"normalization\", \"defense-in-depth\"], \"status\": \"published\", \"evidence_level\": \"E2\", \"created\": \"2026-08-06\", \"updated\": \"2026-08-06\", \"source\": \"b2-robot-utilization project — FE/TGO line name normalization\", \"verified_date\": \"2026-08-06\"}",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-08-11T21:14:18+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # Data Quality Fix: Always Keep Three Layers (DB + ETL + Query)

--- a/lessons/contrib/dco_signoff_force_push_pitfall.md
+++ b/lessons/contrib/dco_signoff_force_push_pitfall.md
@@ -1,10 +1,17 @@
 ---
-name: dco-signoff-force-push-pitfall
-description: DCO signoff 在 force push 后丢失——squash 必须在 reset --hard 后重新 commit --signoff
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T10:19:47.621Z
+{
+  "name": "dco-signoff-force-push-pitfall",
+  "description": "DCO signoff 在 force push 后丢失——squash 必须在 reset --hard 后重新 commit --signoff",
+  "metadata": "",
+  "type": "feedback",
+  "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+  "modified": "2026-08-04T10:19:47.621Z",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-08-04T23:50:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 801
+}
 ---
 
 ## 问题

--- a/lessons/contrib/debugging-memory-leaks-in-ruby.md
+++ b/lessons/contrib/debugging-memory-leaks-in-ruby.md
@@ -1,12 +1,17 @@
 ---
-title: Debugging memory leaks in Ruby
-domain: Ruby/Performance
-tags: [memory-leaks, debugging, Ruby, Rails, heap-dump, ObjectSpace]
-language: en
-status: published
-source: https://samsaffron.com/archive/2015/03/31/debugging-memory-leaks-in-ruby
-created: 2026-07-28
-confidence: 0.85
+{
+  "title": "Debugging memory leaks in Ruby",
+  "domain": "Ruby/Performance",
+  "tags": "[memory-leaks, debugging, Ruby, Rails, heap-dump, ObjectSpace]",
+  "language": "en",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-28",
+  "confidence": 0.85,
+  "author": "zsxh1990",
+  "edited_at": "2026-07-29T09:18:36+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/deepseek-tui-write-file-sandbox-worktree-git-path.md
+++ b/lessons/contrib/deepseek-tui-write-file-sandbox-worktree-git-path.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "deepseek tui write file sandbox worktree git path",
-  "verification": "metadata-normalized",
-  "{\"title\"": "DeepSeek TUI — write_file Sandbox + Worktree Git Path Breakage\", \"domain\": \"devops\", \"source\": \"hermes_wsl2\", \"status\": \"published\", \"tags\": [\"deepseek-tui\", \"agent-mode\", \"write-file\", \"worktree\", \"wsl\", \"git\", \"lesson-written\"], \"created\": \"2026-05-13 01:01:46 UTC\", \"updated\": \"2026-05-13 01:01:46 UTC\", \"domain_expert\": \"hermes_wsl2\", \"verified_date\": \"2026-05-13\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "deepseek tui write file sandbox worktree git path\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "DeepSeek TUI — write_file Sandbox + Worktree Git Path Breakage\\\", \\\"domain\\\": \\\"devops\\\", \\\"source\\\": \\\"hermes_wsl2\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"deepseek-tui\\\", \\\"agent-mode\\\", \\\"write-file\\\", \\\"worktree\\\", \\\"wsl\\\", \\\"git\\\", \\\"lesson-written\\\"], \\\"created\\\": \\\"2026-05-13 01:01:46 UTC\\\", \\\"updated\\\": \\\"2026-05-13 01:01:46 UTC\\\", \\\"domain_expert\\\": \\\"hermes_wsl2\\\", \\\"verified_date\\\": \\\"2026-05-13\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/disk-space-cleanup.md
+++ b/lessons/contrib/disk-space-cleanup.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "磁盘空间不足 / chroma_db_v4 CacheCleanup",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "磁盘空间不足 / chroma_db_v4 CacheCleanup\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "磁盘空间不足 / chroma_db_v4 CacheCleanup", "updated": "2026-05-01 08:00 UTC"}---

--- a/lessons/contrib/erreur-permission-docker-linux.md
+++ b/lessons/contrib/erreur-permission-docker-linux.md
@@ -1,13 +1,18 @@
 ---
-title: "Erreur de permission Docker: permission denied sur /var/run/docker.sock"
-domain: "devops"
-tags: [docker, linux, permission, socket, security]
-language: fr
-status: published
-source: "https://docs.docker.com/engine/install/linux-postinstall/"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "Erreur de permission Docker: permission denied sur /var/run/docker.sock",
+  "domain": "devops",
+  "tags": "[docker, linux, permission, socket, security]",
+  "language": "fr",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:27:32-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/erro-push-git-rejeitado-divergente.md
+++ b/lessons/contrib/erro-push-git-rejeitado-divergente.md
@@ -1,13 +1,18 @@
 ---
-title: "Erro de push rejeitado no Git: branches divergentes e como resolver"
-domain: "devops"
-tags: [git, push, merge, rebase, divergente]
-language: pt
-status: published
-source: "https://docs.github.com/en/get-started/using-git/dealing-with-non-fast-forward-errors"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "Erro de push rejeitado no Git: branches divergentes e como resolver",
+  "domain": "devops",
+  "tags": "[git, push, merge, rebase, divergente]",
+  "language": "pt",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:29:12-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/error-dco-signoff-windows.md
+++ b/lessons/contrib/error-dco-signoff-windows.md
@@ -1,13 +1,18 @@
 ---
-title: "Error de DCO sign-off en commits de Git en Windows"
-domain: "devops"
-tags: [git, dco, windows, signoff, commit]
-language: es
-status: published
-source: "https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/dco-auto-fix-workflow.md"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "Error de DCO sign-off en commits de Git en Windows",
+  "domain": "devops",
+  "tags": "[git, dco, windows, signoff, commit]",
+  "language": "es",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:23:25-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/escrow-fee-rounding-per-provider.md
+++ b/lessons/contrib/escrow-fee-rounding-per-provider.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "Banking-style escrow fee estimate has a per-provider rounding disparity",
-  "domain": "development",
-  "tags": [
-    "payments",
-    "calculation",
-    "rounding",
-    "precision",
-    "ledger"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "Banking-style escrow fee estimate has a per-provider rounding disparity\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:55:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/fanuc-alarm-code-reference.md
+++ b/lessons/contrib/fanuc-alarm-code-reference.md
@@ -1,14 +1,25 @@
 ---
-id: fanuc-alarm-code-reference
-title: "FANUC Robot Alarm Code Reference Table"
-domain: fanuc
-subdomain: alarm-troubleshooting
-source: "bbs.gongkong.com/d/202401/915680"
-status: draft
-confidence: 0.6
-created: "2026-07-12"
-tags: ["fanuc", "alarm", "error-code", "troubleshooting", "reference"]
-quality_score: 43
+{
+  "id": "fanuc-alarm-code-reference",
+  "title": "FANUC Robot Alarm Code Reference Table",
+  "domain": "fanuc",
+  "subdomain": "alarm-troubleshooting",
+  "source": "manual",
+  "status": "draft",
+  "confidence": 0.6,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "alarm",
+    "error-code",
+    "troubleshooting",
+    "reference"
+  ],
+  "quality_score": 43,
+  "author": "Ikalus1988",
+  "edited_at": "2026-08-04T00:03:23+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-alarm-severity-guide.md
+++ b/lessons/contrib/fanuc-alarm-severity-guide.md
@@ -1,12 +1,27 @@
 ---
-title: "FANUC Alarm Severity Levels — Handling and Color Codes"
-domain: "fanuc"
-subdomain: "troubleshooting"
-tags: ["alarm", "severity", "warn", "pause", "stop", "servo", "abort", "system", "troubleshooting"]
-status: "published"
-source: "internal-training"
-confidence: "0.95"
-created: "2026-07-14"
+{
+  "title": "FANUC Alarm Severity Levels — Handling and Color Codes",
+  "domain": "fanuc",
+  "subdomain": "troubleshooting",
+  "tags": [
+    "alarm",
+    "severity",
+    "warn",
+    "pause",
+    "stop",
+    "servo",
+    "abort",
+    "system",
+    "troubleshooting"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.95",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-auto-abort-on-fault-restart.md
+++ b/lessons/contrib/fanuc-auto-abort-on-fault-restart.md
@@ -1,14 +1,27 @@
 ---
-title: "FANUC Auto Abort on Fault — Restart $SHELL_WRK Program"
-domain: "fanuc"
-subdomain: "error-handling"
-tags: ["abort", "fault", "restart", "shell-wrk", "bg-logic", "error-severity", "auto-recovery"]
-source: "robot-forum.com"
-status: "published"
-confidence: "0.8"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: "pdl"
+{
+  "title": "FANUC Auto Abort on Fault — Restart $SHELL_WRK Program",
+  "domain": "fanuc",
+  "subdomain": "error-handling",
+  "tags": [
+    "abort",
+    "fault",
+    "restart",
+    "shell-wrk",
+    "bg-logic",
+    "error-severity",
+    "auto-recovery"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.8",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "pdl",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/fanuc-backup-payload-extraction.md
+++ b/lessons/contrib/fanuc-backup-payload-extraction.md
@@ -1,20 +1,36 @@
 ---
-title: "FANUC Backup Payload Extraction — .VR/.SV Binary Parsing and .LS Text Fallback"
-domain: "fanuc"
-subdomain: "backup-analysis"
-tags: ["backup", "payload", "vr-file", "sv-file", "kconvars", "sysvars", "cbparam", "plst-grp", "binary-parsing", "spottool"]
-source: "internal"
-status: "published"
-confidence: "0.85"
-created: "2026-07-14"
-verified_date: "2026-07-14"
-domain_expert: ""
-evidence:
-  level: "pre_ingest_reused"
-  source_type: "colleague_memory_dump"
-  verified_by: "maintainer"
-  context: "Distilled from real field debugging session. kcantrans VR-variable access path verified as practically useful before ingestion."
-  public_quote_allowed: false
+{
+  "title": "FANUC Backup Payload Extraction — .VR/.SV Binary Parsing and .LS Text Fallback",
+  "domain": "fanuc",
+  "subdomain": "backup-analysis",
+  "tags": [
+    "backup",
+    "payload",
+    "vr-file",
+    "sv-file",
+    "kconvars",
+    "sysvars",
+    "cbparam",
+    "plst-grp",
+    "binary-parsing",
+    "spottool"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-14",
+  "verified_date": "2026-07-14",
+  "domain_expert": "",
+  "evidence": "",
+  "level": "pre_ingest_reused",
+  "source_type": "colleague_memory_dump",
+  "verified_by": "maintainer",
+  "context": "Distilled from real field debugging session. kcantrans VR-variable access path verified as practically useful before ingestion.",
+  "public_quote_allowed": false,
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-17T00:48:44+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/fanuc-backup-restore-guide.md
+++ b/lessons/contrib/fanuc-backup-restore-guide.md
@@ -1,12 +1,26 @@
 ---
-title: "FANUC Robot Backup and Restore — Full, Mirror, Auto, and File Restore"
-domain: "fanuc"
-subdomain: "maintenance"
-tags: ["backup", "restore", "mirror", "image", "auto-backup", "file-restore", "usb", "maintenance"]
-status: "published"
-source: "internal-training"
-confidence: "0.9"
-created: "2026-07-14"
+{
+  "title": "FANUC Robot Backup and Restore — Full, Mirror, Auto, and File Restore",
+  "domain": "fanuc",
+  "subdomain": "maintenance",
+  "tags": [
+    "backup",
+    "restore",
+    "mirror",
+    "image",
+    "auto-backup",
+    "file-restore",
+    "usb",
+    "maintenance"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.9",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-communication-protocol-socket.md
+++ b/lessons/contrib/fanuc-communication-protocol-socket.md
@@ -3,16 +3,28 @@
   "title": "FANUC Robot TCP/IP Socket Communication Protocol and MAPPDK Setup",
   "domain": "fanuc",
   "subdomain": "communication",
-  "source": "github.com/torayeff/fanucpy/blob/main/fanuc.md",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.85,
   "created": "2026-07-12",
-  "tags": ["fanuc", "socket-messaging", "tcp-ip", "mappdk", "network", "karel", "r648"],
+  "tags": [
+    "fanuc",
+    "socket-messaging",
+    "tcp-ip",
+    "mappdk",
+    "network",
+    "karel",
+    "r648"
+  ],
   "quality_score": 85,
   "problem": "需要从外部 PC 通过网络与 FANUC 机器人控制器建立通信，实现远程指令下发和状态读取。",
   "root_cause": "FANUC 控制器支持 User Socket Messaging（R648 选件）实现 TCP/IP 通信，但配置步骤分散在多个菜单中，涉及网络配置、服务器设置、KAREL 程序部署等多个环节，容易遗漏。",
   "solution": "按照完整流程配置：网络连接（IP/子网/DHCP）→ 服务器配置（S8 tag/18735 端口/SM 协议）→ Logger 配置（S7 tag/18736）→ MAPPDK 程序部署 → 验证通信。",
-  "verification": "1. 控制器 IP 可 ping 通；2. S8 服务器 Current State 为 STARTED；3. 外部客户端能连接 18735 端口；4. MAPPDK 程序在控制器上运行中。"
+  "verification": "1. 控制器 IP 可 ping 通；2. S8 服务器 Current State 为 STARTED；3. 外部客户端能连接 18735 端口；4. MAPPDK 程序在控制器上运行中。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## FANUC Robot TCP/IP Socket Communication Protocol and MAPPDK Setup

--- a/lessons/contrib/fanuc-dcs-safety-configuration.md
+++ b/lessons/contrib/fanuc-dcs-safety-configuration.md
@@ -1,12 +1,26 @@
 ---
-title: "FANUC DCS Safety System — Configuration and Stop Modes"
-domain: "fanuc"
-subdomain: "safety"
-tags: ["dcs", "safety", "dual-check", "emergency-stop", "fence", "stop-mode", "safety-io", "iso13849"]
-status: "published"
-source: "internal-training"
-confidence: "0.95"
-created: "2026-07-14"
+{
+  "title": "FANUC DCS Safety System — Configuration and Stop Modes",
+  "domain": "fanuc",
+  "subdomain": "safety",
+  "tags": [
+    "dcs",
+    "safety",
+    "dual-check",
+    "emergency-stop",
+    "fence",
+    "stop-mode",
+    "safety-io",
+    "iso13849"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.95",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-do-not-found-in-program-reference-position.md
+++ b/lessons/contrib/fanuc-do-not-found-in-program-reference-position.md
@@ -1,14 +1,26 @@
 ---
-title: "FANUC DO Not Found in Program — Check Reference Position"
-domain: "fanuc"
-subdomain: "troubleshooting"
-tags: ["do", "digital-output", "reference-position", "background-logic", "space-function", "search"]
-source: "robot-forum.com"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: "Nation"
+{
+  "title": "FANUC DO Not Found in Program — Check Reference Position",
+  "domain": "fanuc",
+  "subdomain": "troubleshooting",
+  "tags": [
+    "do",
+    "digital-output",
+    "reference-position",
+    "background-logic",
+    "space-function",
+    "search"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "Nation",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/fanuc-eip-omron-plc-connection.md
+++ b/lessons/contrib/fanuc-eip-omron-plc-connection.md
@@ -1,4 +1,30 @@
-{"id": "fanuc-eip-omron-plc-connection", "title": "FANUC Robot EtherNet/IP Connection with OMRON PLC", "domain": "fanuc", "subdomain": "plc-communication", "source": "bbs.gongkong.com/d/202112/878050", "status": "draft", "confidence": 0.6, "created": "2026-07-12", "tags": ["fanuc", "ethernet-ip", "eip", "omron", "plc-communication", "hardware-cost"], "quality_score": 50, "problem": "需要将 OMRON PLC 与 FANUC 机器人建立通讯连接。传统方案（如 PROFINET、DeviceNet）需要额外购买通讯硬件卡，增加了系统成本。", "root_cause": "FANUC 机器人的以太网端口为标准配置，无需额外购买硬件即可支持 EtherNet/IP (EIP) 协议。使用 EIP 通讯可有效减少硬件成本，但需要正确配置以太网参数和 EIP 连接。", "solution": "1. 确认 FANUC 机器人固件版本支持 EtherNet/IP\n2. 配置 FANUC 侧以太网参数（IP 地址、子网掩码）\n3. 在 OMRON PLC 侧（CX-Integrator 或 Sysmac Studio）添加 FANUC EIP 设备\n4. 配置 EIP 连接参数（Assembly Instance、连接大小）\n5. 映射 I/O 信号（DI/DO 与 PLC 地址对应）\n6. 测试通讯连接并验证信号收发", "verification": "1. OMRON PLC 编程软件显示 FANUC EIP 设备在线\n2. PLC 写入 DO 信号，FANUC 侧 DI 信号正确响应\n3. FANUC 输出 DO 信号，PLC 侧读取值正确\n4. 通讯无超时或断线报警"}
+{
+  "id": "fanuc-eip-omron-plc-connection",
+  "title": "FANUC Robot EtherNet/IP Connection with OMRON PLC",
+  "domain": "fanuc",
+  "subdomain": "plc-communication",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.6,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "ethernet-ip",
+    "eip",
+    "omron",
+    "plc-communication",
+    "hardware-cost"
+  ],
+  "quality_score": 50,
+  "problem": "需要将 OMRON PLC 与 FANUC 机器人建立通讯连接。传统方案（如 PROFINET、DeviceNet）需要额外购买通讯硬件卡，增加了系统成本。",
+  "root_cause": "FANUC 机器人的以太网端口为标准配置，无需额外购买硬件即可支持 EtherNet/IP (EIP) 协议。使用 EIP 通讯可有效减少硬件成本，但需要正确配置以太网参数和 EIP 连接。",
+  "solution": "1. 确认 FANUC 机器人固件版本支持 EtherNet/IP\n2. 配置 FANUC 侧以太网参数（IP 地址、子网掩码）\n3. 在 OMRON PLC 侧（CX-Integrator 或 Sysmac Studio）添加 FANUC EIP 设备\n4. 配置 EIP 连接参数（Assembly Instance、连接大小）\n5. 映射 I/O 信号（DI/DO 与 PLC 地址对应）\n6. 测试通讯连接并验证信号收发",
+  "verification": "1. OMRON PLC 编程软件显示 FANUC EIP 设备在线\n2. PLC 写入 DO 信号，FANUC 侧 DI 信号正确响应\n3. FANUC 输出 DO 信号，PLC 侧读取值正确\n4. 通讯无超时或断线报警",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ## FANUC 机器人与 OMRON PLC 的 EtherNet/IP 连接
 

--- a/lessons/contrib/fanuc-handling-robot-auto-drop-diagnosis.md
+++ b/lessons/contrib/fanuc-handling-robot-auto-drop-diagnosis.md
@@ -1,4 +1,30 @@
-{"id": "fanuc-handling-robot-auto-drop-diagnosis", "title": "FANUC Handling Robot Unexpected Auto Mode Dropout Diagnosis", "domain": "fanuc", "subdomain": "troubleshooting", "source": "bbs.gongkong.com/d/202603/974683", "status": "draft", "confidence": 0.7, "created": "2026-07-12", "tags": ["fanuc", "auto-drop", "handling", "quick-change-coupler", "signal-loss", "troubleshooting"], "quality_score": 56, "problem": "FANUC 搬运机器人在运行过程中偶尔掉出自动模式（AUTO mode dropout），频率约每天一次，有时数天不出现。掉自动后需手动按下电气控制面板的复位和启动按钮才能恢复。", "root_cause": "社区技术共识指向快换耦合器（quick-change coupler）的电气触点问题。搬运机器人在抓件→焊接→放件流程中，销式快换耦合器需断开/重连。断开/重连过程中的瞬间信号丢失会触发 FANUC 控制器退出自动模式。具体原因包括：1) 快换耦合器触点接触不良（磨损/污染）；2) 机械对位精度不足导致连接不稳；3) 焊接线缆虚焊或连接松动。", "solution": "1. 清洁检查快换耦合器触点，排除磨损或污染\n2. 验证耦合器机械对位精度，确保连接稳定\n3. 编写监控程序，逐一检测信号线的瞬断情况\n4. 若无法定位具体故障线，更换整条线束\n5. 检查信号线焊接质量，排除虚焊问题", "verification": "1. 清洁/更换触点后连续运行 3 天无掉自动现象\n2. 监控程序记录的信号瞬断次数降为 0\n3. 更换线束后问题彻底消失"}
+{
+  "id": "fanuc-handling-robot-auto-drop-diagnosis",
+  "title": "FANUC Handling Robot Unexpected Auto Mode Dropout Diagnosis",
+  "domain": "fanuc",
+  "subdomain": "troubleshooting",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.7,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "auto-drop",
+    "handling",
+    "quick-change-coupler",
+    "signal-loss",
+    "troubleshooting"
+  ],
+  "quality_score": 56,
+  "problem": "FANUC 搬运机器人在运行过程中偶尔掉出自动模式（AUTO mode dropout），频率约每天一次，有时数天不出现。掉自动后需手动按下电气控制面板的复位和启动按钮才能恢复。",
+  "root_cause": "社区技术共识指向快换耦合器（quick-change coupler）的电气触点问题。搬运机器人在抓件→焊接→放件流程中，销式快换耦合器需断开/重连。断开/重连过程中的瞬间信号丢失会触发 FANUC 控制器退出自动模式。具体原因包括：1) 快换耦合器触点接触不良（磨损/污染）；2) 机械对位精度不足导致连接不稳；3) 焊接线缆虚焊或连接松动。",
+  "solution": "1. 清洁检查快换耦合器触点，排除磨损或污染\n2. 验证耦合器机械对位精度，确保连接稳定\n3. 编写监控程序，逐一检测信号线的瞬断情况\n4. 若无法定位具体故障线，更换整条线束\n5. 检查信号线焊接质量，排除虚焊问题",
+  "verification": "1. 清洁/更换触点后连续运行 3 天无掉自动现象\n2. 监控程序记录的信号瞬断次数降为 0\n3. 更换线束后问题彻底消失",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ## FANUC 搬运机器人掉自动模式诊断
 

--- a/lessons/contrib/fanuc-intp-102-detect-joint-olp-whitespace.md
+++ b/lessons/contrib/fanuc-intp-102-detect-joint-olp-whitespace.md
@@ -1,14 +1,27 @@
 ---
-title: "FANUC INTP-102 DETECT JOINT — OLP Whitespace Bug"
-domain: "fanuc"
-subdomain: "olp"
-tags: ["intp-102", "detect-joint", "olp", "robodk", "ls-format", "whitespace", "arc-sensor"]
-source: "robot-forum.com"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "FANUC INTP-102 DETECT JOINT — OLP Whitespace Bug",
+  "domain": "fanuc",
+  "subdomain": "olp",
+  "tags": [
+    "intp-102",
+    "detect-joint",
+    "olp",
+    "robodk",
+    "ls-format",
+    "whitespace",
+    "arc-sensor"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/fanuc-io-marker-m-instruction.md
+++ b/lessons/contrib/fanuc-io-marker-m-instruction.md
@@ -1,14 +1,27 @@
 ---
-title: FANUC IO Marker M[] Instruction — Background Logic Alternative
-domain: fanuc
-subdomain: tp-programming
-tags: ["marker", "m-register", "io", "background-logic", "handling-tool", "vass"]
-source: robot-forum.com
-status: published
-confidence: 0.85
-created: 2026-07-01
-verified_date: 
-domain_expert: cattmampbell
+{
+  "title": "FANUC IO Marker M[] Instruction — Background Logic Alternative",
+  "domain": "fanuc",
+  "subdomain": "tp-programming",
+  "tags": [
+    "marker",
+    "m-register",
+    "io",
+    "background-logic",
+    "handling-tool",
+    "vass"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "cattmampbell",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/fanuc-karel-core-utility-modules.md
+++ b/lessons/contrib/fanuc-karel-core-utility-modules.md
@@ -3,16 +3,29 @@
   "title": "KAREL Core Utility Modules: errors, system, Strings API Reference",
   "domain": "fanuc",
   "subdomain": "karel-programming",
-  "source": "github.com/kobbled/ka-boost/.claude/rules/layer-1-core-utilities.md",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.85,
   "created": "2026-07-12",
-  "tags": ["fanuc", "karel", "ka-boost", "errors", "strings", "system", "utility", "api"],
+  "tags": [
+    "fanuc",
+    "karel",
+    "ka-boost",
+    "errors",
+    "strings",
+    "system",
+    "utility",
+    "api"
+  ],
   "quality_score": 85,
   "problem": "KAREL 缺乏标准库，错误处理、字符串操作、系统类型定义等基础功能需要从零实现，代码复用率低。",
   "root_cause": "KAREL 语言没有标准库，连基本的字符串分割、类型转换、错误码管理都需要手动实现。Ka-Boost Layer 1 提供三个核心模块（errors, system, Strings）作为所有上层模块的基础。",
   "solution": "使用 Ka-Boost Layer 1 的三个基础模块：errors（错误处理+变量初始化）、system（系统类型+时间+坐标系）、Strings（字符串全操作），作为 KAREL 项目的基础设施。",
-  "verification": "1. errors 模块：karelError 能输出到 TP 显示和历史记录；2. system 模块：system__date()/system__time() 返回正确格式；3. Strings 模块：split_str、i_to_s/r_to_s 等函数在 KUnit 测试中通过。"
+  "verification": "1. errors 模块：karelError 能输出到 TP 显示和历史记录；2. system 模块：system__date()/system__time() 返回正确格式；3. Strings 模块：split_str、i_to_s/r_to_s 等函数在 KUnit 测试中通过。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## KAREL Core Utility Modules: errors, system, Strings API Reference

--- a/lessons/contrib/fanuc-karel-geometry-kinematics-layer.md
+++ b/lessons/contrib/fanuc-karel-geometry-kinematics-layer.md
@@ -1,4 +1,32 @@
-{"id":"fanuc-karel-geometry-kinematics-layer","title":"Geometry and Kinematics Layer — Shapes, Pose, Sensors for Robot Programming","domain":"fanuc","subdomain":"karel-geometry","source":"github-ka-boost-layer6-geometry-kinematics.md","status":"draft","confidence":0.8,"created":"2026-07-12","tags":["fanuc","karel","geometry","shapes","sensors","tof","plane","collision"],"quality_score":80,"problem":"KAREL原生缺少3D几何图元(平面、线段、圆柱、包围盒)的交集、投影、碰撞检测等操作，以及ToF传感器集成，限制了机器人在复杂几何环境中的编程能力","root_cause":"FANUC KAREL标准库仅提供基础数学函数，没有面向机器人应用的几何计算库和传感器抽象层","solution":"Ka-Boost Layer6提供三个模块：shapes模块实现3D几何图元(plane/line/segment/box/cylinder)及交集/投影/碰撞检测；pose模块提供运动学和坐标变换(详见pose专题)；sensors模块封装ToF激光测距传感器(支持Keyence IL300/IL065、Panasonic MLDS)，含校准、滑动窗口平均、边沿检测","verification":"shapes模块通过TP交互式示教程序验证(如shp_splitedv、incylinder)；sensors模块通过实际传感器标定和空间扫描验证"}
+{
+  "id": "fanuc-karel-geometry-kinematics-layer",
+  "title": "Geometry and Kinematics Layer — Shapes, Pose, Sensors for Robot Programming",
+  "domain": "fanuc",
+  "subdomain": "karel-geometry",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.8,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "karel",
+    "geometry",
+    "shapes",
+    "sensors",
+    "tof",
+    "plane",
+    "collision"
+  ],
+  "quality_score": 80,
+  "problem": "KAREL原生缺少3D几何图元(平面、线段、圆柱、包围盒)的交集、投影、碰撞检测等操作，以及ToF传感器集成，限制了机器人在复杂几何环境中的编程能力",
+  "root_cause": "FANUC KAREL标准库仅提供基础数学函数，没有面向机器人应用的几何计算库和传感器抽象层",
+  "solution": "Ka-Boost Layer6提供三个模块：shapes模块实现3D几何图元(plane/line/segment/box/cylinder)及交集/投影/碰撞检测；pose模块提供运动学和坐标变换(详见pose专题)；sensors模块封装ToF激光测距传感器(支持Keyence IL300/IL065、Panasonic MLDS)，含校准、滑动窗口平均、边沿检测",
+  "verification": "shapes模块通过TP交互式示教程序验证(如shp_splitedv、incylinder)；sensors模块通过实际传感器标定和空间扫描验证",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ### 问题描述
 

--- a/lessons/contrib/fanuc-karel-http-api-webcontrol.md
+++ b/lessons/contrib/fanuc-karel-http-api-webcontrol.md
@@ -1,4 +1,32 @@
-{"id":"fanuc-karel-http-api-webcontrol","title":"FANUC KAREL HTTP API — WebControl Robot Motion and Monitoring","domain":"fanuc","subdomain":"karel-webcontrol","source":"github-fanuc-webcontrol-api.md","status":"draft","confidence":0.75,"created":"2026-07-12","tags":["fanuc","karel","http","api","webcontrol","rest","motion","monitoring"],"quality_score":75,"problem":"需要通过HTTP接口远程控制FANUC机器人运动、监控状态、管理程序执行，但FANUC原生不提供REST API","root_cause":"FANUC控制器内置KAREL webserver，但官方文档分散，缺少完整的API参考和使用示例","solution":"基于KAREL webserver实现HTTP API：webcontrol端点发送6种运动模式(关节/笛卡尔×绝对/相对)、webmonitor返回完整状态JSON(关节/笛卡尔/限位/状态/错误)、weblimit设置18个运动限位、webstart运行TP程序、webabort紧急停止","verification":"webcontrol/weblimit成功返回204状态码；webmonitor返回完整JSON包含joint/pose/limit/status/message/error/timestamp字段；各KAREL程序(webabort/webcheck/webkeep/webreset等)功能独立可测"}
+{
+  "id": "fanuc-karel-http-api-webcontrol",
+  "title": "FANUC KAREL HTTP API — WebControl Robot Motion and Monitoring",
+  "domain": "fanuc",
+  "subdomain": "karel-webcontrol",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.75,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "karel",
+    "http",
+    "api",
+    "webcontrol",
+    "rest",
+    "motion",
+    "monitoring"
+  ],
+  "quality_score": 75,
+  "problem": "需要通过HTTP接口远程控制FANUC机器人运动、监控状态、管理程序执行，但FANUC原生不提供REST API",
+  "root_cause": "FANUC控制器内置KAREL webserver，但官方文档分散，缺少完整的API参考和使用示例",
+  "solution": "基于KAREL webserver实现HTTP API：webcontrol端点发送6种运动模式(关节/笛卡尔×绝对/相对)、webmonitor返回完整状态JSON(关节/笛卡尔/限位/状态/错误)、weblimit设置18个运动限位、webstart运行TP程序、webabort紧急停止",
+  "verification": "webcontrol/weblimit成功返回204状态码；webmonitor返回完整JSON包含joint/pose/limit/status/message/error/timestamp字段；各KAREL程序(webabort/webcheck/webkeep/webreset等)功能独立可测",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ### 问题描述
 

--- a/lessons/contrib/fanuc-karel-ik-fk-quaternion-guide.md
+++ b/lessons/contrib/fanuc-karel-ik-fk-quaternion-guide.md
@@ -1,4 +1,33 @@
-{"id":"fanuc-karel-ik-fk-quaternion-guide","title":"IK/FK and Quaternion Math Guide for FANUC KAREL Robot Programming","domain":"fanuc","subdomain":"karel-kinematics","source":"github-ka-boost-kl-pose-readme.md","status":"draft","confidence":0.85,"created":"2026-07-12","tags":["fanuc","karel","ik","fk","quaternion","euler","pose","gimbal-lock","coordinate-system"],"quality_score":85,"problem":"FANUC KAREL机器人编程中，IK/FK求解、欧拉角处理、坐标系转换等操作容易出错，尤其是万向锁问题、z_axis参数误用、PR模式不匹配等常见陷阱","root_cause":"KAREL原生运动学函数有限，欧拉角在±90°俯仰角附近存在万向锁，坐标系约定(ZYX/RPY)容易混淆，PR寄存器有joint/Cartesian两种模式需要区分","solution":"pose库提供：solveIK/solveK做IK/FK(需检查get_ok)、vector_to_euler2用四元数避免万向锁、cylindrical_to_cartesian支持Z_AXES/VERT_AXES等z_axis参数、mask_posreg_xyz/orient做选择性PR更新、correctFrame用四元数对齐工具坐标系","verification":"KUnit测试套件覆盖IK/FK往返精度、四元数运算正确性、圆柱坐标转换精度；6种常见模式(路径规划IK、圆柱映射、表面法线对齐、切线转欧拉、选择性PR更新、4x4矩阵组合)均有完整代码示例"}
+{
+  "id": "fanuc-karel-ik-fk-quaternion-guide",
+  "title": "IK/FK and Quaternion Math Guide for FANUC KAREL Robot Programming",
+  "domain": "fanuc",
+  "subdomain": "karel-kinematics",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.85,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "karel",
+    "ik",
+    "fk",
+    "quaternion",
+    "euler",
+    "pose",
+    "gimbal-lock",
+    "coordinate-system"
+  ],
+  "quality_score": 85,
+  "problem": "FANUC KAREL机器人编程中，IK/FK求解、欧拉角处理、坐标系转换等操作容易出错，尤其是万向锁问题、z_axis参数误用、PR模式不匹配等常见陷阱",
+  "root_cause": "KAREL原生运动学函数有限，欧拉角在±90°俯仰角附近存在万向锁，坐标系约定(ZYX/RPY)容易混淆，PR寄存器有joint/Cartesian两种模式需要区分",
+  "solution": "pose库提供：solveIK/solveK做IK/FK(需检查get_ok)、vector_to_euler2用四元数避免万向锁、cylindrical_to_cartesian支持Z_AXES/VERT_AXES等z_axis参数、mask_posreg_xyz/orient做选择性PR更新、correctFrame用四元数对齐工具坐标系",
+  "verification": "KUnit测试套件覆盖IK/FK往返精度、四元数运算正确性、圆柱坐标转换精度；6种常见模式(路径规划IK、圆柱映射、表面法线对齐、切线转欧拉、选择性PR更新、4x4矩阵组合)均有完整代码示例",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ### 问题描述
 

--- a/lessons/contrib/fanuc-karel-intp-316-call-error-motion-lock.md
+++ b/lessons/contrib/fanuc-karel-intp-316-call-error-motion-lock.md
@@ -3,16 +3,27 @@
   "title": "FANUC KAREL: INTP-316 调用TP程序触发动作锁定",
   "domain": "fanuc",
   "subdomain": "karel-programming",
-  "source": "bbs.gongkong.com/d/202503/934119",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.7,
   "created": "2026-07-12",
-  "tags": ["fanuc", "karel", "tp-program", "intp-316", "motion-lock", "call-error"],
+  "tags": [
+    "fanuc",
+    "karel",
+    "tp-program",
+    "intp-316",
+    "motion-lock",
+    "call-error"
+  ],
   "quality_score": 67,
   "problem": "从 KAREL 调用 TP 程序时触发 INTP-316（呼叫错误），同时动作锁定被激活，机器人无法运动。KAREL 程序本身可正常运行，仅调用 TP 程序时出错。",
   "root_cause": "INTP-316 是 KAREL 运行时的 CALL/RUN_TPP 呼叫错误。常见根因：1) 调用语法不正确（缺少单引号或 .TP 扩展名）；2) $KAREL_ENB 未启用；3) 目标 TP 程序缺少 CALL 权限或含冲突运动指令导致组锁定。",
   "solution": "1. 验证调用语法：CALL 'PROGRAM.TP'（单引号 + .TP 扩展名）\n2. 确认 $KAREL_ENB=1 已启用\n3. 检查目标 TP 程序的运动组配置是否与调用方一致\n4. 排查目标 TP 程序是否含冲突运动指令\n5. 确认 TP 程序属性中允许被 KAREL 调用",
-  "verification": "在 KAREL 中执行 CALL 'TEST.TP'，确认无 INTP-316 报错且机器人正常运动。"
+  "verification": "在 KAREL 中执行 CALL 'TEST.TP'，确认无 INTP-316 报错且机器人正常运动。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## FANUC KAREL: INTP-316 调用TP程序触发动作锁定

--- a/lessons/contrib/fanuc-karel-ka-boost-architecture.md
+++ b/lessons/contrib/fanuc-karel-ka-boost-architecture.md
@@ -3,16 +3,29 @@
   "title": "Ka-Boost: 8-Layer KAREL Module Architecture and Build System",
   "domain": "fanuc",
   "subdomain": "karel-architecture",
-  "source": "github.com/kobbled/ka-boost/CLAUDE.md",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.85,
   "created": "2026-07-12",
-  "tags": ["fanuc", "karel", "ka-boost", "architecture", "module-system", "rossum", "build-system", "gpp"],
+  "tags": [
+    "fanuc",
+    "karel",
+    "ka-boost",
+    "architecture",
+    "module-system",
+    "rossum",
+    "build-system",
+    "gpp"
+  ],
   "quality_score": 85,
   "problem": "KAREL 语言缺乏标准库、泛型、关联数组、字符串操作等现代编程基础设施，大型项目（如 5 轴 DLP 3D 打印切片器）难以模块化开发和维护。",
   "root_cause": "KAREL 是类 Pascal 的编译语言，运行在 FANUC 控制器上，语言特性有限。Ka-Boost 通过 GPP 预处理器实现泛型、命名空间、OOP 类等高级特性，并建立 8 层模块依赖体系填补标准库空白。",
   "solution": "采用 Ka-Boost 的分层模块架构：从底层预处理器宏（Layer 0）到高层系统（Layer 7），每层只依赖下层。使用 rossum 包管理器 + ninja 构建系统管理依赖和编译。",
-  "verification": "1. rossum 能解析 package.json 依赖图并生成 build.ninja；2. ninja 编译所有 .kl/.klc 文件生成 .pc 二进制；3. kpush 成功部署到控制器；4. 各层模块单元测试通过（KUnit HTTP 访问）。"
+  "verification": "1. rossum 能解析 package.json 依赖图并生成 build.ninja；2. ninja 编译所有 .kl/.klc 文件生成 .pc 二进制；3. kpush 成功部署到控制器；4. 各层模块单元测试通过（KUnit HTTP 访问）。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## Ka-Boost: 8-Layer KAREL Module Architecture and Build System

--- a/lessons/contrib/fanuc-karel-kl-pose-api-reference.md
+++ b/lessons/contrib/fanuc-karel-kl-pose-api-reference.md
@@ -1,4 +1,32 @@
-{"id":"fanuc-karel-kl-pose-api-reference","title":"KAREL Pose Library API Reference — IK/FK, Quaternion, Matrix Transforms","domain":"fanuc","subdomain":"karel-kinematics","source":"github-ka-boost-kl-pose-CLAUDE.md","status":"draft","confidence":0.85,"created":"2026-07-12","tags":["fanuc","karel","pose","ik","fk","quaternion","matrix","coordinate-transform"],"quality_score":85,"problem":"FANUC KAREL lacks built-in高级运动学函数，如逆运动学、四元数旋转、圆柱坐标转换、4x4矩阵运算等，导致机器人路径规划和坐标变换开发困难","root_cause":"KAREL原生仅提供基础PR读写和简单的位姿操作，缺少IK/FK求解器、万向锁安全的旋转表示、以及多坐标系之间的转换工具","solution":"Ka-Boost pose库提供完整的运动学工具链：solveIK/solveK做IK/FK、quaternion子模块避免万向锁、matpose做4x4矩阵变换、cylindrical_to_cartesian做圆柱坐标转换、correctFrame用四元数对齐工具坐标系到工件表面","verification":"通过KUnit测试套件验证：test_pose.kl覆盖IK/FK往返、字符串构造、mask操作、圆柱转换、外接圆心；test_matpose.kl覆盖矩阵和四元数运算"}
+{
+  "id": "fanuc-karel-kl-pose-api-reference",
+  "title": "KAREL Pose Library API Reference — IK/FK, Quaternion, Matrix Transforms",
+  "domain": "fanuc",
+  "subdomain": "karel-kinematics",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.85,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "karel",
+    "pose",
+    "ik",
+    "fk",
+    "quaternion",
+    "matrix",
+    "coordinate-transform"
+  ],
+  "quality_score": 85,
+  "problem": "FANUC KAREL lacks built-in高级运动学函数，如逆运动学、四元数旋转、圆柱坐标转换、4x4矩阵运算等，导致机器人路径规划和坐标变换开发困难",
+  "root_cause": "KAREL原生仅提供基础PR读写和简单的位姿操作，缺少IK/FK求解器、万向锁安全的旋转表示、以及多坐标系之间的转换工具",
+  "solution": "Ka-Boost pose库提供完整的运动学工具链：solveIK/solveK做IK/FK、quaternion子模块避免万向锁、matpose做4x4矩阵变换、cylindrical_to_cartesian做圆柱坐标转换、correctFrame用四元数对齐工具坐标系到工件表面",
+  "verification": "通过KUnit测试套件验证：test_pose.kl覆盖IK/FK往返、字符串构造、mask操作、圆柱转换、外接圆心；test_matpose.kl覆盖矩阵和四元数运算",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ### 问题描述
 

--- a/lessons/contrib/fanuc-karel-unit-testing-kunit.md
+++ b/lessons/contrib/fanuc-karel-unit-testing-kunit.md
@@ -3,16 +3,27 @@
   "title": "Unit Testing FANUC KAREL Programs with KUnit Framework",
   "domain": "fanuc",
   "subdomain": "karel-testing",
-  "source": "github.com/kylerlippincott/kunit",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.8,
   "created": "2026-07-12",
-  "tags": ["fanuc", "karel", "unit-testing", "kunit", "roboguide", "quality"],
+  "tags": [
+    "fanuc",
+    "karel",
+    "unit-testing",
+    "kunit",
+    "roboguide",
+    "quality"
+  ],
   "quality_score": 80,
   "problem": "FANUC KAREL 程序缺乏单元测试手段，无法在部署前验证逻辑正确性，调试依赖实机运行。",
   "root_cause": "KAREL 是类 Pascal 的编译语言，运行在 FANUC 控制器上，没有原生的测试框架。KUnit 通过 KAREL 程序实现测试运行器，利用控制器的 HTTP 服务提供 Web 浏览器访问的测试结果输出。",
   "solution": "使用 KUnit 框架编写 KAREL 单元测试：编写返回 BOOLEAN 的测试函数，通过 HTTP 端点运行测试并在浏览器查看结果。",
-  "verification": "1. kunit.pc 和 strings.pc 已部署到控制器；2. 测试程序翻译编译成功；3. 浏览器访问 http://robot_ip/KAREL/kunit?filenames=test_name 显示测试结果；4. 所有断言通过，0 failures。"
+  "verification": "1. kunit.pc 和 strings.pc 已部署到控制器；2. 测试程序翻译编译成功；3. 浏览器访问 http://robot_ip/KAREL/kunit?filenames=test_name 显示测试结果；4. 所有断言通过，0 failures。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## Unit Testing FANUC KAREL Programs with KUnit Framework

--- a/lessons/contrib/fanuc-karel-uv-to-xyzwpr-pipeline.md
+++ b/lessons/contrib/fanuc-karel-uv-to-xyzwpr-pipeline.md
@@ -1,4 +1,32 @@
-{"id":"fanuc-karel-uv-to-xyzwpr-pipeline","title":"UV-to-XYZWPR Pipeline — From 2D Slice Geometry to Robot Motion","domain":"fanuc","subdomain":"karel-slicer","source":"github-ka-boost-layer7-high-level-systems.md","status":"draft","confidence":0.8,"created":"2026-07-12","tags":["fanuc","karel","path-planning","slicer","uv-to-xyzwpr","dxf","svg","5-axis"],"quality_score":80,"problem":"5轴DLP 3D打印切片器需要将2D切片几何(SVG/DXF)转换为机器人可执行的XYZWPR运动指令，中间涉及光栅化、路径规划、坐标系转换、多层迭代等复杂流程","root_cause":"切片器管线跨越多个模块(draw→pathplan→pathmake→pathmotion→pathlayer)，每个模块负责不同阶段的转换，缺乏统一的端到端参考文档","solution":"Ka-Boost Layer7实现完整的UV→XYZWPR管线：draw模块做2D光栅化和轮廓提取，pathplan用图算法排序路径段，pathmake做插值和坐标转换，pathmotion发TP运动指令，pathlayer做逐层迭代和硬件控制","verification":"通过实际5轴DLP打印验证管线完整性，Python工具链(DXF/SVG解析、Clipper裁剪、Matplotlib可视化)用于离线验证几何正确性"}
+{
+  "id": "fanuc-karel-uv-to-xyzwpr-pipeline",
+  "title": "UV-to-XYZWPR Pipeline — From 2D Slice Geometry to Robot Motion",
+  "domain": "fanuc",
+  "subdomain": "karel-slicer",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.8,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "karel",
+    "path-planning",
+    "slicer",
+    "uv-to-xyzwpr",
+    "dxf",
+    "svg",
+    "5-axis"
+  ],
+  "quality_score": 80,
+  "problem": "5轴DLP 3D打印切片器需要将2D切片几何(SVG/DXF)转换为机器人可执行的XYZWPR运动指令，中间涉及光栅化、路径规划、坐标系转换、多层迭代等复杂流程",
+  "root_cause": "切片器管线跨越多个模块(draw→pathplan→pathmake→pathmotion→pathlayer)，每个模块负责不同阶段的转换，缺乏统一的端到端参考文档",
+  "solution": "Ka-Boost Layer7实现完整的UV→XYZWPR管线：draw模块做2D光栅化和轮廓提取，pathplan用图算法排序路径段，pathmake做插值和坐标转换，pathmotion发TP运动指令，pathlayer做逐层迭代和硬件控制",
+  "verification": "通过实际5轴DLP打印验证管线完整性，Python工具链(DXF/SVG解析、Clipper裁剪、Matplotlib可视化)用于离线验证几何正确性",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ### 问题描述
 

--- a/lessons/contrib/fanuc-kl-1086-is-line-number-not-error-code.md
+++ b/lessons/contrib/fanuc-kl-1086-is-line-number-not-error-code.md
@@ -3,17 +3,27 @@
   "title": "FANUC KL: 1086 是代码行号而非错误码",
   "domain": "fanuc",
   "subdomain": "debug-methodology",
-  "source": "实操经验",
+  "source": "pr",
   "status": "published",
   "confidence": 0.85,
   "created": "2026-05-03",
   "updated": "2026-07-06",
-  "tags": ["fanuc", "karel", "ktrans", "debugging", "error-analysis"],
+  "tags": [
+    "fanuc",
+    "karel",
+    "ktrans",
+    "debugging",
+    "error-analysis"
+  ],
   "quality_score": 78,
   "problem": "分析 FANUC 1086 报错时，误将 1086 当作某种错误码，一路追错方向。",
   "root_cause": "1086 是 MM_MODULE.kl 的代码行号（line number），不是错误码。KTRANS 输出报错时同时标注行号，但之前分析路径将其误认为错误编号。",
   "solution": "1. 报错信息中的数字需区分：行号 vs 错误码\n2. ERR_ABORT=2 是真正导致'所有任务中止'的根因（而非 1086）\n3. IPC 通信超时导致 ERR_ABORT 触发 → 根因是 Mech-Vision 12:00 文件夹切换竞争",
-  "verification": "复现 IPC 超时场景，确认 1086 出现在 KTRANS 编译输出中（而非运行时日志）。"
+  "verification": "复现 IPC 超时场景，确认 1086 出现在 KTRANS 编译输出中（而非运行时日志）。",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-06T15:54:24+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 362
 }
 
 ## FANUC KL: 1086 是代码行号而非错误码

--- a/lessons/contrib/fanuc-kl-bytes-ahead-is-builtin-procedure.md
+++ b/lessons/contrib/fanuc-kl-bytes-ahead-is-builtin-procedure.md
@@ -1,19 +1,31 @@
 ---
-id: fanuc-kl-bytes-ahead-is-builtin-procedure
-title: "FANUC KL: BYTES_AHEAD 是 Karel 内置 Procedure"
-domain: fanuc
-subdomain: kl-syntax
-source: 实操经验
-status: published
-confidence: 0.9
-created: 2026-05-03
-updated: 2026-07-06
-tags: ["fanuc", "karel", "ktrans", "reserved-words", "built-in"]
-quality_score: 80
-problem: KL 编译报错时，误认为 BYTES_AHEAD 是禁用标识符或非法调用，将其从 MM_RCV_NTFY.kl 中删除。
-root_cause: BYTES_AHEAD 是 Karel 语言的内置系统调用（Built-in Procedure），用法完全正确。KL 语言保留字（禁用标识符）有特定列表，BYTES_AHEAD 不在其中。
-solution: 恢复 MM_RCV_NTFY.kl 中所有 BYTES_AHEAD 调用，不应删除。禁用标识符列表：SECONDS、ENDDO、ELSEIF 等（详见 fanuc-kl-compile SKILL.md）。
-verification: KTRANS 编译 MM_RCV_NTFY.kl，无 BYTES_AHEAD 相关报错。
+{
+  "id": "fanuc-kl-bytes-ahead-is-builtin-procedure",
+  "title": "FANUC KL: BYTES_AHEAD 是 Karel 内置 Procedure",
+  "domain": "fanuc",
+  "subdomain": "kl-syntax",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.9,
+  "created": "2026-05-03",
+  "updated": "2026-07-06",
+  "tags": [
+    "fanuc",
+    "karel",
+    "ktrans",
+    "reserved-words",
+    "built-in"
+  ],
+  "quality_score": 80,
+  "problem": "KL 编译报错时，误认为 BYTES_AHEAD 是禁用标识符或非法调用，将其从 MM_RCV_NTFY.kl 中删除。",
+  "root_cause": "BYTES_AHEAD 是 Karel 语言的内置系统调用（Built-in Procedure），用法完全正确。KL 语言保留字（禁用标识符）有特定列表，BYTES_AHEAD 不在其中。",
+  "solution": "恢复 MM_RCV_NTFY.kl 中所有 BYTES_AHEAD 调用，不应删除。禁用标识符列表：SECONDS、ENDDO、ELSEIF 等（详见 fanuc-kl-compile SKILL.md）。",
+  "verification": "KTRANS 编译 MM_RCV_NTFY.kl，无 BYTES_AHEAD 相关报错。",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ## FANUC KL: BYTES_AHEAD 是 Karel 内置 Procedure

--- a/lessons/contrib/fanuc-kl-err-abort-vs-err-pause.md
+++ b/lessons/contrib/fanuc-kl-err-abort-vs-err-pause.md
@@ -1,4 +1,18 @@
-{"title": "FANUC KL: ERR_ABORT vs ERR_PAUSE 行为差异", "domain": "fanuc", "subdomain": "error-handling", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-05-03", "domain_expert": "bootstrap", "verified_date": "2026-05-03"}
+{
+  "title": "FANUC KL: ERR_ABORT vs ERR_PAUSE 行为差异",
+  "domain": "fanuc",
+  "subdomain": "error-handling",
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.7",
+  "created": "2026-05-03",
+  "domain_expert": "bootstrap",
+  "verified_date": "2026-05-03",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-02T16:15:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 277
+}
 
 
 ## FANUC KL: ERR_ABORT vs ERR_PAUSE 行为差异

--- a/lessons/contrib/fanuc-kl-mm-module-h-no-routine.md
+++ b/lessons/contrib/fanuc-kl-mm-module-h-no-routine.md
@@ -1,13 +1,19 @@
 ---
-title: "FANUC KL: mm_module_h.kl 禁止 ROUTINE 声明"
-domain: fanuc
-subdomain: kl-modules
-source: bootstrap
-status: published
-confidence: 0.7
-created: 2026-05-03
-domain_expert: bootstrap
-verified_date: 2026-05-03
+{
+  "title": "FANUC KL: mm_module_h.kl 禁止 ROUTINE 声明",
+  "domain": "fanuc",
+  "subdomain": "kl-modules",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.7,
+  "created": "2026-05-03",
+  "domain_expert": "bootstrap",
+  "verified_date": "2026-05-03",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/fanuc-mi-standard-software-instructions.md
+++ b/lessons/contrib/fanuc-mi-standard-software-instructions.md
@@ -1,12 +1,30 @@
 ---
-title: "FANUC MI Standard Software — Complete Instruction Reference (MI01-MI22)"
-domain: "fanuc"
-subdomain: "tp-programming"
-tags: ["mi-standard", "mi01-cmn", "mi02-tch", "mi04-ssw", "mi08-dsp", "mi11-apl", "mi14-spr", "mi22-fds", "automotive", "welding", "gluing", "riveting"]
-status: "published"
-source: "internal-training"
-confidence: "0.9"
-created: "2026-07-14"
+{
+  "title": "FANUC MI Standard Software — Complete Instruction Reference (MI01-MI22)",
+  "domain": "fanuc",
+  "subdomain": "tp-programming",
+  "tags": [
+    "mi-standard",
+    "mi01-cmn",
+    "mi02-tch",
+    "mi04-ssw",
+    "mi08-dsp",
+    "mi11-apl",
+    "mi14-spr",
+    "mi22-fds",
+    "automotive",
+    "welding",
+    "gluing",
+    "riveting"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.9",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-payload-estimation.md
+++ b/lessons/contrib/fanuc-payload-estimation.md
@@ -1,12 +1,26 @@
 ---
-title: "FANUC Payload Estimation — Auto and Manual Load Configuration"
-domain: "fanuc"
-subdomain: "configuration"
-tags: ["payload", "load", "estimation", "tcp", "tool", "mass", "inertia", "center-of-gravity"]
-status: "published"
-source: "internal-training"
-confidence: "0.9"
-created: "2026-07-14"
+{
+  "title": "FANUC Payload Estimation — Auto and Manual Load Configuration",
+  "domain": "fanuc",
+  "subdomain": "configuration",
+  "tags": [
+    "payload",
+    "load",
+    "estimation",
+    "tcp",
+    "tool",
+    "mass",
+    "inertia",
+    "center-of-gravity"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.9",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-profinet-32bit-real-value-transfer.md
+++ b/lessons/contrib/fanuc-profinet-32bit-real-value-transfer.md
@@ -1,14 +1,27 @@
 ---
-title: FANUC Profinet 32-bit Real Value Transfer Without KAREL
-domain: fanuc
-subdomain: profinet
-tags: ["profinet", "real-value", "32-bit", "gi-go", "plc-communication", "scara"]
-source: robot-forum.com
-status: published
-confidence: 0.85
-created: 2026-07-01
-verified_date: 
-domain_expert: 
+{
+  "title": "FANUC Profinet 32-bit Real Value Transfer Without KAREL",
+  "domain": "fanuc",
+  "subdomain": "profinet",
+  "tags": [
+    "profinet",
+    "real-value",
+    "32-bit",
+    "gi-go",
+    "plc-communication",
+    "scara"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/fanuc-profinet-io-software-config.md
+++ b/lessons/contrib/fanuc-profinet-io-software-config.md
@@ -3,16 +3,28 @@
   "title": "FANUC Robot PROFINET IO Configuration with PFN-CT Software",
   "domain": "fanuc",
   "subdomain": "profinet-io",
-  "source": "bbs.gongkong.com/d/202311/912784",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.6,
   "created": "2026-07-12",
-  "tags": ["fanuc", "profinet", "io", "pfn-ct", "plc", "fieldbus", "configuration"],
+  "tags": [
+    "fanuc",
+    "profinet",
+    "io",
+    "pfn-ct",
+    "plc",
+    "fieldbus",
+    "configuration"
+  ],
   "quality_score": 60,
   "problem": "FANUC 机器人需要与 PROFINET IO 主站（如西门子 PLC）通信，需要专用配置软件来设置 PROFINET IO 从站参数。",
   "root_cause": "FANUC 机器人作为 PROFINET IO 从站时，需要使用专用的 PFN-CT（PROFINET Configuration Tool）软件在 PC 端配置 GSD 文件、IO 模块映射等参数，然后下载到控制器。该软件不随控制器出厂提供，需要单独获取。",
   "solution": "使用 PFN-CT V1.0.14 软件配置 FANUC 机器人的 PROFINET IO 通信参数。该软件为 PC 端工具，用于配置从站设备参数并生成配置文件。",
-  "verification": "1. PFN-CT 软件安装并能正常启动；2. 能加载 FANUC 机器人的 GSD 文件；3. IO 模块配置完成并下载到控制器；4. PLC 端能识别 FANUC PROFINET IO 从站并建立通信。"
+  "verification": "1. PFN-CT 软件安装并能正常启动；2. 能加载 FANUC 机器人的 GSD 文件；3. IO 模块配置完成并下载到控制器；4. PLC 端能识别 FANUC PROFINET IO 从站并建立通信。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## FANUC Robot PROFINET IO Configuration with PFN-CT Software

--- a/lessons/contrib/fanuc-profinet-s7-1200-external-startup.md
+++ b/lessons/contrib/fanuc-profinet-s7-1200-external-startup.md
@@ -1,4 +1,32 @@
-{"id": "fanuc-profinet-s7-1200-external-startup", "title": "FANUC PROFINET Communication with Siemens S7-1200 and External Startup", "domain": "fanuc", "subdomain": "plc-communication", "source": "bbs.gongkong.com/d/202011/845226", "status": "draft", "confidence": 0.7, "created": "2026-07-12", "tags": ["fanuc", "profinet", "siemens", "s7-1200", "external-startup", "rsr", "pns", "plc-communication"], "quality_score": 60, "problem": "需要将 FANUC 机器人与 Siemens S7-1200 PLC 通过 PROFINET 协议建立通讯，并配置外部启动功能，使 PLC 能远程触发机器人程序执行。", "root_cause": "PROFINET 通讯配置涉及多个环节：S7-1200 作为 PROFINET Controller、FANUC 机器人装有 PROFINET 适配卡作为 Device、外部启动(RSR/PNS)模式需正确配置信号映射。任一环节配置错误都会导致通讯失败或无法远程启动。", "solution": "1. 硬件准备：FANUC 机器人需安装 PROFINET 适配卡（如 PCI 卡）\n2. S7-1200 侧：在 TIA Portal 中添加 FANUC GSD 文件，配置 PROFINET Device\n3. FANUC 侧：设置 PROFINET 通讯参数（IP 地址、设备名）\n4. 信号映射：配置 DI/DO 信号与 PLC 的对应关系\n5. 外部启动配置：设置 RSR（Robot Start Request）或 PNS（Program Number Select）启动模式\n6. RSR 模式：PLC 通过 DI 信号选择程序编号并触发启动\n7. PNS 模式：PLC 通过信号组选择程序号，FANUC 自动执行对应程序", "verification": "1. 在 TIA Portal 中确认 PROFINET 网络拓扑显示 FANUC Device 为绿色（在线）\n2. 手动触发 DI 信号，确认 FANUC 侧对应信号响应正确\n3. 通过 PLC 发送 RSR/PNS 启动信号，确认机器人自动执行目标程序\n4. 监控通讯状态无断线或超时报警"}
+{
+  "id": "fanuc-profinet-s7-1200-external-startup",
+  "title": "FANUC PROFINET Communication with Siemens S7-1200 and External Startup",
+  "domain": "fanuc",
+  "subdomain": "plc-communication",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.7,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "profinet",
+    "siemens",
+    "s7-1200",
+    "external-startup",
+    "rsr",
+    "pns",
+    "plc-communication"
+  ],
+  "quality_score": 60,
+  "problem": "需要将 FANUC 机器人与 Siemens S7-1200 PLC 通过 PROFINET 协议建立通讯，并配置外部启动功能，使 PLC 能远程触发机器人程序执行。",
+  "root_cause": "PROFINET 通讯配置涉及多个环节：S7-1200 作为 PROFINET Controller、FANUC 机器人装有 PROFINET 适配卡作为 Device、外部启动(RSR/PNS)模式需正确配置信号映射。任一环节配置错误都会导致通讯失败或无法远程启动。",
+  "solution": "1. 硬件准备：FANUC 机器人需安装 PROFINET 适配卡（如 PCI 卡）\n2. S7-1200 侧：在 TIA Portal 中添加 FANUC GSD 文件，配置 PROFINET Device\n3. FANUC 侧：设置 PROFINET 通讯参数（IP 地址、设备名）\n4. 信号映射：配置 DI/DO 信号与 PLC 的对应关系\n5. 外部启动配置：设置 RSR（Robot Start Request）或 PNS（Program Number Select）启动模式\n6. RSR 模式：PLC 通过 DI 信号选择程序编号并触发启动\n7. PNS 模式：PLC 通过信号组选择程序号，FANUC 自动执行对应程序",
+  "verification": "1. 在 TIA Portal 中确认 PROFINET 网络拓扑显示 FANUC Device 为绿色（在线）\n2. 手动触发 DI 信号，确认 FANUC 侧对应信号响应正确\n3. 通过 PLC 发送 RSR/PNS 启动信号，确认机器人自动执行目标程序\n4. 监控通讯状态无断线或超时报警",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ## FANUC PROFINET 通讯与 S7-1200 外部启动配置
 

--- a/lessons/contrib/fanuc-program-inspection-methodology.md
+++ b/lessons/contrib/fanuc-program-inspection-methodology.md
@@ -1,12 +1,25 @@
 ---
-title: "FANUC Robot Program Inspection Methodology — Systematic Check Guide"
-domain: "fanuc"
-subdomain: "quality"
-tags: ["inspection", "checklist", "program-review", "signal-check", "collision-zone", "fine-point", "quality"]
-status: "published"
-source: "internal-training"
-confidence: "0.9"
-created: "2026-07-14"
+{
+  "title": "FANUC Robot Program Inspection Methodology — Systematic Check Guide",
+  "domain": "fanuc",
+  "subdomain": "quality",
+  "tags": [
+    "inspection",
+    "checklist",
+    "program-review",
+    "signal-check",
+    "collision-zone",
+    "fine-point",
+    "quality"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.9",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-python-interface-fanucpy.md
+++ b/lessons/contrib/fanuc-python-interface-fanucpy.md
@@ -3,16 +3,27 @@
   "title": "FANUC Robot Python Control via fanucpy Library",
   "domain": "fanuc",
   "subdomain": "python-interface",
-  "source": "github.com/torayeff/fanucpy",
+  "source": "pr",
   "status": "draft",
   "confidence": 0.8,
   "created": "2026-07-12",
-  "tags": ["fanuc", "python", "fanucpy", "socket-messaging", "robot-control", "uop-sop"],
+  "tags": [
+    "fanuc",
+    "python",
+    "fanucpy",
+    "socket-messaging",
+    "robot-control",
+    "uop-sop"
+  ],
   "quality_score": 80,
   "problem": "需要从 Python 端控制 FANUC 机器人运动、查询状态、操作夹爪和数字 IO，但 FANUC 控制器原生不支持 Python 接口。",
   "root_cause": "FANUC 控器运行 KAREL/TP 语言，不直接支持 Python。需要一个中间层：Python 客户端通过 TCP/IP Socket Messaging（R648 选项）与控制器上的 KAREL 服务端程序通信，实现远程控制。",
   "solution": "使用 fanucpy 开源库（pip install fanucpy），配合控制器端的 MAPPDK 驱动（KAREL+TP 程序），通过 socket 协议实现 Python→FANUC 的全功能控制。",
-  "verification": "1. pip install fanucpy 成功；2. 控制器端 MAPPDK 服务运行且端口 18735 可达；3. robot.connect() 返回成功；4. robot.get_curpos() 能返回当前位姿。"
+  "verification": "1. pip install fanucpy 成功；2. 控制器端 MAPPDK 服务运行且端口 18735 可达；3. robot.connect() 返回成功；4. robot.get_curpos() 能返回当前位姿。",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
 }
 
 ## FANUC Robot Python Control via fanucpy Library

--- a/lessons/contrib/fanuc-r-2000ic-retrieval-fix.md
+++ b/lessons/contrib/fanuc-r-2000ic-retrieval-fix.md
@@ -1,11 +1,17 @@
 ---
-created: "2026-04-30 08:50 UTC"
-domain: rag
-source: hermes_wsl
-status: published
-tags: 
-title: FANUC R-2000iC 检索混淆Fix — 关键词强制召回
-updated: "2026-04-30 08:50 UTC"
+{
+  "created": "2026-04-30 08:50 UTC",
+  "domain": "rag",
+  "source": "pr",
+  "status": "published",
+  "tags": "",
+  "title": "FANUC R-2000iC 检索混淆Fix — 关键词强制召回",
+  "updated": "2026-04-30 08:50 UTC",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ---{"created": "2026-04-30 08:50 UTC", "domain": "rag", "source": "hermes_wsl", "status": "published", "tags": "", "title": "FANUC R-2000iC 检索混淆Fix — 关键词强制召回", "updated": "2026-04-30 08:50 UTC"}---

--- a/lessons/contrib/fanuc-rsr-program-select-logic.md
+++ b/lessons/contrib/fanuc-rsr-program-select-logic.md
@@ -1,4 +1,32 @@
-{"id": "fanuc-rsr-program-select-logic", "title": "FANUC RSR Program with OFFSET and SELECT Logic Sharing", "domain": "fanuc", "subdomain": "tp-programming", "source": "bbs.gongkong.com/d/201302/481940", "status": "draft", "confidence": 0.7, "created": "2026-07-12", "tags": ["fanuc", "rsr", "tp-programming", "select", "offset", "register", "program-logic", "r-2000ib"], "quality_score": 70, "problem": "需要编写一个 FANUC 机器人 RSR 程序，实现多位置循环搬运，并通过寄存器索引和 SELECT 分支逻辑实现位置偏移选择，同时配合 PLC 信号实现自动化流程控制。", "root_cause": "FANUC TP 编程语言中，RSR 程序需要综合运用运动指令（J/L）、寄存器操作（R/PR）、I/O 信号（DO/DI/RO）、OFFSET 偏移功能和 SELECT 分支结构来实现复杂的搬运逻辑。缺乏对这些编程要素组合使用的理解是主要障碍。", "solution": "1. 使用 RSR 编号命名程序（如 RSR0112）\n2. 运动段使用 J（关节移动）和 L（直线移动）指令\n3. 用 R[n] 寄存器作为索引，通过 SELECT/LBL 实现多分支\n4. 用 PR[n] 位置寄存器存储偏移量，配合 OFFSET 实现可变定位\n5. 用 DO/DI 信号与 PLC 交互（如通知完成、等待许可）\n6. 循环逻辑：寄存器递增遍历位置，达到上限时通知 PLC", "verification": "1. 程序能通过 RSR 正常启动执行\n2. 运动轨迹符合预期，位置精度满足要求\n3. OFFSET 偏移量正确应用，不同分支到达不同位置\n4. DO/DI 信号时序与 PLC 配合正确\n5. 循环逻辑完整，达到上限后正确触发 PLC 信号"}
+{
+  "id": "fanuc-rsr-program-select-logic",
+  "title": "FANUC RSR Program with OFFSET and SELECT Logic Sharing",
+  "domain": "fanuc",
+  "subdomain": "tp-programming",
+  "source": "pr",
+  "status": "draft",
+  "confidence": 0.7,
+  "created": "2026-07-12",
+  "tags": [
+    "fanuc",
+    "rsr",
+    "tp-programming",
+    "select",
+    "offset",
+    "register",
+    "program-logic",
+    "r-2000ib"
+  ],
+  "quality_score": 70,
+  "problem": "需要编写一个 FANUC 机器人 RSR 程序，实现多位置循环搬运，并通过寄存器索引和 SELECT 分支逻辑实现位置偏移选择，同时配合 PLC 信号实现自动化流程控制。",
+  "root_cause": "FANUC TP 编程语言中，RSR 程序需要综合运用运动指令（J/L）、寄存器操作（R/PR）、I/O 信号（DO/DI/RO）、OFFSET 偏移功能和 SELECT 分支结构来实现复杂的搬运逻辑。缺乏对这些编程要素组合使用的理解是主要障碍。",
+  "solution": "1. 使用 RSR 编号命名程序（如 RSR0112）\n2. 运动段使用 J（关节移动）和 L（直线移动）指令\n3. 用 R[n] 寄存器作为索引，通过 SELECT/LBL 实现多分支\n4. 用 PR[n] 位置寄存器存储偏移量，配合 OFFSET 实现可变定位\n5. 用 DO/DI 信号与 PLC 交互（如通知完成、等待许可）\n6. 循环逻辑：寄存器递增遍历位置，达到上限时通知 PLC",
+  "verification": "1. 程序能通过 RSR 正常启动执行\n2. 运动轨迹符合预期，位置精度满足要求\n3. OFFSET 偏移量正确应用，不同分支到达不同位置\n4. DO/DI 信号时序与 PLC 配合正确\n5. 循环逻辑完整，达到上限后正确触发 PLC 信号",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-15T10:25:40+08:00",
+  "merged_by": "Ikalus1988",
+  "pr": 472
+}
 
 ## FANUC RSR 程序的 OFFSET 与 SELECT 逻辑
 

--- a/lessons/contrib/fanuc-spot-wear-max-lookup.md
+++ b/lessons/contrib/fanuc-spot-wear-max-lookup.md
@@ -1,20 +1,33 @@
 ---
-title: "FANUC Spot Weld Tip Max Wear Amount — sysspot.sv Variable Lookup via kconvars"
-domain: "fanuc"
-subdomain: "spot-weld"
-tags: ["spot-weld", "electrode-wear", "sysspot", "kconvars", "spoteqsetup", "epaf-trgdst", "tip-dress"]
-source: "colleague_memory_dump"
-status: "published"
-confidence: "0.85"
-created: "2026-07-16"
-verified_date: "2026-07-16"
-domain_expert: ""
-evidence:
-  level: "pre_ingest_reused"
-  source_type: "colleague_memory_dump"
-  verified_by: "maintainer"
-  context: "Distilled from field debugging session. kconvars sysspot.sv parsing path verified as practically useful."
-  public_quote_allowed: false
+{
+  "title": "FANUC Spot Weld Tip Max Wear Amount — sysspot.sv Variable Lookup via kconvars",
+  "domain": "fanuc",
+  "subdomain": "spot-weld",
+  "tags": [
+    "spot-weld",
+    "electrode-wear",
+    "sysspot",
+    "kconvars",
+    "spoteqsetup",
+    "epaf-trgdst",
+    "tip-dress"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-16",
+  "verified_date": "2026-07-16",
+  "domain_expert": "",
+  "evidence": "",
+  "level": "pre_ingest_reused",
+  "source_type": "colleague_memory_dump",
+  "verified_by": "maintainer",
+  "context": "Distilled from field debugging session. kconvars sysspot.sv parsing path verified as practically useful.",
+  "public_quote_allowed": false,
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-17T11:21:04+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fanuc-tcp-tool-configuration-standards.md
+++ b/lessons/contrib/fanuc-tcp-tool-configuration-standards.md
@@ -1,12 +1,28 @@
 ---
-title: "FANUC TCP and Tool Configuration — Standards for Automotive Applications"
-domain: "fanuc"
-subdomain: "configuration"
-tags: ["tcp", "tool", "utool", "uframe", "payload", "coordinate", "automotive", "welding", "gluing", "riveting"]
-status: "published"
-source: "internal-training"
-confidence: "0.9"
-created: "2026-07-14"
+{
+  "title": "FANUC TCP and Tool Configuration — Standards for Automotive Applications",
+  "domain": "fanuc",
+  "subdomain": "configuration",
+  "tags": [
+    "tcp",
+    "tool",
+    "utool",
+    "uframe",
+    "payload",
+    "coordinate",
+    "automotive",
+    "welding",
+    "gluing",
+    "riveting"
+  ],
+  "status": "published",
+  "source": "manual",
+  "confidence": "0.9",
+  "created": "2026-07-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-15T10:16:28+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/fehler-python-modul-nicht-gefunden.md
+++ b/lessons/contrib/fehler-python-modul-nicht-gefunden.md
@@ -1,13 +1,18 @@
 ---
-title: "ModuleNotFoundError in Python trotz pip install"
-domain: "python"
-tags: [python, pip, module, path, virtualenv]
-language: de
-status: published
-source: "https://docs.python.org/3/tutorial/venv.html"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "ModuleNotFoundError in Python trotz pip install",
+  "domain": "python",
+  "tags": "[python, pip, module, path, virtualenv]",
+  "language": "de",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:28:33-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/feishu-agent-display-settings.md
+++ b/lessons/contrib/feishu-agent-display-settings.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu agent display settings",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu agent display settings\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "飞书 Agent 显示Optimization：禁用工具调用和上下文提示", "domain": "feishu", "source": "bootstrap", "status": "published", "confidence": "0.9", "created": "2026-05-19"}---

--- a/lessons/contrib/feishu-block-api-false-success.md
+++ b/lessons/contrib/feishu-block-api-false-success.md
@@ -2,14 +2,25 @@
   "title": "Feishu Block API returns code=0 but creates zero blocks under rate limiting",
   "domain": "feishu",
   "subdomain": "block-api",
-  "tags": ["feishu", "block-api", "rate-limit", "false-success", "batch-write", "retry"],
+  "tags": [
+    "feishu",
+    "block-api",
+    "rate-limit",
+    "false-success",
+    "batch-write",
+    "retry"
+  ],
   "status": "published",
   "confidence": "0.9",
   "created": "2026-07-06",
   "updated": "2026-07-06",
-  "source": "zsxh1990",
+  "source": "pr",
   "verified_date": "2026-07-06",
-  "domain_expert": "zsxh1990"
+  "domain_expert": "zsxh1990",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-06T15:55:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 359
 }
 
 # Feishu Block API returns code=0 but creates zero blocks under rate limiting

--- a/lessons/contrib/feishu-block-batch-limit.md
+++ b/lessons/contrib/feishu-block-batch-limit.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu block batch limit",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu block batch limit\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "飞书 Block Batch写入上限", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "draft", "confidence": "0.7", "created": "2026-05-03"}---

--- a/lessons/contrib/feishu-block-type-values-limits.md
+++ b/lessons/contrib/feishu-block-type-values-limits.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu block type values limits",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu block type values limits\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "飞书 Block Type 正确值与已知Limit", "domain": "feishu", "subdomain": "block-api", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-05-03"}---

--- a/lessons/contrib/feishu-bot-setup-complete.md
+++ b/lessons/contrib/feishu-bot-setup-complete.md
@@ -1,15 +1,20 @@
 ---
 {
-  "title": "Near-duplicate Feishu bot lessons: keep cc-connect, archive generic stub",
-  "domain": "feishu",
-  "tags": ["feishu", "cc-connect", "duplicate", "lesson-quality", "archive", "cleanup"],
-  "status": "published",
-  "source": "uncledad96-glitch",
-  "created": "2026-07-21",
-  "updated": "2026-07-21",
-  "confidence": "0.9",
-  "supersedes": "lessons/_archive/feishu-bot-setup-complete.md",
-  "see_also": "lessons/contrib/cc-connect-feishu-setup-complete.md"
+  "\"title\"": "Near-duplicate Feishu bot lessons: keep cc-connect, archive generic stub\",",
+  "\"domain\"": "feishu\",",
+  "\"tags\"": "[\"feishu\", \"cc-connect\", \"duplicate\", \"lesson-quality\", \"archive\", \"cleanup\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "uncledad96-glitch\",",
+  "\"created\"": "2026-07-21\",",
+  "\"updated\"": "2026-07-21\",",
+  "\"confidence\"": "0.9\",",
+  "\"supersedes\"": "lessons/_archive/feishu-bot-setup-complete.md\",",
+  "\"see_also\"": "lessons/contrib/cc-connect-feishu-setup-complete.md",
+  "author": "uncledad96-glitch",
+  "source": "pr",
+  "edited_at": "2026-07-21T12:26:29+02:00",
+  "merged_by": "uncledad96-glitch",
+  "pr": 552
 }
 ---
 

--- a/lessons/contrib/feishu-doc-delete-blocks-by-range-pitfall.md
+++ b/lessons/contrib/feishu-doc-delete-blocks-by-range-pitfall.md
@@ -1,19 +1,20 @@
 ---
-title: "飞书 doc_delete_blocks_by_range 不传 end 会删到文档末尾"
-domain: "feishu"
-subdomain: "mcp-api"
-tags:
-  - feishu
-  - mcp
-  - data-loss
-  - api-pitfall
-  - docx
-source: "zsxh1990"
-status: "published"
-confidence: "1.0"
-created: "2026-06-25"
-domain_expert: "zsxh1990"
-verified_date: "2026-07-06"
+{
+  "title": "飞书 doc_delete_blocks_by_range 不传 end 会删到文档末尾",
+  "domain": "feishu",
+  "subdomain": "mcp-api",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": "1.0",
+  "created": "2026-06-25",
+  "domain_expert": "zsxh1990",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-07T11:58:11+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 375
+}
 ---
 
 ## Problem

--- a/lessons/contrib/feishu-doc-url-use-api-return.md
+++ b/lessons/contrib/feishu-doc-url-use-api-return.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu doc url use api return",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Feishu 文档 URL：必须用 API 返回值，不要拼接\", \"domain\": \"feishu\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-03-29\", \"confidence\": \"0.95\", \"scope\": \"broad\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-03-29\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu doc url use api return\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Feishu 文档 URL：必须用 API 返回值，不要拼接\\\", \\\"domain\\\": \\\"feishu\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-03-29\\\", \\\"confidence\\\": \\\"0.95\\\", \\\"scope\\\": \\\"broad\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-03-29\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/feishu-markdown-table-not-rendered.md
+++ b/lessons/contrib/feishu-markdown-table-not-rendered.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu markdown table not rendered",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu markdown table not rendered\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "飞书 post Messaging中 Markdown 表格不渲染", "domain": "development", "source": "Misaka10019", "tags": ["feishu", "markdown", "table", "post", "lark"]}---

--- a/lessons/contrib/feishu-mcp-server-deepseek-tui-setup.md
+++ b/lessons/contrib/feishu-mcp-server-deepseek-tui-setup.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries",
-  "verification": "metadata-normalized",
-  "{\"title\"": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries\", \"domain\": \"feishu\", \"source\": \"deepseek-tui\", \"status\": \"published\", \"tags\": [\"feishu\", \"mcp\", \"deepseek\", \"docx-api\", \"permissions\"], \"created\": \"2026-05-19\", \"updated\": \"2026-05-19\", \"domain_expert\": \"deepseek-tui\", \"verified_date\": \"2026-05-19\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "DeepSeek TUI — Feishu MCP Server Setup & Permission Boundaries\\\", \\\"domain\\\": \\\"feishu\\\", \\\"source\\\": \\\"deepseek-tui\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"feishu\\\", \\\"mcp\\\", \\\"deepseek\\\", \\\"docx-api\\\", \\\"permissions\\\"], \\\"created\\\": \\\"2026-05-19\\\", \\\"updated\\\": \\\"2026-05-19\\\", \\\"domain_expert\\\": \\\"deepseek-tui\\\", \\\"verified_date\\\": \\\"2026-05-19\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/feishu-upload-file-type-opus.md
+++ b/lessons/contrib/feishu-upload-file-type-opus.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu upload file type opus",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Feishu 文件上传：file_type 必须用 opus\", \"domain\": \"feishu\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-03-29\", \"confidence\": \"0.95\", \"scope\": \"broad\", \"alternative_of\": \"None\", \"related\": \"\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-03-29\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu upload file type opus\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Feishu 文件上传：file_type 必须用 opus\\\", \\\"domain\\\": \\\"feishu\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-03-29\\\", \\\"confidence\\\": \\\"0.95\\\", \\\"scope\\\": \\\"broad\\\", \\\"alternative_of\\\": \\\"None\\\", \\\"related\\\": \\\"\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-03-29\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/feishu-webhook-url-env-config.md
+++ b/lessons/contrib/feishu-webhook-url-env-config.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu webhook url env config",
-  "verification": "metadata-normalized",
-  "{\"title\"": "飞书 webhook URL 必须用环境变量或 gitignored 的 config.yaml\", \"domain\": \"devops\", \"subdomain\": \"feishu\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:agent-medici\", \"severity:critical\", \"node:hermes_wsl\"], \"confidence\": \"0.8\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu webhook url env config\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "飞书 webhook URL 必须用环境变量或 gitignored 的 config.yaml\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"feishu\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:agent-medici\\\", \\\"severity:critical\\\", \\\"node:hermes_wsl\\\"], \\\"confidence\\\": \\\"0.8\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
+++ b/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu websocket 404 error http webhook required",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Feishu WebSocket 404 Error - HTTP Webhook Required\", \"domain\": \"feishu-integration\", \"source\": \"hermes_wsl2\", \"status\": \"published\", \"tags\": [], \"created\": \"2026-05-19 01:19:29 UTC\", \"updated\": \"2026-05-19 01:19:29 UTC\", \"domain_expert\": \"hermes_wsl2\", \"verified_date\": \"2026-05-19\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "feishu websocket 404 error http webhook required\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Feishu WebSocket 404 Error - HTTP Webhook Required\\\", \\\"domain\\\": \\\"feishu-integration\\\", \\\"source\\\": \\\"hermes_wsl2\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [], \\\"created\\\": \\\"2026-05-19 01:19:29 UTC\\\", \\\"updated\\\": \\\"2026-05-19 01:19:29 UTC\\\", \\\"domain_expert\\\": \\\"hermes_wsl2\\\", \\\"verified_date\\\": \\\"2026-05-19\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/feishu-wiki-batch-download.md
+++ b/lessons/contrib/feishu-wiki-batch-download.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Feishu WikiBatch Download：文件类型Handling策略",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Feishu WikiBatch Download：文件类型Handling策略\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Feishu WikiBatch Download：文件类型Handling策略", "domain": "devops", "tags": "feishu, wiki, batch-download, file-type, pdf, docx, safari", "status": "published", "source": "hermes_wsl2", "updated": "2026-05-19 15:40:11 UTC"}---

--- a/lessons/contrib/ffmpeg-audio-libopus-not-ogg.md
+++ b/lessons/contrib/ffmpeg-audio-libopus-not-ogg.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "ffmpeg audio libopus not ogg",
-  "verification": "metadata-normalized",
-  "{\"title\"": "FFmpeg 音频转码：必须用 libopus 而非 -format ogg\", \"domain\": \"audio\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-03-29\", \"confidence\": \"0.9\", \"scope\": \"broad\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-03-29\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "ffmpeg audio libopus not ogg\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "FFmpeg 音频转码：必须用 libopus 而非 -format ogg\\\", \\\"domain\\\": \\\"audio\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-03-29\\\", \\\"confidence\\\": \\\"0.9\\\", \\\"scope\\\": \\\"broad\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-03-29\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/finding-and-fixing-ghostty-s-largest-memory-leak.md
+++ b/lessons/contrib/finding-and-fixing-ghostty-s-largest-memory-leak.md
@@ -1,5 +1,11 @@
 ---
-{"title": "Finding and fixing Ghostty's largest memory leak", "domain": "memory_management", "tags": ["memory_leak", "memory_management", "terminal", "optimization", "debugging"], "language": "en", "status": "published", "source": "https://mitchellh.com/writing/ghostty-memory-leak-fix", "created": "2026-07-28", "confidence": "0.85"}
+{
+  "{\"title\"": "Finding and fixing Ghostty's largest memory leak\", \"domain\": \"memory_management\", \"tags\": [\"memory_leak\", \"memory_management\", \"terminal\", \"optimization\", \"debugging\"], \"language\": \"en\", \"status\": \"published\", \"source\": \"https://mitchellh.com/writing/ghostty-memory-leak-fix\", \"created\": \"2026-07-28\", \"confidence\": \"0.85\"}",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-29T09:18:36+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/firewall-port-open-not-public.md
+++ b/lessons/contrib/firewall-port-open-not-public.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "firewall port open not public",
-  "verification": "metadata-normalized",
-  "{\"title\"": "防火墙端口开放不等于内网穿透\", \"domain\": \"devops\", \"subdomain\": \"network\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:wsl\", \"node:hermes_wsl\", \"scope:broad\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "firewall port open not public\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "防火墙端口开放不等于内网穿透\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"network\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:rag\\\", \\\"platform:wsl\\\", \\\"node:hermes_wsl\\\", \\\"scope:broad\\\"], \\\"confidence\\\": \\\"0.85\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/fiverr-perimeterx-blocks-seller-automation.md
+++ b/lessons/contrib/fiverr-perimeterx-blocks-seller-automation.md
@@ -1,12 +1,16 @@
 ---
 {
-  "title": "Fiverr PerimeterX captcha blocks headless seller gig creation",
-  "domain": "web",
-  "tags": ["fiverr", "captcha", "perimeterx", "playwright", "seller", "automation"],
-  "status": "published",
-  "source": "uncledad96-glitch",
-  "created": "2026-07-20",
-  "updated": "2026-07-20"
+  "\"title\"": "Fiverr PerimeterX captcha blocks headless seller gig creation\",",
+  "\"domain\"": "web\",",
+  "\"tags\"": "[\"fiverr\", \"captcha\", \"perimeterx\", \"playwright\", \"seller\", \"automation\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "uncledad96-glitch\",",
+  "\"created\"": "2026-07-20\",",
+  "\"updated\"": "2026-07-20",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:17:44+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 

--- a/lessons/contrib/frontmatter-parsing-edge-cases.md
+++ b/lessons/contrib/frontmatter-parsing-edge-cases.md
@@ -1,4 +1,24 @@
-{"title": "Frontmatter Parsing Edge Cases — Silent Failures and Data Loss", "domain": "devops", "source": "MisakaNet validate_lessons.py testing", "status": "draft", "tags": ["frontmatter", "parsing", "validation", "edge-cases", "data-loss"], "created": "2026-07-10 00:00:00 UTC", "updated": "2026-07-10 00:00:00 UTC", "confidence": "0.95", "verified_date": "2026-07-10"}
+{
+  "title": "Frontmatter Parsing Edge Cases — Silent Failures and Data Loss",
+  "domain": "devops",
+  "source": "pr",
+  "status": "draft",
+  "tags": [
+    "frontmatter",
+    "parsing",
+    "validation",
+    "edge-cases",
+    "data-loss"
+  ],
+  "created": "2026-07-10 00:00:00 UTC",
+  "updated": "2026-07-10 00:00:00 UTC",
+  "confidence": "0.95",
+  "verified_date": "2026-07-10",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:08+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 267
+}
 
 ## Verification
 

--- a/lessons/contrib/game-mcp-end-turn-conflict-409.md
+++ b/lessons/contrib/game-mcp-end-turn-conflict-409.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Game MCP: End Turn Returns 409 Conflict",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Game MCP: End Turn Returns 409 Conflict\", \"domain\": \"mcp\", \"source\": \"hanged-man\", \"status\": \"published\", \"domain_expert\": \"hanged-man\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Game MCP: End Turn Returns 409 Conflict\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Game MCP: End Turn Returns 409 Conflict\\\", \\\"domain\\\": \\\"mcp\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"domain_expert\\\": \\\"hanged-man\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/game-mcp-game-over-restart-flow.md
+++ b/lessons/contrib/game-mcp-game-over-restart-flow.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Game MCP: GAME OVER Restart Flow",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Game MCP: GAME OVER Restart Flow\", \"domain\": \"mcp\", \"source\": \"hanged-man\", \"status\": \"published\", \"domain_expert\": \"hanged-man\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Game MCP: GAME OVER Restart Flow\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Game MCP: GAME OVER Restart Flow\\\", \\\"domain\\\": \\\"mcp\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"domain_expert\\\": \\\"hanged-man\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/game-mcp-rare-relic-freeze.md
+++ b/lessons/contrib/game-mcp-rare-relic-freeze.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "game mcp rare relic freeze",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Game MCP: Rare Relic Selection Freeze\", \"domain\": \"mcp\", \"source\": \"hanged-man\", \"status\": \"published\", \"domain_expert\": \"hanged-man\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "game mcp rare relic freeze\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Game MCP: Rare Relic Selection Freeze\\\", \\\"domain\\\": \\\"mcp\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"domain_expert\\\": \\\"hanged-man\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/gateway-hang-watchdog-recovery.md
+++ b/lessons/contrib/gateway-hang-watchdog-recovery.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Gateway 进程挂死未崩溃 — watchdog 自动Recovery",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Gateway 进程挂死未崩溃 — watchdog 自动Recovery\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Gateway 进程挂死未崩溃 — watchdog 自动Recovery", "domain": "devops", "source": "bootstrap", "status": "published", "confidence": "0.7", "created": "2026-04-01"}---

--- a/lessons/contrib/gfw-tls-sni-block-pattern.md
+++ b/lessons/contrib/gfw-tls-sni-block-pattern.md
@@ -1,14 +1,28 @@
 ---
-title: GFW TLS SNI Block Pattern — Why Tool-Layer Solutions Fail
-domain: ops
-subdomain: network
-tags: ["gfw", "tls", "sni", "scraping", "proxy", "curl", "playwright"]
-source: practical-experience
-status: published
-confidence: 0.95
-created: 2026-07-01
-verified_date: 
-domain_expert: 
+{
+  "title": "GFW TLS SNI Block Pattern — Why Tool-Layer Solutions Fail",
+  "domain": "ops",
+  "subdomain": "network",
+  "tags": [
+    "gfw",
+    "tls",
+    "sni",
+    "scraping",
+    "proxy",
+    "curl",
+    "playwright"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.95,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/gfw-tls-sni-blocking-tool-layer-ineffective.md
+++ b/lessons/contrib/gfw-tls-sni-blocking-tool-layer-ineffective.md
@@ -1,19 +1,20 @@
 ---
-title: "GFW TLS SNI 阻断：工具层全部无效，只有代理能解"
-domain: "devops"
-subdomain: "network"
-tags:
-  - gfw
-  - tls-sni
-  - scraper
-  - proxy
-  - china-network
-source: "zsxh1990"
-status: "published"
-confidence: "1.0"
-created: "2026-07-01"
-domain_expert: "zsxh1990"
-verified_date: "2026-07-06"
+{
+  "title": "GFW TLS SNI 阻断：工具层全部无效，只有代理能解",
+  "domain": "devops",
+  "subdomain": "network",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": "1.0",
+  "created": "2026-07-01",
+  "domain_expert": "zsxh1990",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-07T11:58:11+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 375
+}
 ---
 
 ## Problem

--- a/lessons/contrib/ghidra-mcp-server-reverse-engineering.md
+++ b/lessons/contrib/ghidra-mcp-server-reverse-engineering.md
@@ -1,4 +1,25 @@
-{"title": "Ghidra MCP Server — AI-Assisted Reverse Engineering", "domain": "mcp", "subdomain": "reverse-engineering", "tags": ["mcp", "ghidra", "reverse-engineering", "binary-analysis", "security"], "source": "github.com/LaurieWired/GhidraMCP", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+{
+  "title": "Ghidra MCP Server — AI-Assisted Reverse Engineering",
+  "domain": "mcp",
+  "subdomain": "reverse-engineering",
+  "tags": [
+    "mcp",
+    "ghidra",
+    "reverse-engineering",
+    "binary-analysis",
+    "security"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-02T16:15:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 277
+}
 
 
 ## Problem

--- a/lessons/contrib/git-clean-branch-after-merged-pr-ru.md
+++ b/lessons/contrib/git-clean-branch-after-merged-pr-ru.md
@@ -1,14 +1,19 @@
 ---
-title: "Чистая ветка после слияния предыдущего pull request"
-domain: "devops"
-tags: [git, github, pull-request, ветки, восстановление, node:hermes-bounty-agent]
-language: ru
-status: published
-source: "https://docs.github.com/en/get-started/using-git/about-git-rebase"
-created: 2026-07-29
-verified_date: 2026-07-29
-confidence: 0.95
-node_id: "hermes-bounty-agent"
+{
+  "title": "Чистая ветка после слияния предыдущего pull request",
+  "domain": "devops",
+  "tags": "[git, github, pull-request, ветки, восстановление, node:hermes-bounty-agent]",
+  "language": "ru",
+  "status": "published",
+  "source": "pr",
+  "created": "2026-07-29",
+  "verified_date": "2026-07-29",
+  "confidence": 0.95,
+  "node_id": "hermes-bounty-agent",
+  "author": "2lll5",
+  "edited_at": "2026-07-29T17:15:17Z",
+  "merged_by": "2lll5"
+}
 ---
 
 # Чистая ветка после слияния предыдущего pull request

--- a/lessons/contrib/git-credential-helper-gh-path-mismatch.md
+++ b/lessons/contrib/git-credential-helper-gh-path-mismatch.md
@@ -1,10 +1,14 @@
 ---
 {
-  "domain": "contrib",
-  "title": "gh credential helper 路径Error导致 git push 静默失败",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "gh credential helper 路径Error导致 git push 静默失败\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:21:02+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 ---{"title": "gh credential helper 路径Error导致 git push 静默失败", "domain": "devops", "tags": ["git", "github", "credential", "gh", "auth", "push"]}---

--- a/lessons/contrib/git-credentials-and-node-id-setup.md
+++ b/lessons/contrib/git-credentials-and-node-id-setup.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Git Credentials 和 Node ID Setup",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Git Credentials 和 Node ID Setup\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Git Credentials 和 Node ID Setup", "domain": "devops", "source": "hermes_wsl2", "status": "published", "tags": ["git", "credentials", "node-id", "setup"]}---

--- a/lessons/contrib/git-credentials-automation.md
+++ b/lessons/contrib/git-credentials-automation.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Git 凭证Setup — Automation push 免密码",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Git 凭证Setup — Automation push 免密码\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Git 凭证Setup — Automation push 免密码", "domain": "devops", "tags": ["git", "credentials", "auth", "github"]}---

--- a/lessons/contrib/git-force-with-lease-detached-head.md
+++ b/lessons/contrib/git-force-with-lease-detached-head.md
@@ -1,19 +1,20 @@
 ---
-title: Git Push Force-With-Lease — Detached HEAD Recovery After Hash Change
-domain: devops
-subdomain: git
-tags:
-  - git
-  - force-push
-  - detached-head
-  - rebase
-  - recovery
-source: hermes-agent
-status: published
-confidence: 0.90
-created: 2026-07-21
-verified_date: ''
-domain_expert: ''
+{
+  "title": "Git Push Force-With-Lease — Detached HEAD Recovery After Hash Change",
+  "domain": "devops",
+  "subdomain": "git",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.9,
+  "created": "2026-07-21",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "lb1192176991-lab",
+  "edited_at": "2026-07-23T01:13:28+08:00",
+  "merged_by": "lb1192176991-lab",
+  "pr": 535
+}
 ---
 
 {"title": "Git Push Force-With-Lease — Detached HEAD Recovery After Hash Change", "domain": "devops", "subdomain": "git", "tags": ["git", "force-push", "detached-head", "rebase", "recovery"], "source": "hermes-agent", "status": "published", "confidence": "0.90", "created": "2026-07-21", "verified_date": "", "domain_expert": ""}

--- a/lessons/contrib/git-merge-conflict-resolution.md
+++ b/lessons/contrib/git-merge-conflict-resolution.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Git 合并ConflictHandling — 手动解决最佳实践",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Git 合并ConflictHandling — 手动解决最佳实践\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Git 合并ConflictHandling — 手动解决最佳实践", "domain": "development", "tags": ["git", "merge", "conflict", "rebase"]}---

--- a/lessons/contrib/git-push-without-shell-agent.md
+++ b/lessons/contrib/git-push-without-shell-agent.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码\", \"domain\": \"devops\", \"tags\": [\"git\", \"push\", \"agent\", \"gh-cli\", \"lesson\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Git Push 的正确方式 — 在受限 Agent 环境中推送代码\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"git\\\", \\\"push\\\", \\\"agent\\\", \\\"gh-cli\\\", \\\"lesson\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/git-tls-handshake-failure.md
+++ b/lessons/contrib/git-tls-handshake-failure.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "GitHub TLS 握手失败 — gnutls_handshake() Error",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "GitHub TLS 握手失败 — gnutls_handshake() Error\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "GitHub TLS 握手失败 — gnutls_handshake() Error", "domain": "devops", "tags": ["git", "github", "TLS", "SSL", "network"]}---

--- a/lessons/contrib/git-worktree-dangling-commit-recovery.md
+++ b/lessons/contrib/git-worktree-dangling-commit-recovery.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "git worktree commit lost after pushing from the wrong directory",
-  "domain": "development",
-  "tags": [
-    "git",
-    "worktree",
-    "reflog",
-    "recovery",
-    "branch"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "git worktree commit lost after pushing from the wrong directory\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:55:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/github-401-credential-lookup.md
+++ b/lessons/contrib/github-401-credential-lookup.md
@@ -1,11 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "GitHub API 401 后本地凭证查找顺序",
-  "verification": "metadata-normalized",
-  "tags": ["github", "api", "credential", "401", "auth", "pat"],
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "GitHub API 401 后本地凭证查找顺序\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"tags\"": "[\"github\", \"api\", \"credential\", \"401\", \"auth\", \"pat\"],",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:21:02+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 

--- a/lessons/contrib/github-api-pr-issue-management.md
+++ b/lessons/contrib/github-api-pr-issue-management.md
@@ -1,10 +1,22 @@
 ---
-title: GitHub API for PR and Issue Management
-domain: devops
-tags: ["github", "api", "pr", "issue", "automation"]
-status: published
-source: agent_experience
-created: 2026-07-02
+{
+  "title": "GitHub API for PR and Issue Management",
+  "domain": "devops",
+  "tags": [
+    "github",
+    "api",
+    "pr",
+    "issue",
+    "automation"
+  ],
+  "status": "published",
+  "source": "pr",
+  "created": "2026-07-02",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 ---
 

--- a/lessons/contrib/github-automation-without-gh-cli-pt.md
+++ b/lessons/contrib/github-automation-without-gh-cli-pt.md
@@ -1,14 +1,19 @@
 ---
-title: "Automação do GitHub quando o comando gh não está instalado"
-domain: "devops"
-tags: [github, automacao, api-rest, python, cli, node:hermes-bounty-agent]
-language: pt
-status: published
-source: "https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api"
-created: 2026-07-29
-verified_date: 2026-07-29
-confidence: 0.95
-node_id: "hermes-bounty-agent"
+{
+  "title": "Automação do GitHub quando o comando gh não está instalado",
+  "domain": "devops",
+  "tags": "[github, automacao, api-rest, python, cli, node:hermes-bounty-agent]",
+  "language": "pt",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "verified_date": "2026-07-29",
+  "confidence": 0.95,
+  "node_id": "hermes-bounty-agent",
+  "author": "2lll5",
+  "edited_at": "2026-07-29T16:13:55Z",
+  "merged_by": "2lll5"
+}
 ---
 
 # Automação do GitHub quando o comando `gh` não está instalado

--- a/lessons/contrib/github-contents-api-sha-required.md
+++ b/lessons/contrib/github-contents-api-sha-required.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "GitHub contents API edit fails with 422 without the file sha",
-  "domain": "development",
-  "tags": [
-    "github-api",
-    "automation",
-    "rest-api",
-    "file-edit",
-    "scripting"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "GitHub contents API edit fails with 422 without the file sha\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:40:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/github-dns-443-block-hosts-workaround.md
+++ b/lessons/contrib/github-dns-443-block-hosts-workaround.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案",
-  "verification": "metadata-normalized",
-  "{\"title\"": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案\", \"domain\": \"devops\", \"tags\": [\"git\", \"github\", \"TLS\", \"network\", \"DNS\", \"hosts\", \"connectivity\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "GitHub DNS 污染/443端口不通 — hosts 备用 IP 方案\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"git\\\", \\\"github\\\", \\\"TLS\\\", \\\"network\\\", \\\"DNS\\\", \\\"hosts\\\", \\\"connectivity\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/github-rate-limit-auth.md
+++ b/lessons/contrib/github-rate-limit-auth.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "GitHub rate limiting hitting unauthenticated searches during automation",
-  "domain": "network",
-  "tags": [
-    "github",
-    "rate-limit",
-    "api",
-    "automation",
-    "token"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "GitHub rate limiting hitting unauthenticated searches during automation\",",
+  "\"domain\"": "network\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:15:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/github-sudo-email-otp-wrong-input-field.md
+++ b/lessons/contrib/github-sudo-email-otp-wrong-input-field.md
@@ -1,12 +1,16 @@
 ---
 {
-  "title": "GitHub sudo email OTP fails when the wrong input is filled",
-  "domain": "github",
-  "tags": ["github", "sudo", "otp", "playwright", "auth", "pat", "automation"],
-  "status": "published",
-  "source": "uncledad96-glitch",
-  "created": "2026-07-20",
-  "updated": "2026-07-20"
+  "\"title\"": "GitHub sudo email OTP fails when the wrong input is filled\",",
+  "\"domain\"": "github\",",
+  "\"tags\"": "[\"github\", \"sudo\", \"otp\", \"playwright\", \"auth\", \"pat\", \"automation\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "uncledad96-glitch\",",
+  "\"created\"": "2026-07-20\",",
+  "\"updated\"": "2026-07-20",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:16:37+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 

--- a/lessons/contrib/github_api_pr_submission_pitfalls.md
+++ b/lessons/contrib/github_api_pr_submission_pitfalls.md
@@ -1,10 +1,17 @@
 ---
-name: github-api-pr-submission-pitfalls
-description: 用 GitHub API 直接提 PR（不 clone）的 4 个坑：base64 换行、SHA 冲突、空白行、diff 膨胀
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T09:43:52.372Z
+{
+  "name": "github-api-pr-submission-pitfalls",
+  "description": "用 GitHub API 直接提 PR（不 clone）的 4 个坑：base64 换行、SHA 冲突、空白行、diff 膨胀",
+  "metadata": "",
+  "type": "feedback",
+  "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+  "modified": "2026-08-04T09:43:52.372Z",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-08-04T23:50:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 801
+}
 ---
 
 ## 背景

--- a/lessons/contrib/glama-mcp-server-deploy-lessons.md
+++ b/lessons/contrib/glama-mcp-server-deploy-lessons.md
@@ -1,12 +1,16 @@
 ---
 {
-  "title": "Glama MCP Server Deployment — 10 Build Failures and Fixes",
-  "domain": "devops",
-  "tags": ["glama", "mcp", "docker", "uv", "deployment", "ci-cd", "badges", "markdown"],
-  "status": "published",
-  "source": "agent_experience",
-  "created": "2026-07-26",
-  "confidence": "0.95"
+  "\"title\"": "Glama MCP Server Deployment — 10 Build Failures and Fixes\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[\"glama\", \"mcp\", \"docker\", \"uv\", \"deployment\", \"ci-cd\", \"badges\", \"markdown\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "agent_experience\",",
+  "\"created\"": "2026-07-26\",",
+  "\"confidence\"": "0.95",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-29T14:04:33+08:00",
+  "merged_by": "zsxh1990"
 }
 ---
 

--- a/lessons/contrib/go-scheduler-deadlock-lock-order.md
+++ b/lessons/contrib/go-scheduler-deadlock-lock-order.md
@@ -1,19 +1,20 @@
 ---
-title: Go Scheduler Deadlock — Nested Lock Acquisition in gocron v1
-domain: go
-subdomain: concurrency
-tags:
-  - deadlock
-  - mutex
-  - sync
-  - scheduler
-  - gocron
-source: hermes-agent
-status: published
-confidence: 0.95
-created: 2026-07-21
-verified_date: ''
-domain_expert: ''
+{
+  "title": "Go Scheduler Deadlock — Nested Lock Acquisition in gocron v1",
+  "domain": "go",
+  "subdomain": "concurrency",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.95,
+  "created": "2026-07-21",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "lb1192176991-lab",
+  "edited_at": "2026-07-23T01:13:28+08:00",
+  "merged_by": "lb1192176991-lab",
+  "pr": 535
+}
 ---
 
 {"title": "Go Scheduler Deadlock — Nested Lock Acquisition in gocron v1", "domain": "go", "subdomain": "concurrency", "tags": ["deadlock", "mutex", "sync", "scheduler", "gocron"], "source": "hermes-agent", "status": "published", "confidence": "0.95", "created": "2026-07-21", "verified_date": "", "domain_expert": ""}

--- a/lessons/contrib/go-toolchain-vuln-bump-wrong-arch.md
+++ b/lessons/contrib/go-toolchain-vuln-bump-wrong-arch.md
@@ -1,17 +1,16 @@
 ---
 {
-  "title": "Go dependency vuln bump blocked by wrong-architecture toolchain download",
-  "domain": "devops",
-  "tags": [
-    "golang",
-    "toolchain",
-    "vulnerability",
-    "dependencies"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "Go dependency vuln bump blocked by wrong-architecture toolchain download\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:00:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/gpt-sovits-hubert-16khz.md
+++ b/lessons/contrib/gpt-sovits-hubert-16khz.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "gpt sovits hubert 16khz",
-  "verification": "metadata-normalized",
-  "{\"title\"": "GPT-SoVITS：HuBERT 必须 16kHz 且 get_model() 返回单体\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-05\", \"confidence\": \"0.9\", \"scope\": \"narrow\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-05\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "gpt sovits hubert 16khz\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "GPT-SoVITS：HuBERT 必须 16kHz 且 get_model() 返回单体\\\", \\\"domain\\\": \\\"tts\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-04-05\\\", \\\"confidence\\\": \\\"0.9\\\", \\\"scope\\\": \\\"narrow\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-04-05\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/gpt-sovits-name2text-arpabet.md
+++ b/lessons/contrib/gpt-sovits-name2text-arpabet.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "gpt sovits name2text arpabet",
-  "verification": "metadata-normalized",
-  "{\"title\"": "GPT-SoVITS 训练：2-name2text 格式必须用 ARPABET 音素而非中文原文\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-06\", \"confidence\": \"0.9\", \"scope\": \"narrow\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-06\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "gpt sovits name2text arpabet\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "GPT-SoVITS 训练：2-name2text 格式必须用 ARPABET 音素而非中文原文\\\", \\\"domain\\\": \\\"tts\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-04-06\\\", \\\"confidence\\\": \\\"0.9\\\", \\\"scope\\\": \\\"narrow\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-04-06\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/gpt-sovits-ref-free-bug.md
+++ b/lessons/contrib/gpt-sovits-ref-free-bug.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "gpt sovits ref free bug",
-  "verification": "metadata-normalized",
-  "{\"title\"": "GPT-SoVITS：ref_free bug——prompt_text 为空时参数被覆盖\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-06\", \"confidence\": \"0.9\", \"scope\": \"narrow\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-06\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "gpt sovits ref free bug\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "GPT-SoVITS：ref_free bug——prompt_text 为空时参数被覆盖\\\", \\\"domain\\\": \\\"tts\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-04-06\\\", \\\"confidence\\\": \\\"0.9\\\", \\\"scope\\\": \\\"narrow\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-04-06\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/heartbeat_scan_improvement.md
+++ b/lessons/contrib/heartbeat_scan_improvement.md
@@ -1,10 +1,17 @@
 ---
-name: heartbeat-scan-improvement
-description: 心跳扫描必须同时查 author PR 和 involvement issue，否则 claimed issue 会丢失
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T10:19:56.150Z
+{
+  "name": "heartbeat-scan-improvement",
+  "description": "心跳扫描必须同时查 author PR 和 involvement issue，否则 claimed issue 会丢失",
+  "metadata": "",
+  "type": "feedback",
+  "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+  "modified": "2026-08-04T10:19:56.150Z",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-08-04T23:50:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 801
+}
 ---
 
 ## 问题

--- a/lessons/contrib/hub-credential-gateway-vs-hub.md
+++ b/lessons/contrib/hub-credential-gateway-vs-hub.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里\", \"domain\": \"devops\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Hub Hermes 凭证体系 — Gateway vs Hub 各自读哪里\\\", \\\"domain\\\": \\\"devops\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.7\\\", \\\"created\\\": \\\"2026-04-01\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-04-01\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/hub-feishu-wsclient-start-never-called.md
+++ b/lessons/contrib/hub-feishu-wsclient-start-never-called.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "hub feishu wsclient start never called",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Hub FeishuWSClient.start() 从未调用 — WebSocket 接收死代码\", \"domain\": \"feishu\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "hub feishu wsclient start never called\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Hub FeishuWSClient.start() 从未调用 — WebSocket 接收死代码\\\", \\\"domain\\\": \\\"feishu\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.7\\\", \\\"created\\\": \\\"2026-04-01\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-04-01\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/issue-comment-newbie-welcome.md
+++ b/lessons/contrib/issue-comment-newbie-welcome.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Auto-Welcome Newcomers via issue_comment Event",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Auto-Welcome Newcomers via issue_comment Event\", \"domain\": \"devops\", \"tags\": [\"github-actions\", \"ci\", \"community\", \"newbie\", \"good-first-issue\", \"automation\"], \"status\": \"published\", \"source\": \"deepseek\", \"created\": \"2026-06-12 00:00:00 UTC\", \"updated\": \"2026-06-12 00:00:00 UTC\", \"domain_expert\": \"deepseek\", \"verified_date\": \"2026-06-12\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Auto-Welcome Newcomers via issue_comment Event\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Auto-Welcome Newcomers via issue_comment Event\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"github-actions\\\", \\\"ci\\\", \\\"community\\\", \\\"newbie\\\", \\\"good-first-issue\\\", \\\"automation\\\"], \\\"status\\\": \\\"published\\\", \\\"source\\\": \\\"deepseek\\\", \\\"created\\\": \\\"2026-06-12 00:00:00 UTC\\\", \\\"updated\\\": \\\"2026-06-12 00:00:00 UTC\\\", \\\"domain_expert\\\": \\\"deepseek\\\", \\\"verified_date\\\": \\\"2026-06-12\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/js-dead-code-chain-break.md
+++ b/lessons/contrib/js-dead-code-chain-break.md
@@ -1,10 +1,21 @@
 ---
-title: "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效"
-domain: "frontend"
-tags: ["js", "runtime", "typeerror", "execution-model", "defensive"]
-domain_expert: "unknown"
-created: "2026-07-06"
-source: "unknown"
+{
+  "title": "JavaScript 执行链断裂：一个未捕获 TypeError 如何让整个页面静默失效",
+  "domain": "frontend",
+  "tags": [
+    "js",
+    "runtime",
+    "typeerror",
+    "execution-model",
+    "defensive"
+  ],
+  "domain_expert": "unknown",
+  "created": "2026-07-06",
+  "source": "manual",
+  "author": "Muhammad Bilal Mukhtar",
+  "edited_at": "2026-08-06T01:00:28+08:00",
+  "merged_by": "Muhammad Bilal Mukhtar"
+}
 ---
 
 ## 背景

--- a/lessons/contrib/json-parse-failure-handling.md
+++ b/lessons/contrib/json-parse-failure-handling.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "JSON 解析失败Handling — 截断 / 格式Error",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "JSON 解析失败Handling — 截断 / 格式Error\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "JSON 解析失败Handling — 截断 / 格式Error", "domain": "devops", "tags": ["json", "parse", "truncated", "llm", "output"]}---

--- a/lessons/contrib/kb-4sigma-quality-audit-pipeline.md
+++ b/lessons/contrib/kb-4sigma-quality-audit-pipeline.md
@@ -1,19 +1,23 @@
 ---
 {
-  "title": "Knowledge Base 4-Sigma Quality Audit Pipeline",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "tags": [
-    "project:self-grow-wiki",
-    "severity:medium",
-    "node:hermes-wsl"
-  ],
-  "language": "en",
-  "created": "2026-05-03",
-  "domain_expert": "bootstrap",
-  "verified_date": "2026-05-03",
-  "subdomain": "quality"
+  "\"title\"": "Knowledge Base 4-Sigma Quality Audit Pipeline\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"severity": "medium\",",
+  "\"node": "hermes-wsl",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-05-03\",",
+  "\"domain_expert\"": "bootstrap\",",
+  "\"verified_date\"": "2026-05-03\",",
+  "\"subdomain\"": "quality",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/knowledge-graph-ux-patterns-from-high-star-projects.md
+++ b/lessons/contrib/knowledge-graph-ux-patterns-from-high-star-projects.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "knowledge graph ux patterns from high star projects",
-  "verification": "metadata-normalized",
-  "{\"title\"": "知识图谱 UX 增强: 从高星项目提炼的 7 个交互模式\", \"domain\": \"development\", \"tags\": [\"knowledge-graph\", \"d3js\", \"ux\", \"graph-visualization\", \"force-directed\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "knowledge graph ux patterns from high star projects\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "知识图谱 UX 增强: 从高星项目提炼的 7 个交互模式\\\", \\\"domain\\\": \\\"development\\\", \\\"tags\\\": [\\\"knowledge-graph\\\", \\\"d3js\\\", \\\"ux\\\", \\\"graph-visualization\\\", \\\"force-directed\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/kubernetes-crashloopbackoff-debugging.md
+++ b/lessons/contrib/kubernetes-crashloopbackoff-debugging.md
@@ -1,17 +1,17 @@
 ---
-title: Tips for Debugging Kubernetes CrashLoopBackOff in a Container
-domain: kubernetes
-tags:
-  - debugging
-  - crashloopbackoff
-  - container
-  - kubernetes
-  - troubleshooting
-language: en
-status: published
-source: https://releaseapp.io/blog/kubernetes-how-to-debug-crashloopbackoff-in-a-container
-created: 2026-07-28
-confidence: 0.85
+{
+  "title": "Tips for Debugging Kubernetes CrashLoopBackOff in a Container",
+  "domain": "kubernetes",
+  "tags": "",
+  "language": "en",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-28",
+  "confidence": 0.85,
+  "author": "zsxh1990",
+  "edited_at": "2026-07-29T09:18:36+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/lesson-06-git-push-credential-helper-403.md
+++ b/lessons/contrib/lesson-06-git-push-credential-helper-403.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "devops",
-  "title": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper\", \"domain\": \"devops\", \"tags\": [\"git\", \"github\", \"credentials-helper\", \"pat\", \"multi-account\", \"403\", \"fork-workflow\"], \"status\": \"published\", \"confidence\": \"0.95\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"https://github.com/zsxh1990/pr-genius (commit history, 2026-07-02T23:36 GMT+8)\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "devops\",",
+  "\"title\"": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Git Push to Fork Repo: 'Permission Denied to Other User' — Wrong PAT Selected by Helper\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"git\\\", \\\"github\\\", \\\"credentials-helper\\\", \\\"pat\\\", \\\"multi-account\\\", \\\"403\\\", \\\"fork-workflow\\\"], \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.95\\\", \\\"created\\\": \\\"2026-07-03\\\", \\\"updated\\\": \\\"2026-07-03\\\", \\\"source\\\": \\\"https://github.com/zsxh1990/pr-genius (commit history, 2026-07-02T23:36 GMT+8)\\\", \\\"verified_date\\\": \\\"\\\", \\\"domain_expert\\\": \\\"\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/lesson-07-uv-venv-seed-fix-no-pip.md
+++ b/lessons/contrib/lesson-07-uv-venv-seed-fix-no-pip.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "devops",
-  "title": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo\", \"domain\": \"devops\", \"tags\": [\"python\", \"venv\", \"uv\", \"pip\", \"wsl\", \"ubuntu\", \"pep-668\", \"agent-reach-install\"], \"status\": \"published\", \"confidence\": \"0.92\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real incident, agent-reach install (2026-07-03T00:25 GMT+8)\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "devops\",",
+  "\"title\"": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Ubuntu WSL Python venv Missing pip — uv venv --seed Fixes Without sudo\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"python\\\", \\\"venv\\\", \\\"uv\\\", \\\"pip\\\", \\\"wsl\\\", \\\"ubuntu\\\", \\\"pep-668\\\", \\\"agent-reach-install\\\"], \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.92\\\", \\\"created\\\": \\\"2026-07-03\\\", \\\"updated\\\": \\\"2026-07-03\\\", \\\"source\\\": \\\"Real incident, agent-reach install (2026-07-03T00:25 GMT+8)\\\", \\\"verified_date\\\": \\\"\\\", \\\"domain_expert\\\": \\\"\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/lesson-08-pip-https-proxy-clash.md
+++ b/lessons/contrib/lesson-08-pip-https-proxy-clash.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "devops",
-  "title": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890",
-  "verification": "metadata-normalized",
-  "{\"title\"": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890\", \"domain\": \"devops\", \"tags\": [\"pip\", \"proxy\", \"wsl\", \"clash\", \"github-timeout\", \"agent-reach-install\", \"network-config\"], \"status\": \"published\", \"confidence\": \"0.94\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real incident, agent-reach install (2026-07-03T00:30 GMT+8)\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "devops\",",
+  "\"title\"": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "pip install HTTPS Timeout from WSL — Prepend HTTPS_PROXY=http://172.19.128.1:7890\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"pip\\\", \\\"proxy\\\", \\\"wsl\\\", \\\"clash\\\", \\\"github-timeout\\\", \\\"agent-reach-install\\\", \\\"network-config\\\"], \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.94\\\", \\\"created\\\": \\\"2026-07-03\\\", \\\"updated\\\": \\\"2026-07-03\\\", \\\"source\\\": \\\"Real incident, agent-reach install (2026-07-03T00:30 GMT+8)\\\", \\\"verified_date\\\": \\\"\\\", \\\"domain_expert\\\": \\\"\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/lesson-09-v2ex-api-show-endpoint-unstable.md
+++ b/lessons/contrib/lesson-09-v2ex-api-show-endpoint-unstable.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "scraping",
-  "title": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead",
-  "verification": "metadata-normalized",
-  "{\"title\"": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead\", \"domain\": \"scraping\", \"tags\": [\"v2ex\", \"api\", \"json-parse-error\", \"jina-reader\", \"fallback-strategy\", \"agent-reach\"], \"status\": \"published\", \"confidence\": \"0.85\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real incident, lesson fetching from V2EX 2026-07-03T00:42 GMT+8\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "scraping\",",
+  "\"title\"": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "V2EX API /api/topics/show.json Unstable — Use r.jina.ai Instead\\\", \\\"domain\\\": \\\"scraping\\\", \\\"tags\\\": [\\\"v2ex\\\", \\\"api\\\", \\\"json-parse-error\\\", \\\"jina-reader\\\", \\\"fallback-strategy\\\", \\\"agent-reach\\\"], \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.85\\\", \\\"created\\\": \\\"2026-07-03\\\", \\\"updated\\\": \\\"2026-07-03\\\", \\\"source\\\": \\\"Real incident, lesson fetching from V2EX 2026-07-03T00:42 GMT+8\\\", \\\"verified_date\\\": \\\"\\\", \\\"domain_expert\\\": \\\"\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/lesson-10-agent-reach-doctor-baseline.md
+++ b/lessons/contrib/lesson-10-agent-reach-doctor-baseline.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "tooling",
-  "title": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login\", \"domain\": \"tooling\", \"tags\": [\"agent-reach\", \"doctor\", \"channel-availability\", \"baseline\", \"v2ex\", \"rss\", \"jina\", \"bilibili\", \"cookie-required\"], \"status\": \"published\", \"confidence\": \"0.88\", \"created\": \"2026-07-03\", \"updated\": \"2026-07-03\", \"source\": \"Real test output 2026-07-03T00:32 GMT+8 on WSL Ubuntu\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "tooling\",",
+  "\"title\"": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Agent-Reach v1.5.0 doctor Baseline: 4/15 Channels Available Without Login\\\", \\\"domain\\\": \\\"tooling\\\", \\\"tags\\\": [\\\"agent-reach\\\", \\\"doctor\\\", \\\"channel-availability\\\", \\\"baseline\\\", \\\"v2ex\\\", \\\"rss\\\", \\\"jina\\\", \\\"bilibili\\\", \\\"cookie-required\\\"], \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.88\\\", \\\"created\\\": \\\"2026-07-03\\\", \\\"updated\\\": \\\"2026-07-03\\\", \\\"source\\\": \\\"Real test output 2026-07-03T00:32 GMT+8 on WSL Ubuntu\\\", \\\"verified_date\\\": \\\"\\\", \\\"domain_expert\\\": \\\"\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/lesson-10-microservices-latency-math.md
+++ b/lessons/contrib/lesson-10-microservices-latency-math.md
@@ -1,14 +1,25 @@
 ---
-title: "微服务延迟成本分析 — 何时不该用微服务"
-domain: "ops"
-subdomain: "architecture"
-tags: ["microservices", "architecture", "latency", "performance", "monolith"]
-source: "dev.to"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "微服务延迟成本分析 — 何时不该用微服务",
+  "domain": "ops",
+  "subdomain": "architecture",
+  "tags": [
+    "microservices",
+    "architecture",
+    "latency",
+    "performance",
+    "monolith"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-11-github-commit-signing.md
+++ b/lessons/contrib/lesson-11-github-commit-signing.md
@@ -1,14 +1,26 @@
 ---
-title: "GitHub Commit Signing — GPG 防止提交伪造"
-domain: "ops"
-subdomain: "security"
-tags: ["git", "github", "gpg", "security", "commit-signing", "impersonation"]
-source: "dev.to"
-status: "published"
-confidence: "0.95"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "GitHub Commit Signing — GPG 防止提交伪造",
+  "domain": "ops",
+  "subdomain": "security",
+  "tags": [
+    "git",
+    "github",
+    "gpg",
+    "security",
+    "commit-signing",
+    "impersonation"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.95",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-13-aws-lambda-microvms.md
+++ b/lessons/contrib/lesson-13-aws-lambda-microvms.md
@@ -1,14 +1,26 @@
 ---
-title: "AWS Lambda MicroVMs — 隔离沙箱与 Firecracker"
-domain: "ops"
-subdomain: "serverless"
-tags: ["aws", "lambda", "microvm", "firecracker", "sandbox", "isolation"]
-source: "aws.amazon.com/blogs"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "AWS Lambda MicroVMs — 隔离沙箱与 Firecracker",
+  "domain": "ops",
+  "subdomain": "serverless",
+  "tags": [
+    "aws",
+    "lambda",
+    "microvm",
+    "firecracker",
+    "sandbox",
+    "isolation"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-14-api-pagination-design.md
+++ b/lessons/contrib/lesson-14-api-pagination-design.md
@@ -1,14 +1,26 @@
 ---
-title: "API 分页设计 — Cursor vs Offset vs Keyset"
-domain: "ops"
-subdomain: "api"
-tags: ["api", "pagination", "cursor", "offset", "keyset", "design"]
-source: "solovyov.net"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "API 分页设计 — Cursor vs Offset vs Keyset",
+  "domain": "ops",
+  "subdomain": "api",
+  "tags": [
+    "api",
+    "pagination",
+    "cursor",
+    "offset",
+    "keyset",
+    "design"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-15-cloudflare-workflows-durable.md
+++ b/lessons/contrib/lesson-15-cloudflare-workflows-durable.md
@@ -1,14 +1,25 @@
 ---
-title: "Cloudflare Workflows — 持久化多步骤执行"
-domain: "ops"
-subdomain: "workflow"
-tags: ["cloudflare", "workflows", "durable", "serverless", "state-machine"]
-source: "blog.cloudflare.com"
-status: "published"
-confidence: "0.85"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "Cloudflare Workflows — 持久化多步骤执行",
+  "domain": "ops",
+  "subdomain": "workflow",
+  "tags": [
+    "cloudflare",
+    "workflows",
+    "durable",
+    "serverless",
+    "state-machine"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-16-aws-ecs-high-resolution-metrics.md
+++ b/lessons/contrib/lesson-16-aws-ecs-high-resolution-metrics.md
@@ -1,14 +1,25 @@
 ---
-title: "AWS ECS 高分辨率指标 — 更快的自动扩缩容"
-domain: "ops"
-subdomain: "kubernetes"
-tags: ["aws", "ecs", "metrics", "auto-scaling", "monitoring"]
-source: "aws.amazon.com/blogs"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "AWS ECS 高分辨率指标 — 更快的自动扩缩容",
+  "domain": "ops",
+  "subdomain": "kubernetes",
+  "tags": [
+    "aws",
+    "ecs",
+    "metrics",
+    "auto-scaling",
+    "monitoring"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-17-segmentfault-mcp-standardization.md
+++ b/lessons/contrib/lesson-17-segmentfault-mcp-standardization.md
@@ -1,14 +1,25 @@
 ---
-title: "MCP — AI Agent 工具调用标准化协议"
-domain: "mcp"
-subdomain: "standardization"
-tags: ["mcp", "agent", "tool-calling", "standardization", "protocol"]
-source: "segmentfault.com"
-status: "published"
-confidence: "0.85"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "MCP — AI Agent 工具调用标准化协议",
+  "domain": "mcp",
+  "subdomain": "standardization",
+  "tags": [
+    "mcp",
+    "agent",
+    "tool-calling",
+    "standardization",
+    "protocol"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-18-database-performance-indexing.md
+++ b/lessons/contrib/lesson-18-database-performance-indexing.md
@@ -1,14 +1,25 @@
 ---
-title: "数据库性能 — 索引与查询优化实践"
-domain: "ops"
-subdomain: "database"
-tags: ["database", "postgresql", "indexing", "performance", "query-optimization"]
-source: "practical-experience"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "数据库性能 — 索引与查询优化实践",
+  "domain": "ops",
+  "subdomain": "database",
+  "tags": [
+    "database",
+    "postgresql",
+    "indexing",
+    "performance",
+    "query-optimization"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-19-grpc-openapi-rest-comparison.md
+++ b/lessons/contrib/lesson-19-grpc-openapi-rest-comparison.md
@@ -1,14 +1,26 @@
 ---
-title: "gRPC vs OpenAPI vs REST — API 协议选择指南"
-domain: "ops"
-subdomain: "api"
-tags: ["grpc", "openapi", "rest", "api", "protocol", "architecture"]
-source: "cloud.google.com/blog"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "gRPC vs OpenAPI vs REST — API 协议选择指南",
+  "domain": "ops",
+  "subdomain": "api",
+  "tags": [
+    "grpc",
+    "openapi",
+    "rest",
+    "api",
+    "protocol",
+    "architecture"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-20-api-design-principles.md
+++ b/lessons/contrib/lesson-20-api-design-principles.md
@@ -1,14 +1,25 @@
 ---
-title: "API 设计原则 — 无抽象、一致性、幂等性"
-domain: "ops"
-subdomain: "api"
-tags: ["api", "design", "principles", "rest", "consistency"]
-source: "increase.com/articles"
-status: "published"
-confidence: "0.85"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "API 设计原则 — 无抽象、一致性、幂等性",
+  "domain": "ops",
+  "subdomain": "api",
+  "tags": [
+    "api",
+    "design",
+    "principles",
+    "rest",
+    "consistency"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-9-redis-postgresql-replacement.md
+++ b/lessons/contrib/lesson-9-redis-postgresql-replacement.md
@@ -1,14 +1,26 @@
 ---
-title: "Redis → PostgreSQL 替换 — 缓存/PubSub/队列统一"
-domain: "ops"
-subdomain: "database"
-tags: ["redis", "postgresql", "caching", "pubsub", "database", "performance"]
-source: "dev.to"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "Redis → PostgreSQL 替换 — 缓存/PubSub/队列统一",
+  "domain": "ops",
+  "subdomain": "database",
+  "tags": [
+    "redis",
+    "postgresql",
+    "caching",
+    "pubsub",
+    "database",
+    "performance"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-management-standardization.md
+++ b/lessons/contrib/lesson-management-standardization.md
@@ -1,13 +1,26 @@
 ---
-title: Lesson Management Standardization — Naming, Content Sanitization, and Automated Submission Pipeline
-domain: devops
-tags: ["lesson", "naming-convention", "content-sanitization", "automation", "ci", "standardization"]
-status: published
-confidence: 0.95
-created: 2026-06-14
-source: codewhale
-domain_expert: codewhale
-verified_date: 2026-06-14
+{
+  "title": "Lesson Management Standardization — Naming, Content Sanitization, and Automated Submission Pipeline",
+  "domain": "devops",
+  "tags": [
+    "lesson",
+    "naming-convention",
+    "content-sanitization",
+    "automation",
+    "ci",
+    "standardization"
+  ],
+  "status": "published",
+  "confidence": 0.95,
+  "created": "2026-06-14",
+  "source": "pr",
+  "domain_expert": "codewhale",
+  "verified_date": "2026-06-14",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/lesson-quality-requirements.md
+++ b/lessons/contrib/lesson-quality-requirements.md
@@ -1,10 +1,19 @@
 {
   "title": "Lesson Quality Requirements: SKP Format",
   "domain": "devops",
-  "tags": ["lesson", "quality", "format", "skp", "misakanet"],
+  "tags": [
+    "lesson",
+    "quality",
+    "format",
+    "skp",
+    "misakanet"
+  ],
   "status": "published",
-  "source": "agent_experience",
-  "created": "2026-07-02"
+  "source": "manual",
+  "created": "2026-07-02",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-02T17:02:43+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/lesson-review-3-devops-platform-engineering.md
+++ b/lessons/contrib/lesson-review-3-devops-platform-engineering.md
@@ -1,14 +1,25 @@
 ---
-title: "DevOps Platform Engineering — Golden Paths to Reduce Cognitive Load"
-domain: "ops"
-subdomain: "devops"
-tags: ["devops", "platform-engineering", "golden-paths", "cognitive-load", "idp"]
-source: "dev.to"
-status: "published"
-confidence: "0.8"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "DevOps Platform Engineering — Golden Paths to Reduce Cognitive Load",
+  "domain": "ops",
+  "subdomain": "devops",
+  "tags": [
+    "devops",
+    "platform-engineering",
+    "golden-paths",
+    "cognitive-load",
+    "idp"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.8",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-review-4-mcp-bedrock-integration.md
+++ b/lessons/contrib/lesson-review-4-mcp-bedrock-integration.md
@@ -1,14 +1,26 @@
 ---
-title: "MCP 协议 + Bedrock 实战 — Agent 外部工具调用标准化"
-domain: "mcp"
-subdomain: "integration"
-tags: ["mcp", "bedrock", "aws", "agent", "tool-calling", "standardization"]
-source: "segmentfault.com"
-status: "published"
-confidence: "0.85"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "MCP 协议 + Bedrock 实战 — Agent 外部工具调用标准化",
+  "domain": "mcp",
+  "subdomain": "integration",
+  "tags": [
+    "mcp",
+    "bedrock",
+    "aws",
+    "agent",
+    "tool-calling",
+    "standardization"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-review-5-eks-version-rollback.md
+++ b/lessons/contrib/lesson-review-5-eks-version-rollback.md
@@ -1,14 +1,26 @@
 ---
-title: "EKS Kubernetes 版本回滚 — 安全升级集群"
-domain: "ops"
-subdomain: "kubernetes"
-tags: ["kubernetes", "eks", "aws", "upgrade", "rollback", "cluster-management"]
-source: "aws.amazon.com/blogs"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "EKS Kubernetes 版本回滚 — 安全升级集群",
+  "domain": "ops",
+  "subdomain": "kubernetes",
+  "tags": [
+    "kubernetes",
+    "eks",
+    "aws",
+    "upgrade",
+    "rollback",
+    "cluster-management"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-review-6-cloudflare-x402-monetization.md
+++ b/lessons/contrib/lesson-review-6-cloudflare-x402-monetization.md
@@ -1,14 +1,26 @@
 ---
-title: "Cloudflare Monetization Gateway — x402 API 支付协议"
-domain: "ops"
-subdomain: "api"
-tags: ["cloudflare", "x402", "api", "monetization", "payment", "mcp"]
-source: "blog.cloudflare.com"
-status: "published"
-confidence: "0.8"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "Cloudflare Monetization Gateway — x402 API 支付协议",
+  "domain": "ops",
+  "subdomain": "api",
+  "tags": [
+    "cloudflare",
+    "x402",
+    "api",
+    "monetization",
+    "payment",
+    "mcp"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.8",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-review-7-cloudflare-saga-rollbacks.md
+++ b/lessons/contrib/lesson-review-7-cloudflare-saga-rollbacks.md
@@ -1,14 +1,26 @@
 ---
-title: "Cloudflare Workflows Saga Rollback — Durable Multi-Step Compensation"
-domain: "ops"
-subdomain: "workflow"
-tags: ["cloudflare", "workflows", "saga", "rollback", "durable", "compensation"]
-source: "blog.cloudflare.com"
-status: "published"
-confidence: "0.9"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "Cloudflare Workflows Saga Rollback — Durable Multi-Step Compensation",
+  "domain": "ops",
+  "subdomain": "workflow",
+  "tags": [
+    "cloudflare",
+    "workflows",
+    "saga",
+    "rollback",
+    "durable",
+    "compensation"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-review-8-cloudflare-ai-traffic-options.md
+++ b/lessons/contrib/lesson-review-8-cloudflare-ai-traffic-options.md
@@ -1,14 +1,26 @@
 ---
-title: "Cloudflare AI Traffic Options — Content Monetization for the Agentic Internet"
-domain: "ops"
-subdomain: "api"
-tags: ["cloudflare", "ai", "monetization", "crawling", "pay-per-crawl", "content"]
-source: "blog.cloudflare.com"
-status: "published"
-confidence: "0.85"
-created: "2026-07-01"
-verified_date: ""
-domain_expert: ""
+{
+  "title": "Cloudflare AI Traffic Options — Content Monetization for the Agentic Internet",
+  "domain": "ops",
+  "subdomain": "api",
+  "tags": [
+    "cloudflare",
+    "ai",
+    "monetization",
+    "crawling",
+    "pay-per-crawl",
+    "content"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-04T11:38:13+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 

--- a/lessons/contrib/lesson-template-network.md
+++ b/lessons/contrib/lesson-template-network.md
@@ -1,12 +1,17 @@
 ---
 {
-  "title": "Network Domain Lesson Template",
-  "domain": "network",
-  "tags": ["http", "dns", "proxy", "ssl", "websocket", "timeout", "template"],
-  "status": "published",
-  "source": "template",
-  "created": "2026-07-13",
-  "confidence": "1.0"
+  "\"title\"": "Network Domain Lesson Template\",",
+  "\"domain\"": "network\",",
+  "\"tags\"": "[\"http\", \"dns\", \"proxy\", \"ssl\", \"websocket\", \"timeout\", \"template\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "template\",",
+  "\"created\"": "2026-07-13\",",
+  "\"confidence\"": "1.0",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-14T11:57:22+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 295
 }
 ---
 

--- a/lessons/contrib/lesson_file_line_number_corruption.md
+++ b/lessons/contrib/lesson_file_line_number_corruption.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Before — inspect raw first line",
-  "verification": "metadata-normalized",
-  "{\"title\"": "File Content Corrupted by Terminal Line-Number Prefixes\", \"domain\": \"devops\", \"tags\": [\"terminal\", \"sed\", \"line-number\", \"file-corruption\", \"html\", \"debug\"], \"status\": \"published\", \"created\": \"2026-06-20\", \"source\": \"codewhale\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Before — inspect raw first line\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "File Content Corrupted by Terminal Line-Number Prefixes\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"terminal\\\", \\\"sed\\\", \\\"line-number\\\", \\\"file-corruption\\\", \\\"html\\\", \\\"debug\\\"], \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-06-20\\\", \\\"source\\\": \\\"codewhale\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/lessons-md-fix-heading-block-type.md
+++ b/lessons/contrib/lessons-md-fix-heading-block-type.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "lessons md fix heading block type",
-  "verification": "metadata-normalized",
-  "{\"title\"": "lessons.md 修正（4 处） 项目 旧结论 修正后 heading block（type=4\", \"domain\": \"rag\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "lessons md fix heading block type\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "lessons.md 修正（4 处） 项目 旧结论 修正后 heading block（type=4\\\", \\\"domain\\\": \\\"rag\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.7\\\", \\\"created\\\": \\\"2026-04-01\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-04-01\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/macos-homebrew-python-pip-install-blocked-by-pep-668-externa.md
+++ b/lessons/contrib/macos-homebrew-python-pip-install-blocked-by-pep-668-externa.md
@@ -1,5 +1,11 @@
 ---
-{"title": "macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment", "domain": "devops", "tags": ["python", "pip", "homebrew", "macos", "pep-668", "venv", "pyyaml"], "status": "published", "evidence_level": "E2", "created": "2026-07-09", "updated": "2026-07-09", "source": "Real incident, running validate.py on macOS Homebrew Python 3.14 (2026-07-09)", "verified_date": "2026-07-09"}
+{
+  "{\"title\"": "macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment\", \"domain\": \"devops\", \"tags\": [\"python\", \"pip\", \"homebrew\", \"macos\", \"pep-668\", \"venv\", \"pyyaml\"], \"status\": \"published\", \"evidence_level\": \"E2\", \"created\": \"2026-07-09\", \"updated\": \"2026-07-09\", \"source\": \"Real incident, running validate.py on macOS Homebrew Python 3.14 (2026-07-09)\", \"verified_date\": \"2026-07-09\"}",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-08-11T21:14:18+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # macOS Homebrew Python: pip install Blocked by PEP 668 externally-managed-environment

--- a/lessons/contrib/maintainer-feedback-iteration.md
+++ b/lessons/contrib/maintainer-feedback-iteration.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Maintainer Feedback Iteration — Address Blockers, Not Just Comments",
-  "tags": ["contrib", "maintainer", "feedback", "iteration", "pr"],
-  "status": "draft",
-  "source": "Multiple PR review cycles",
-  "created": "2026-07-15",
-  "confidence": "0.95"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Maintainer Feedback Iteration — Address Blockers, Not Just Comments\",",
+  "\"tags\"": "[\"contrib\", \"maintainer\", \"feedback\", \"iteration\", \"pr\"],",
+  "\"status\"": "draft\",",
+  "\"source\"": "Multiple PR review cycles\",",
+  "\"created\"": "2026-07-15\",",
+  "\"confidence\"": "0.95",
+  "author": "zsxh1990",
+  "source": "intake",
+  "edited_at": "2026-07-15T19:31:51+08:00",
+  "merged_by": "zsxh1990"
 }
 ---
 

--- a/lessons/contrib/mcp-context-mode-98-reduction.md
+++ b/lessons/contrib/mcp-context-mode-98-reduction.md
@@ -1,4 +1,25 @@
-{"title": "MCP Context Mode — 98% Context Window Reduction for Claude Code", "domain": "mcp", "subdomain": "optimization", "tags": ["mcp", "claude-code", "context-window", "optimization", "token-efficiency"], "source": "mksg.lu/blog/context-mode", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+{
+  "title": "MCP Context Mode — 98% Context Window Reduction for Claude Code",
+  "domain": "mcp",
+  "subdomain": "optimization",
+  "tags": [
+    "mcp",
+    "claude-code",
+    "context-window",
+    "optimization",
+    "token-efficiency"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-02T16:15:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 277
+}
 
 
 ## Problem

--- a/lessons/contrib/mcp-registry-readiness-requires-qa-before-promotion.md
+++ b/lessons/contrib/mcp-registry-readiness-requires-qa-before-promotion.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "mcp",
-  "title": "MCP Registry Readiness Requires QA Before Promotion",
-  "tags": ["mcp", "registry", "qa", "glama", "tooling"],
-  "status": "published",
-  "source": "generalized MCP listing readiness analysis",
-  "created": "2026-07-17",
-  "confidence": "0.86"
+  "\"domain\"": "mcp\",",
+  "\"title\"": "MCP Registry Readiness Requires QA Before Promotion\",",
+  "\"tags\"": "[\"mcp\", \"registry\", \"qa\", \"glama\", \"tooling\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "generalized MCP listing readiness analysis\",",
+  "\"created\"": "2026-07-17\",",
+  "\"confidence\"": "0.86",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-07-17T01:09:07+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/mcp-server-direct-handler-testing.md
+++ b/lessons/contrib/mcp-server-direct-handler-testing.md
@@ -1,16 +1,17 @@
 ---
-title: "MCP Server 测试 — 直接调用 handler 跳过 stdio 传输"
-domain: development
-tags:
-  - mcp
-  - testing
-  - json-rpc
-  - python
-  - unit-test
-status: published
-source: practical-experience
-confidence: 0.85
-created: 2026-07-07
+{
+  "title": "MCP Server 测试 — 直接调用 handler 跳过 stdio 传输",
+  "domain": "development",
+  "tags": "",
+  "status": "published",
+  "source": "pr",
+  "confidence": 0.85,
+  "created": "2026-07-07",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-08T17:09:01+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 415
+}
 ---
 
 ## Problem

--- a/lessons/contrib/mcp-server-testing-patterns-ru.md
+++ b/lessons/contrib/mcp-server-testing-patterns-ru.md
@@ -1,12 +1,23 @@
 ---
-title: "Паттерны тестирования MCP серверов — прямой вызов обработчика"
-domain: development
-tags: ["mcp", "testing", "russian", "agent", "tutorial"]
-source: "practical-experience"
-status: published
-confidence: 0.85
-created: 2026-08-01
-lang: ru
+{
+  "title": "Паттерны тестирования MCP серверов — прямой вызов обработчика",
+  "domain": "development",
+  "tags": [
+    "mcp",
+    "testing",
+    "russian",
+    "agent",
+    "tutorial"
+  ],
+  "source": "manual",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-08-01",
+  "lang": "ru",
+  "author": "zsxh1990",
+  "edited_at": "2026-08-02T00:17:21+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Проблема

--- a/lessons/contrib/mcp-server-that-reduces-claude-code-context-consumption-by-9.md
+++ b/lessons/contrib/mcp-server-that-reduces-claude-code-context-consumption-by-9.md
@@ -1,5 +1,11 @@
 ---
-{"title": "Context Mode: Reducing Claude Code Context Consumption by 98%", "domain": "ai-agents", "tags": ["mcp", "claude", "context-management", "performance"], "language": "en", "status": "published", "source": "https://mksg.lu/blog/context-mode", "created": "2026-07-28", "confidence": "0.85"}
+{
+  "{\"title\"": "Context Mode: Reducing Claude Code Context Consumption by 98%\", \"domain\": \"ai-agents\", \"tags\": [\"mcp\", \"claude\", \"context-management\", \"performance\"], \"language\": \"en\", \"status\": \"published\", \"source\": \"https://mksg.lu/blog/context-mode\", \"created\": \"2026-07-28\", \"confidence\": \"0.85\"}",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-29T09:18:36+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/mcp-tool-error-convention-inconsistency.md
+++ b/lessons/contrib/mcp-tool-error-convention-inconsistency.md
@@ -1,5 +1,11 @@
 ---
-{"title": "MCP tool ERROR convention — inconsistency between failure paths causes silent data corruption", "domain": "mcp", "tags": ["mcp", "error_handling", "convention", "git", "commit_message"], "language": "en", "status": "published", "source": "https://dev.to/enjoy_kumawat/i-gave-my-mcp-tool-an-error-convention-i-only-taught-it-to-one-of-its-two-failure-paths-4619", "created": "2026-07-29", "confidence": "0.85"}
+{
+  "{\"title\"": "MCP tool ERROR convention — inconsistency between failure paths causes silent data corruption\", \"domain\": \"mcp\", \"tags\": [\"mcp\", \"error_handling\", \"convention\", \"git\", \"commit_message\"], \"language\": \"en\", \"status\": \"published\", \"source\": \"https://dev.to/enjoy_kumawat/i-gave-my-mcp-tool-an-error-convention-i-only-taught-it-to-one-of-its-two-failure-paths-4619\", \"created\": \"2026-07-29\", \"confidence\": \"0.85\"}",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-29T09:45:21+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/mergeable-state-blocked-not-red-ci.md
+++ b/lessons/contrib/mergeable-state-blocked-not-red-ci.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "mergeable_state blocked does not mean failing CI",
-  "domain": "development",
-  "tags": [
-    "github",
-    "ci",
-    "pull-request",
-    "merge-queue",
-    "workflow"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "mergeable_state blocked does not mean failing CI\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:40:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/misakanet-heal-engine-bootstrap-workflow.md
+++ b/lessons/contrib/misakanet-heal-engine-bootstrap-workflow.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "MisakaNet --heal Engine Bootstrap Workflow",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "MisakaNet --heal Engine Bootstrap Workflow\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "MisakaNet --heal Engine Bootstrap Workflow — From Traceback to Covered Lesson", "domain": "development", "scope": "broad", "tags": ["misakanet", "heal", "bm25", "broad-only", "fixture", "coverage", "lesson-submission", "workflow", "openclaw"], "status": "published", "confidence": "0.85", "source": "Misaka10004", "created": "2026-06-23", "updated": "2026-06-23"}---

--- a/lessons/contrib/misakanet-heal-ux-gap-queue-lesson-flag-mismatch.md
+++ b/lessons/contrib/misakanet-heal-ux-gap-queue-lesson-flag-mismatch.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "MisakaNet --heal UX Gap — Suggested queue_lesson.py Command Uses Wrong Flag (--file not -f)", "domain": "development", "scope": "broad", "tags": ["misakanet", "heal", "ux", "queue-lesson", "cli", "argparse", "fixture", "openclaw", "flag-mismatch"], "status": "published", "confidence": "0.9", "source": "Misaka10004", "created": "2026-06-23", "updated": "2026-06-23"}---

--- a/lessons/contrib/misakanet-refactor-v2-review.md
+++ b/lessons/contrib/misakanet-refactor-v2-review.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "misakanet refactor v2 review",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "misakanet refactor v2 review\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "MisakaNet Refactoring复盘 — 从中心协调到 Agent 图书馆", "domain": "development", "tags": ["refactor", "architecture", "v2", "misakanet"], "status": "published", "source": "deepseek", "created": "2026-05-30 02:00:00 UTC", "updated": "2026-05-30 02:00:00 UTC"}---

--- a/lessons/contrib/model-output-fix.md
+++ b/lessons/contrib/model-output-fix.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "模型输出截断 / JSON 解析失败Handling",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "模型输出截断 / JSON 解析失败Handling\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "claude", "source": "hermes_wsl", "status": "published", "tags": "", "title": "模型输出截断 / JSON 解析失败Handling", "updated": "2026-05-01 08:00 UTC"}---

--- a/lessons/contrib/model-switch-script-pattern.md
+++ b/lessons/contrib/model-switch-script-pattern.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "多模型Switch脚本模式 — 双 Agent 模型管理",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "多模型Switch脚本模式 — 双 Agent 模型管理\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "多模型Switch脚本模式 — 双 Agent 模型管理", "confidence": "0.7", "created": "2026-05-02", "domain": "devops", "source": "bootstrap", "status": "published", "tags": ""}---

--- a/lessons/contrib/multi-forum-scraping-architecture.md
+++ b/lessons/contrib/multi-forum-scraping-architecture.md
@@ -1,4 +1,26 @@
-{"title": "Multi-Forum Scraping Architecture — API vs Playwright", "domain": "ops", "subdomain": "scraping", "tags": ["scraping", "playwright", "api", "forum", "automation", "data-collection"], "source": "practical-experience", "status": "published", "confidence": "0.9", "created": "2026-07-01", "verified_date": "", "domain_expert": ""}
+{
+  "title": "Multi-Forum Scraping Architecture — API vs Playwright",
+  "domain": "ops",
+  "subdomain": "scraping",
+  "tags": [
+    "scraping",
+    "playwright",
+    "api",
+    "forum",
+    "automation",
+    "data-collection"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.9",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-02T16:15:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 277
+}
 
 
 ## Problem

--- a/lessons/contrib/n8n-nodejs-econnreset-connection-reset-fix.md
+++ b/lessons/contrib/n8n-nodejs-econnreset-connection-reset-fix.md
@@ -1,8 +1,14 @@
 ---
-domain: "automation"
-title: "Fix Node.js ECONNRESET Connection Reset Error in n8n Webhook HTTP Requests"
-status: "published"
-{"title": "Fix Node.js ECONNRESET Connection Reset Error in n8n Webhook HTTP Requests", "domain": "automation", "tags": ["n8n", "nodejs", "econnreset", "http-request", "webhook", "networking"], "status": "published", "confidence": "0.95", "created": "2026-07-30", "updated": "2026-07-30", "source": "https://github.com/agente-gaudi/n8n-automation-workflows", "verified_date": "2026-07-30", "domain_expert": "n8n-node"}
+{
+  "domain": "automation",
+  "title": "Fix Node.js ECONNRESET Connection Reset Error in n8n Webhook HTTP Requests",
+  "status": "published",
+  "{\"title\"": "Fix Node.js ECONNRESET Connection Reset Error in n8n Webhook HTTP Requests\", \"domain\": \"automation\", \"tags\": [\"n8n\", \"nodejs\", \"econnreset\", \"http-request\", \"webhook\", \"networking\"], \"status\": \"published\", \"confidence\": \"0.95\", \"created\": \"2026-07-30\", \"updated\": \"2026-07-30\", \"source\": \"https://github.com/agente-gaudi/n8n-automation-workflows\", \"verified_date\": \"2026-07-30\", \"domain_expert\": \"n8n-node\"}",
+  "author": "agente-gaudi",
+  "source": "manual",
+  "edited_at": "2026-07-30T01:27:59-03:00",
+  "merged_by": "agente-gaudi"
+}
 ---
 
 # Fix Node.js ECONNRESET Connection Reset Error in n8n Webhook HTTP Requests

--- a/lessons/contrib/npm-eacces-permission-error-linux.md
+++ b/lessons/contrib/npm-eacces-permission-error-linux.md
@@ -1,13 +1,18 @@
 ---
-title: "npm install EACCES permission error on Linux and macOS"
-domain: "nodejs"
-tags: [npm, nodejs, permission, eacces, install]
-language: ar
-status: published
-source: "https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "npm install EACCES permission error on Linux and macOS",
+  "domain": "nodejs",
+  "tags": "[npm, nodejs, permission, eacces, install]",
+  "language": "ar",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:32:20-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/npm-native-build-arch-mismatch.md
+++ b/lessons/contrib/npm-native-build-arch-mismatch.md
@@ -1,17 +1,16 @@
 ---
 {
-  "title": "npm install failing on one host but not another (native build arch mismatch)",
-  "domain": "development",
-  "tags": [
-    "npm",
-    "node",
-    "portability",
-    "ci"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "npm install failing on one host but not another (native build arch mismatch)\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:00:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/openai-compatible-api-call.md
+++ b/lessons/contrib/openai-compatible-api-call.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "OpenAI 兼容 API 的通用调用格式",
-  "verification": "metadata-normalized",
-  "{\"title\"": "OpenAI 兼容 API 的通用调用格式\", \"domain\": \"development\", \"tags\": [\"api\", \"openai\", \"llm\", \"inference\", \"chat\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "OpenAI 兼容 API 的通用调用格式\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "OpenAI 兼容 API 的通用调用格式\\\", \\\"domain\\\": \\\"development\\\", \\\"tags\\\": [\\\"api\\\", \\\"openai\\\", \\\"llm\\\", \\\"inference\\\", \\\"chat\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/openclaw-fatal-error-hook-protocol.md
+++ b/lessons/contrib/openclaw-fatal-error-hook-protocol.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "OPENCLAW_ERROR_HANDLER — Standard protocol for CLI fatal error external hooks", "domain": "development", "tags": ["openclaw", "fatal-error", "child-process", "spawn", "argv", "shell-injection", "fire-and-forget", "protocol", "heal"], "status": "published", "confidence": "0.95", "source": "hermes_wsl2", "created": "2026-06-16", "updated": "2026-06-16"}---

--- a/lessons/contrib/openclaw-gateway-dynamic-module-missing.md
+++ b/lessons/contrib/openclaw-gateway-dynamic-module-missing.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "openclaw gateway dynamic module missing",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "openclaw gateway dynamic module missing\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "OpenClaw Gateway 动态Module Not Found — 飞书Messaging分发失败", "domain": "feishu", "subdomain": "openclaw-debug", "source": "bootstrap", "status": "published", "confidence": "1.0", "created": "2026-05-18", "tags": "node:misaka10004\", \"platform:wsl\", \"severity:critical\", \"project:misakanet"}---

--- a/lessons/contrib/openclaw-playwright-wsl-libnss3-libnspr4-snap-chromium.md
+++ b/lessons/contrib/openclaw-playwright-wsl-libnss3-libnspr4-snap-chromium.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4 - use system snap chromium as executable_path\", \"domain\": \"openclaw\", \"scope\": \"broad\", \"source\": \"openclaw-node-misaka10004\", \"status\": \"published\", \"tags\": [\"openclaw\", \"playwright\", \"chromium\", \"wsl\", \"libnss3\", \"libnspr4\", \"snap\", \"browser-automation\", \"executable_path\"], \"created\": \"2026-06-23\", \"updated\": \"2026-06-23\", \"verified_date\": \"\", \"domain_expert\": \"\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Playwright Chromium launch fails on WSL2 with missing libnss3 / libnspr4 - use system snap chromium as executable_path\\\", \\\"domain\\\": \\\"openclaw\\\", \\\"scope\\\": \\\"broad\\\", \\\"source\\\": \\\"openclaw-node-misaka10004\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"openclaw\\\", \\\"playwright\\\", \\\"chromium\\\", \\\"wsl\\\", \\\"libnss3\\\", \\\"libnspr4\\\", \\\"snap\\\", \\\"browser-automation\\\", \\\"executable_path\\\"], \\\"created\\\": \\\"2026-06-23\\\", \\\"updated\\\": \\\"2026-06-23\\\", \\\"verified_date\\\": \\\"\\\", \\\"domain_expert\\\": \\\"\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/openclaw-prefer-cli-and-policy-over-direct-edit.md
+++ b/lessons/contrib/openclaw-prefer-cli-and-policy-over-direct-edit.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "openclaw prefer cli and policy over direct edit",
-  "verification": "metadata-normalized",
-  "{\"title\"": "OpenClaw优先CLI和官方策略\", \"domain\": \"agentops\", \"tags\": [\"openclaw\", \"cli\", \"policy\", \"config\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "openclaw prefer cli and policy over direct edit\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "OpenClaw优先CLI和官方策略\\\", \\\"domain\\\": \\\"agentops\\\", \\\"tags\\\": [\\\"openclaw\\\", \\\"cli\\\", \\\"policy\\\", \\\"config\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/openclaw-reinstall-lesson.md
+++ b/lessons/contrib/openclaw-reinstall-lesson.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "OpenClaw 重装教训 — 删除前先停服务清残留",
-  "verification": "metadata-normalized",
-  "{\"title\"": "OpenClaw 重装教训 — 删除前先停服务清残留\", \"domain\": \"devops\", \"source\": \"bootstrap\", \"status\": \"published\", \"confidence\": \"0.7\", \"created\": \"2026-04-01\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-04-01\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "OpenClaw 重装教训 — 删除前先停服务清残留\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "OpenClaw 重装教训 — 删除前先停服务清残留\\\", \\\"domain\\\": \\\"devops\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"confidence\\\": \\\"0.7\\\", \\\"created\\\": \\\"2026-04-01\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-04-01\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/oss-refactor-lessons.md
+++ b/lessons/contrib/oss-refactor-lessons.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "oss refactor lessons",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "oss refactor lessons\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "开源项目Refactoring复盘 — 从功能堆砌到减法优先", "domain": "development", "tags": ["refactor", "architecture", "lessons", "open-source", "cleanup", "focus", "repository-management"], "status": "published", "source": "deepseek", "created": "2026-05-30 04:00:00 UTC", "updated": "2026-06-14 00:00:00 UTC"}---

--- a/lessons/contrib/permission-denied-fix.md
+++ b/lessons/contrib/permission-denied-fix.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Permission Denied / WSL NTFS 跨文件系统PermissionFix\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"created": "2026-05-01 08:00 UTC", "domain": "devops", "source": "hermes_wsl", "status": "published", "tags": "", "title": "Permission Denied / WSL NTFS 跨文件系统PermissionFix", "updated": "2026-05-01 08:00 UTC"}---

--- a/lessons/contrib/phase-0-output-gate.md
+++ b/lessons/contrib/phase-0-output-gate.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "phase 0 output gate",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Phase 0 Output Gate — Agent 的硬性知识检索规则\", \"domain\": \"methodology\", \"tags\": [\"output-gate\", \"knowledge-reuse\", \"methodology\", \"core\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "phase 0 output gate\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Phase 0 Output Gate — Agent 的硬性知识检索规则\\\", \\\"domain\\\": \\\"methodology\\\", \\\"tags\\\": [\\\"output-gate\\\", \\\"knowledge-reuse\\\", \\\"methodology\\\", \\\"core\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/pip-install-timeout-ssl.md
+++ b/lessons/contrib/pip-install-timeout-ssl.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "pip install Network Timeout / SSL ErrorFix",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "pip install Network Timeout / SSL ErrorFix\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "pip install Network Timeout / SSL ErrorFix", "domain": "devops", "tags": ["pip", "network", "SSL", "timeout", "proxy"]}---

--- a/lessons/contrib/postgresql-connection-pool-exhaustion-ar.md
+++ b/lessons/contrib/postgresql-connection-pool-exhaustion-ar.md
@@ -1,12 +1,22 @@
 ---
-title: "حل مشكلة استنفاد تجميع اتصالات قاعدة البيانات PostgreSQL في بيئات الإنتاج"
-domain: "database"
-tags: ["postgresql", "nodejs", "backend", "performance"]
-language: ar
-status: published
-source: "https://github.com/brianc/node-postgres/issues/1920"
-created: 2026-07-29
-confidence: 0.85
+{
+  "title": "حل مشكلة استنفاد تجميع اتصالات قاعدة البيانات PostgreSQL في بيئات الإنتاج",
+  "domain": "database",
+  "tags": [
+    "postgresql",
+    "nodejs",
+    "backend",
+    "performance"
+  ],
+  "language": "ar",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.85,
+  "author": "Skull0716",
+  "edited_at": "2026-07-29T10:46:46-06:00",
+  "merged_by": "Skull0716"
+}
 ---
 
 # حل مشكلة استنفاد تجميع اتصالات قاعدة البيانات PostgreSQL في بيئات الإنتاج

--- a/lessons/contrib/pr-strategy.md
+++ b/lessons/contrib/pr-strategy.md
@@ -1,11 +1,16 @@
 ---
-title: External PR Strategy via pr-genius
-domain: contrib
-tags: [github-pr, external-pr, pr-genius, federation]
-status: published
-source: pr-genius
-created: 2026-07-06
-updated: 2026-07-06
+{
+  "title": "External PR Strategy via pr-genius",
+  "domain": "contrib",
+  "tags": "[github-pr, external-pr, pr-genius, federation]",
+  "status": "published",
+  "source": "pr",
+  "created": "2026-07-06",
+  "updated": "2026-07-06",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-06T09:52:00+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # External PR Strategy via pr-genius

--- a/lessons/contrib/private-agent-memory-fallacy.md
+++ b/lessons/contrib/private-agent-memory-fallacy.md
@@ -1,4 +1,25 @@
-{"title": "The Private Agent Memory Fallacy — Why Portable Memory Wallets Fail", "domain": "agent", "subdomain": "memory", "tags": ["memory-wallet", "portable-memory", "privacy", "interoperability", "zep"], "source": "blog.getzep.com", "status": "published", "confidence": "0.85", "created": "2026-07-01", "verified_date": "", "domain_expert": "daniel-chalef"}
+{
+  "title": "The Private Agent Memory Fallacy — Why Portable Memory Wallets Fail",
+  "domain": "agent",
+  "subdomain": "memory",
+  "tags": [
+    "memory-wallet",
+    "portable-memory",
+    "privacy",
+    "interoperability",
+    "zep"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.85",
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "daniel-chalef",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-02T16:15:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 277
+}
 
 
 ## Problem

--- a/lessons/contrib/process-card-sequence-extraction-rules.md
+++ b/lessons/contrib/process-card-sequence-extraction-rules.md
@@ -1,19 +1,20 @@
 ---
-title: "工艺卡步序提取：辅助动作不算独立步序，按工艺动作分界"
-domain: "engineering"
-subdomain: "process-analysis"
-tags:
-  - process-card
-  - time-chart
-  - sequence
-  - cycle-time
-  - robot
-source: "zsxh1990"
-status: "published"
-confidence: "0.95"
-created: "2026-07-03"
-domain_expert: "zsxh1990"
-verified_date: "2026-07-06"
+{
+  "title": "工艺卡步序提取：辅助动作不算独立步序，按工艺动作分界",
+  "domain": "engineering",
+  "subdomain": "process-analysis",
+  "tags": "",
+  "source": "pr",
+  "status": "published",
+  "confidence": "0.95",
+  "created": "2026-07-03",
+  "domain_expert": "zsxh1990",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-07T11:58:11+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 375
+}
 ---
 
 ## Problem

--- a/lessons/contrib/promo-use-real-examples-not-hypotheticals.md
+++ b/lessons/contrib/promo-use-real-examples-not-hypotheticals.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "promo use real examples not hypotheticals",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Promo Copy — Use Real Examples, Don't Fabricate\", \"domain\": \"marketing\", \"subdomain\": \"content\", \"source\": \"Misaka10004\", \"tags\": [\"outreach\", \"content-strategy\", \"awesome-list\", \"reddit\", \"hacker-news\"], \"confidence\": \"0.9\", \"created\": \"2026-05-21\", \"domain_expert\": \"Misaka10004\", \"verified_date\": \"2026-05-21\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "promo use real examples not hypotheticals\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Promo Copy — Use Real Examples, Don't Fabricate\\\", \\\"domain\\\": \\\"marketing\\\", \\\"subdomain\\\": \\\"content\\\", \\\"source\\\": \\\"Misaka10004\\\", \\\"tags\\\": [\\\"outreach\\\", \\\"content-strategy\\\", \\\"awesome-list\\\", \\\"reddit\\\", \\\"hacker-news\\\"], \\\"confidence\\\": \\\"0.9\\\", \\\"created\\\": \\\"2026-05-21\\\", \\\"domain_expert\\\": \\\"Misaka10004\\\", \\\"verified_date\\\": \\\"2026-05-21\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/prompt-injection-what-s-the-worst-that-can-happen.md
+++ b/lessons/contrib/prompt-injection-what-s-the-worst-that-can-happen.md
@@ -1,13 +1,17 @@
 ---
 {
-  "title": "Prompt Injection: What's the Worst That Can Happen?",
-  "domain": "AI Security",
-  "tags": ["prompt injection", "LLM security", "vulnerability", "ChatGPT", "prompt leak"],
-  "language": "en",
-  "status": "published",
-  "source": "https://simonwillison.net/2023/Apr/14/worst-that-can-happen/",
-  "created": "2026-07-27",
-  "confidence": "0.85"
+  "\"title\"": "Prompt Injection: What's the Worst That Can Happen?\",",
+  "\"domain\"": "AI Security\",",
+  "\"tags\"": "[\"prompt injection\", \"LLM security\", \"vulnerability\", \"ChatGPT\", \"prompt leak\"],",
+  "\"language\"": "en\",",
+  "\"status\"": "published\",",
+  "\"source\"": "https://simonwillison.net/2023/Apr/14/worst-that-can-happen/\",",
+  "\"created\"": "2026-07-27\",",
+  "\"confidence\"": "0.85",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-27T23:01:34+08:00",
+  "merged_by": "zsxh1990"
 }
 ---
 

--- a/lessons/contrib/python-gbk-encoding-error.md
+++ b/lessons/contrib/python-gbk-encoding-error.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Python GBK Encoding Error — Windows/WSL 跨平台",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Python GBK Encoding Error — Windows/WSL 跨平台\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Python GBK Encoding Error — Windows/WSL 跨平台", "domain": "devops", "tags": ["python", "encoding", "gbk", "windows", "wsl"]}---

--- a/lessons/contrib/python-pycache-stale.md
+++ b/lessons/contrib/python-pycache-stale.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Python 代码修改不生效 — stale .pyc Cache",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Python 代码修改不生效 — stale .pyc Cache\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Python 代码修改不生效 — stale .pyc Cache", "domain": "devops", "tags": ["python", "pyc", "cache", "debug"]}---

--- a/lessons/contrib/python-sandbox-path-isolation.md
+++ b/lessons/contrib/python-sandbox-path-isolation.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离\", \"domain\": \"development\", \"tags\": [\"python\", \"sandbox\", \"path\", \"import\", \"venv\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Python 沙箱/受限环境 — PATH 和 sys.path 隔离\\\", \\\"domain\\\": \\\"development\\\", \\\"tags\\\": [\\\"python\\\", \\\"sandbox\\\", \\\"path\\\", \\\"import\\\", \\\"venv\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/python-smtplib-ssl-certificate-verify-failed-fix.md
+++ b/lessons/contrib/python-smtplib-ssl-certificate-verify-failed-fix.md
@@ -1,8 +1,14 @@
 ---
-domain: "automation"
-title: "Fix Python Smtplib SSL Certificate Verify Failed Error When Sending Emails Via Gmail"
-status: "published"
-{"title": "Fix Python Smtplib SSL Certificate Verify Failed Error When Sending Emails Via Gmail", "domain": "automation", "tags": ["python", "ssl", "smtp", "gmail", "network", "email"], "status": "published", "confidence": "0.95", "created": "2026-07-30", "updated": "2026-07-30", "source": "https://github.com/agente-gaudi/n8n-automation-workflows", "verified_date": "2026-07-30", "domain_expert": "python-net"}
+{
+  "domain": "automation",
+  "title": "Fix Python Smtplib SSL Certificate Verify Failed Error When Sending Emails Via Gmail",
+  "status": "published",
+  "{\"title\"": "Fix Python Smtplib SSL Certificate Verify Failed Error When Sending Emails Via Gmail\", \"domain\": \"automation\", \"tags\": [\"python\", \"ssl\", \"smtp\", \"gmail\", \"network\", \"email\"], \"status\": \"published\", \"confidence\": \"0.95\", \"created\": \"2026-07-30\", \"updated\": \"2026-07-30\", \"source\": \"https://github.com/agente-gaudi/n8n-automation-workflows\", \"verified_date\": \"2026-07-30\", \"domain_expert\": \"python-net\"}",
+  "author": "agente-gaudi",
+  "source": "manual",
+  "edited_at": "2026-07-30T01:17:36-03:00",
+  "merged_by": "agente-gaudi"
+}
 ---
 
 # Fix Python Smtplib SSL Certificate Verify Failed Error When Sending Emails Via Gmail

--- a/lessons/contrib/python-venv-tiktoken-module-not-found.md
+++ b/lessons/contrib/python-venv-tiktoken-module-not-found.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError\", \"domain\": \"development\", \"source\": \"Misaka10019\", \"tags\": [\"python\", \"venv\", \"tiktoken\", \"pip\", \"setuptools\"], \"domain_expert\": \"Misaka10019\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Python venv 中 tiktoken 安装后仍报 ModuleNotFoundError\\\", \\\"domain\\\": \\\"development\\\", \\\"source\\\": \\\"Misaka10019\\\", \\\"tags\\\": [\\\"python\\\", \\\"venv\\\", \\\"tiktoken\\\", \\\"pip\\\", \\\"setuptools\\\"], \\\"domain_expert\\\": \\\"Misaka10019\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/python-venv-troubleshoot.md
+++ b/lessons/contrib/python-venv-troubleshoot.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Python venv 激活失败或路径不匹配",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Python venv 激活失败或路径不匹配\", \"domain\": \"devops\", \"tags\": [\"python\", \"venv\", \"virtualenv\", \"path\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Python venv 激活失败或路径不匹配\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Python venv 激活失败或路径不匹配\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"python\\\", \\\"venv\\\", \\\"virtualenv\\\", \\\"path\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/rag-alarm-code-mandatory-recall.md
+++ b/lessons/contrib/rag-alarm-code-mandatory-recall.md
@@ -1,19 +1,23 @@
 ---
 {
-  "title": "RAG Alarm Code Retrieval Needs Mandatory Keyword Recall",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "tags": [
-    "project:self-grow-wiki",
-    "severity:high",
-    "node:hermes-wsl"
-  ],
-  "language": "en",
-  "created": "2026-05-03",
-  "domain_expert": "bootstrap",
-  "verified_date": "2026-05-03",
-  "subdomain": "fanuc"
+  "\"title\"": "RAG Alarm Code Retrieval Needs Mandatory Keyword Recall\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"severity": "high\",",
+  "\"node": "hermes-wsl",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-05-03\",",
+  "\"domain_expert\"": "bootstrap\",",
+  "\"verified_date\"": "2026-05-03\",",
+  "\"subdomain\"": "fanuc",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/rag-brand-contamination-detection-and-fix.md
+++ b/lessons/contrib/rag-brand-contamination-detection-and-fix.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "RAG 知识库品牌污染Detection与治理",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "RAG 知识库品牌污染Detection与治理\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "RAG 知识库品牌污染Detection与治理", "domain": "rag", "tags": ["rag", "chromadb", "brand-contamination", "data-quality", "metadata"], "confidence": 0.9, "created": "2026-05-29"}---

--- a/lessons/contrib/rag-brand-filter-three-pitfalls.md
+++ b/lessons/contrib/rag-brand-filter-three-pitfalls.md
@@ -1,16 +1,20 @@
 ---
 {
-  "title": "RAG Brand Filter Three Pitfalls",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "language": "en",
-  "tags": [
-    "project:self-grow-wiki",
-    "severity:medium",
-    "node:hermes-wsl"
-  ],
-  "created": "2026-07-06"
+  "\"title\"": "RAG Brand Filter Three Pitfalls\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"language\"": "en\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"severity": "medium\",",
+  "\"node": "hermes-wsl",
+  "\"created\"": "2026-07-06",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/rag-build-strategy-batch.md
+++ b/lessons/contrib/rag-build-strategy-batch.md
@@ -1,18 +1,22 @@
 ---
 {
-  "title": "RAG Build Strategy Batch",
-  "domain": "rag",
-  "source": "hanged-man",
-  "status": "published",
-  "tags": [
-    "project:self-grow-wiki",
-    "severity:medium",
-    "node:hermes-wsl"
-  ],
-  "language": "en",
-  "created": "2026-04-13",
-  "domain_expert": "hanged-man",
-  "verified_date": "2026-04-13"
+  "\"title\"": "RAG Build Strategy Batch\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "hanged-man\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"severity": "medium\",",
+  "\"node": "hermes-wsl",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-04-13\",",
+  "\"domain_expert\"": "hanged-man\",",
+  "\"verified_date\"": "2026-04-13",
+  "author": "2lll5",
+  "source": "pr",
+  "edited_at": "2026-06-30T14:39:15+08:00",
+  "merged_by": "2lll5",
+  "pr": 263
 }
 ---
 

--- a/lessons/contrib/rag-chinese-encoding-pymupdf.md
+++ b/lessons/contrib/rag-chinese-encoding-pymupdf.md
@@ -1,16 +1,20 @@
 ---
 {
-  "title": "RAG Chinese Encoding with PyMuPDF",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "language": "en",
-  "tags": [
-    "project:self-grow-wiki",
-    "severity:medium",
-    "node:hermes-wsl"
-  ],
-  "created": "2026-07-06"
+  "\"title\"": "RAG Chinese Encoding with PyMuPDF\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"language\"": "en\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"severity": "medium\",",
+  "\"node": "hermes-wsl",
+  "\"created\"": "2026-07-06",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/rag-chunk-params-800-100.md
+++ b/lessons/contrib/rag-chunk-params-800-100.md
@@ -1,19 +1,23 @@
 ---
 {
-  "title": "RAG Chunk Parameters 800 Characters and 100 Overlap",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "tags": [
-    "project:self-grow-wiki",
-    "severity:medium",
-    "node:hermes-wsl"
-  ],
-  "language": "en",
-  "created": "2026-05-03",
-  "domain_expert": "bootstrap",
-  "verified_date": "2026-05-03",
-  "subdomain": "chunking"
+  "\"title\"": "RAG Chunk Parameters 800 Characters and 100 Overlap\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"severity": "medium\",",
+  "\"node": "hermes-wsl",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-05-03\",",
+  "\"domain_expert\"": "bootstrap\",",
+  "\"verified_date\"": "2026-05-03\",",
+  "\"subdomain\"": "chunking",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/rag-cross-encoder-cpu-bottleneck.md
+++ b/lessons/contrib/rag-cross-encoder-cpu-bottleneck.md
@@ -1,14 +1,28 @@
 ---
-title: Cross-encoder reranker kills RAG latency on CPU-only machines
-domain: rag
-subdomain: reranking
-tags: ["rag", "cross-encoder", "reranking", "cpu-bottleneck", "latency", "bge-reranker", "performance"]
-status: published
-confidence: 0.9
-created: 2026-07-06
-updated: 2026-07-06
-source: zsxh1990
-verified_date: 2026-07-06
+{
+  "title": "Cross-encoder reranker kills RAG latency on CPU-only machines",
+  "domain": "rag",
+  "subdomain": "reranking",
+  "tags": [
+    "rag",
+    "cross-encoder",
+    "reranking",
+    "cpu-bottleneck",
+    "latency",
+    "bge-reranker",
+    "performance"
+  ],
+  "status": "published",
+  "confidence": 0.9,
+  "created": "2026-07-06",
+  "updated": "2026-07-06",
+  "source": "pr",
+  "verified_date": "2026-07-06",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 # Cross-encoder reranker kills RAG latency on CPU-only machines

--- a/lessons/contrib/rag-kb-quality-flywheel-self-loop.md
+++ b/lessons/contrib/rag-kb-quality-flywheel-self-loop.md
@@ -1,21 +1,19 @@
 ---
 {
-  "title": "RAG Knowledge Base Quality Flywheel Self Loop",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "tags": [
-    "rag",
-    "flywheel",
-    "quality",
-    "audit",
-    "feedback",
-    "self-learning"
-  ],
-  "language": "en",
-  "created": "2026-05-21",
-  "domain_expert": "unknown",
-  "verified_date": "2026-05-21"
+  "\"title\"": "RAG Knowledge Base Quality Flywheel Self Loop\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-05-21\",",
+  "\"domain_expert\"": "unknown\",",
+  "\"verified_date\"": "2026-05-21",
+  "author": "GoThundercats",
+  "source": "pr",
+  "edited_at": "2026-07-06T09:29:40+08:00",
+  "merged_by": "GoThundercats",
+  "pr": 348
 }
 ---
 

--- a/lessons/contrib/rag-three-channel-llm-disaster-recovery.md
+++ b/lessons/contrib/rag-three-channel-llm-disaster-recovery.md
@@ -1,19 +1,23 @@
 ---
 {
-  "title": "RAG Three-Channel LLM Disaster Recovery",
-  "domain": "rag",
-  "source": "bootstrap",
-  "status": "published",
-  "tags": [
-    "project:self-grow-wiki",
-    "node:hermes-wsl",
-    "scope:broad"
-  ],
-  "language": "en",
-  "created": "2026-05-03",
-  "domain_expert": "bootstrap",
-  "verified_date": "2026-05-03",
-  "subdomain": "llm"
+  "\"title\"": "RAG Three-Channel LLM Disaster Recovery\",",
+  "\"domain\"": "rag\",",
+  "\"source\"": "bootstrap\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"project": "self-grow-wiki\",",
+  "\"node": "hermes-wsl\",",
+  "\"scope": "broad",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-05-03\",",
+  "\"domain_expert\"": "bootstrap\",",
+  "\"verified_date\"": "2026-05-03\",",
+  "\"subdomain\"": "llm",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/rdt-cli-reddit-terminal.md
+++ b/lessons/contrib/rdt-cli-reddit-terminal.md
@@ -1,14 +1,26 @@
 ---
-title: rdt-cli — Reddit in Your Terminal (Reverse-Engineered API)
-domain: ops
-subdomain: scraping
-tags: ["rdt-cli", "reddit", "scraping", "cli", "anti-detection"]
-source: github.com/public-clis/rdt-cli
-status: published
-confidence: 0.85
-created: 2026-07-01
-verified_date: 
-domain_expert: 
+{
+  "title": "rdt-cli — Reddit in Your Terminal (Reverse-Engineered API)",
+  "domain": "ops",
+  "subdomain": "scraping",
+  "tags": [
+    "rdt-cli",
+    "reddit",
+    "scraping",
+    "cli",
+    "anti-detection"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/readme-seven-traps-fix-checklist.md
+++ b/lessons/contrib/readme-seven-traps-fix-checklist.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "开源项目 README Optimization — 7 个常见Pitfalls与Fix Checklist", "domain": "development", "tags": ["readme", "open-source", "documentation", "marketing", "community"], "status": "published", "source": "deepseek", "created": "2026-06-04 00:00:00 UTC", "updated": "2026-06-04 00:00:00 UTC"}---

--- a/lessons/contrib/regex-escaped-quotes-source-parsing.md
+++ b/lessons/contrib/regex-escaped-quotes-source-parsing.md
@@ -1,16 +1,17 @@
 ---
-title: "正则陷阱 — 源码中转义引号导致非贪婪匹配提前终止"
-domain: development
-tags:
-  - regex
-  - python
-  - source-parsing
-  - escape-sequences
-  - debug
-status: published
-source: practical-experience
-confidence: 0.9
-created: 2026-07-07
+{
+  "title": "正则陷阱 — 源码中转义引号导致非贪婪匹配提前终止",
+  "domain": "development",
+  "tags": "",
+  "status": "published",
+  "source": "pr",
+  "confidence": 0.9,
+  "created": "2026-07-07",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-08T17:09:01+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 415
+}
 ---
 
 ## Problem

--- a/lessons/contrib/regex-greedy-matching.md
+++ b/lessons/contrib/regex-greedy-matching.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "正则表达式 debugging — 贪婪匹配造成的意外结果",
-  "verification": "metadata-normalized",
-  "{\"title\"": "正则表达式 debugging — 贪婪匹配造成的意外结果\", \"domain\": \"development\", \"tags\": [\"regex\", \"debug\", \"greedy\", \"pattern\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "正则表达式 debugging — 贪婪匹配造成的意外结果\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "正则表达式 debugging — 贪婪匹配造成的意外结果\\\", \\\"domain\\\": \\\"development\\\", \\\"tags\\\": [\\\"regex\\\", \\\"debug\\\", \\\"greedy\\\", \\\"pattern\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/registration-chain-worker-fallback.md
+++ b/lessons/contrib/registration-chain-worker-fallback.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow",
-  "verification": "metadata-normalized",
-  "{\"title\"": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow\", \"domain\": \"devops\", \"tags\": [\"registration\", \"worker\", \"register\", \"github-actions\", \"feishu\", \"fallback\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "注册链路设计 — Worker 只创建 Issue，其余交给 Workflow\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"registration\\\", \\\"worker\\\", \\\"register\\\", \\\"github-actions\\\", \\\"feishu\\\", \\\"fallback\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/repository-traffic-is-not-lesson-use.md
+++ b/lessons/contrib/repository-traffic-is-not-lesson-use.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "growth",
-  "title": "Repository Traffic Is Not Lesson Use",
-  "tags": ["analytics", "growth", "feedback", "lessons", "metrics"],
-  "status": "published",
-  "source": "generalized repository traffic analysis",
-  "created": "2026-07-17",
-  "confidence": "0.90"
+  "\"domain\"": "growth\",",
+  "\"title\"": "Repository Traffic Is Not Lesson Use\",",
+  "\"tags\"": "[\"analytics\", \"growth\", \"feedback\", \"lessons\", \"metrics\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "generalized repository traffic analysis\",",
+  "\"created\"": "2026-07-17\",",
+  "\"confidence\"": "0.90",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-07-17T01:09:07+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/rescue-cards-for-non-github-users.md
+++ b/lessons/contrib/rescue-cards-for-non-github-users.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "ux",
-  "title": "When Lessons Are Too Heavy, Use Rescue Cards",
-  "tags": ["ux", "support", "lessons", "rescue", "feedback"],
-  "status": "published",
-  "source": "generalized support-feedback analysis",
-  "created": "2026-07-17",
-  "confidence": "0.88"
+  "\"domain\"": "ux\",",
+  "\"title\"": "When Lessons Are Too Heavy, Use Rescue Cards\",",
+  "\"tags\"": "[\"ux\", \"support\", \"lessons\", \"rescue\", \"feedback\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "generalized support-feedback analysis\",",
+  "\"created\"": "2026-07-17\",",
+  "\"confidence\"": "0.88",
+  "author": "Ikalus1988",
+  "source": "rescue",
+  "edited_at": "2026-07-17T01:09:07+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/sag-lite-data-quality-cleaning.md
+++ b/lessons/contrib/sag-lite-data-quality-cleaning.md
@@ -1,10 +1,22 @@
 ---
-title: "SAG-Lite Data Quality: Clean Search Results"
-domain: devops
-tags: ["search", "sqlite", "fts5", "data-quality", "misakanet"]
-status: published
-source: agent_experience
-created: 2026-07-02
+{
+  "title": "SAG-Lite Data Quality: Clean Search Results",
+  "domain": "devops",
+  "tags": [
+    "search",
+    "sqlite",
+    "fts5",
+    "data-quality",
+    "misakanet"
+  ],
+  "status": "published",
+  "source": "pr",
+  "created": "2026-07-02",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 ---
 

--- a/lessons/contrib/schema-coupled-cross-repo-ci.md
+++ b/lessons/contrib/schema-coupled-cross-repo-ci.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "Schemas coupled across repos break CI until the counterpart PR merges",
-  "domain": "development",
-  "tags": [
-    "schema",
-    "ci",
-    "pr",
-    "validation",
-    "maintenance"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "Schemas coupled across repos break CI until the counterpart PR merges\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:15:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/scrapling-installation-and-usage.md
+++ b/lessons/contrib/scrapling-installation-and-usage.md
@@ -1,14 +1,26 @@
 ---
-title: Scrapling — Web Scraping Library with Anti-Detection
-domain: ops
-subdomain: scraping
-tags: ["scrapling", "scraping", "curl-cffi", "playwright", "anti-detection"]
-source: github.com/D4Vinci/Scrapling
-status: published
-confidence: 0.8
-created: 2026-07-01
-verified_date: 
-domain_expert: 
+{
+  "title": "Scrapling — Web Scraping Library with Anti-Detection",
+  "domain": "ops",
+  "subdomain": "scraping",
+  "tags": [
+    "scrapling",
+    "scraping",
+    "curl-cffi",
+    "playwright",
+    "anti-detection"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.8,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/search-quota-exhaustion-false-zero.md
+++ b/lessons/contrib/search-quota-exhaustion-false-zero.md
@@ -1,4 +1,24 @@
-{"title": "Search Quota Exhaustion Causes False Zero Results", "domain": "devops", "source": "MisakaNet local search testing", "status": "draft", "tags": ["search", "quota", "rate-limit", "misleading-error", "debugging"], "created": "2026-07-10 00:00:00 UTC", "updated": "2026-07-10 00:00:00 UTC", "confidence": "0.95", "verified_date": "2026-07-10"}
+{
+  "title": "Search Quota Exhaustion Causes False Zero Results",
+  "domain": "devops",
+  "source": "pr",
+  "status": "draft",
+  "tags": [
+    "search",
+    "quota",
+    "rate-limit",
+    "misleading-error",
+    "debugging"
+  ],
+  "created": "2026-07-10 00:00:00 UTC",
+  "updated": "2026-07-10 00:00:00 UTC",
+  "confidence": "0.95",
+  "verified_date": "2026-07-10",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:08+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 267
+}
 
 ## Verification
 

--- a/lessons/contrib/search-smart-fallback-implementation.md
+++ b/lessons/contrib/search-smart-fallback-implementation.md
@@ -1,13 +1,25 @@
 ---
-title: Search Smart Fallback — Turning Zero Results into Discovery
-domain: devops
-source: MisakaNet search_knowledge.py enhancement
-status: draft
-tags: ["search", "fallback", "ux", "zero-results", "discovery"]
-created: "2026-07-10 00:00:00 UTC"
-updated: "2026-07-10 00:00:00 UTC"
-confidence: 0.95
-verified_date: 2026-07-10
+{
+  "title": "Search Smart Fallback — Turning Zero Results into Discovery",
+  "domain": "devops",
+  "source": "pr",
+  "status": "draft",
+  "tags": [
+    "search",
+    "fallback",
+    "ux",
+    "zero-results",
+    "discovery"
+  ],
+  "created": "2026-07-10 00:00:00 UTC",
+  "updated": "2026-07-10 00:00:00 UTC",
+  "confidence": 0.95,
+  "verified_date": "2026-07-10",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ## Verification

--- a/lessons/contrib/search-ssot-data-source-pollution-fix.md
+++ b/lessons/contrib/search-ssot-data-source-pollution-fix.md
@@ -1,11 +1,16 @@
 ---
-title: "Search SSOT: Fixing Data Source Pollution in Static-Deployed Sites"
-domain: devops
-tags: [search, ssot, data-source, static-site, worker, github-pages, frontend]
-status: published
-source: misakanet
-created: 2026-07-10
-updated: 2026-07-10
+{
+  "title": "Search SSOT: Fixing Data Source Pollution in Static-Deployed Sites",
+  "domain": "devops",
+  "tags": "[search, ssot, data-source, static-site, worker, github-pages, frontend]",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-10",
+  "updated": "2026-07-10",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-10T17:56:48+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # Search SSOT: Fixing Data Source Pollution

--- a/lessons/contrib/session-lesson-1-content-quality-scoring.md
+++ b/lessons/contrib/session-lesson-1-content-quality-scoring.md
@@ -1,4 +1,26 @@
-{"title": "Content Quality Scoring System — Automated Lesson Evaluation", "domain": "ops", "subdomain": "automation", "tags": ["quality", "scoring", "automation", "content", "evaluation", "rubric"], "source": "practical-experience", "status": "published", "confidence": 0.95, "created": "2026-07-02", "verified_date": "", "domain_expert": ""}
+{
+  "title": "Content Quality Scoring System — Automated Lesson Evaluation",
+  "domain": "ops",
+  "subdomain": "automation",
+  "tags": [
+    "quality",
+    "scoring",
+    "automation",
+    "content",
+    "evaluation",
+    "rubric"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.95,
+  "created": "2026-07-02",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-02T16:15:59+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 277
+}
 
 ## Problem
 

--- a/lessons/contrib/session-lesson-2-forum-accessibility-testing.md
+++ b/lessons/contrib/session-lesson-2-forum-accessibility-testing.md
@@ -1,14 +1,27 @@
 ---
-title: Forum Accessibility Testing — Systematic Reachability Check
-domain: ops
-subdomain: scraping
-tags: ["scraping", "accessibility", "forum", "testing", "network", "automation"]
-source: practical-experience
-status: published
-confidence: 0.9
-created: 2026-07-02
-verified_date: 
-domain_expert: 
+{
+  "title": "Forum Accessibility Testing — Systematic Reachability Check",
+  "domain": "ops",
+  "subdomain": "scraping",
+  "tags": [
+    "scraping",
+    "accessibility",
+    "forum",
+    "testing",
+    "network",
+    "automation"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.9,
+  "created": "2026-07-02",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ## Problem

--- a/lessons/contrib/session-lesson-3-lobsters-json-api.md
+++ b/lessons/contrib/session-lesson-3-lobsters-json-api.md
@@ -1,14 +1,27 @@
 ---
-title: Lobsters JSON API — Structured Tech Forum Scraping
-domain: ops
-subdomain: scraping
-tags: ["lobsters", "api", "scraping", "json", "forum", "security"]
-source: practical-experience
-status: published
-confidence: 0.9
-created: 2026-07-02
-verified_date: 
-domain_expert: 
+{
+  "title": "Lobsters JSON API — Structured Tech Forum Scraping",
+  "domain": "ops",
+  "subdomain": "scraping",
+  "tags": [
+    "lobsters",
+    "api",
+    "scraping",
+    "json",
+    "forum",
+    "security"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.9,
+  "created": "2026-07-02",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ## Problem

--- a/lessons/contrib/session-lesson-4-playwright-forum-selectors.md
+++ b/lessons/contrib/session-lesson-4-playwright-forum-selectors.md
@@ -1,14 +1,26 @@
 ---
-title: Playwright Forum Selectors — WoltLab/IPS/Common Patterns
-domain: ops
-subdomain: scraping
-tags: ["playwright", "scraping", "selectors", "forum", "automation"]
-source: practical-experience
-status: published
-confidence: 0.85
-created: 2026-07-02
-verified_date: 
-domain_expert: 
+{
+  "title": "Playwright Forum Selectors — WoltLab/IPS/Common Patterns",
+  "domain": "ops",
+  "subdomain": "scraping",
+  "tags": [
+    "playwright",
+    "scraping",
+    "selectors",
+    "forum",
+    "automation"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.85,
+  "created": "2026-07-02",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 ## Problem

--- a/lessons/contrib/shared-json-needs-atomic-write.md
+++ b/lessons/contrib/shared-json-needs-atomic-write.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "shared json needs atomic write",
-  "verification": "metadata-normalized",
-  "{\"title\"": "共享JSON状态需要原子写入\", \"domain\": \"devops\", \"tags\": [\"json\", \"atomic\", \"race-condition\", \"runtime\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "shared json needs atomic write\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "共享JSON状态需要原子写入\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"json\\\", \\\"atomic\\\", \\\"race-condition\\\", \\\"runtime\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/shell-script-debugging.md
+++ b/lessons/contrib/shell-script-debugging.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Shell Debugging — set -x 与常见Pitfalls",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Shell Debugging — set -x 与常见Pitfalls\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Shell Debugging — set -x 与常见Pitfalls", "domain": "development", "tags": ["shell", "bash", "debug", "script"]}---

--- a/lessons/contrib/slugify-path-traversal-deep-coverage.md
+++ b/lessons/contrib/slugify-path-traversal-deep-coverage.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "slugify path traversal deep coverage",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Slugify: deep coverage of path traversal, null bytes, and reserved names\", \"domain\": \"scripts\", \"tags\": [\"slugify\", \"path-traversal\", \"windows-reserved\", \"null-byte\", \"test-coverage\", \"hardening\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "slugify path traversal deep coverage\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Slugify: deep coverage of path traversal, null bytes, and reserved names\\\", \\\"domain\\\": \\\"scripts\\\", \\\"tags\\\": [\\\"slugify\\\", \\\"path-traversal\\\", \\\"windows-reserved\\\", \\\"null-byte\\\", \\\"test-coverage\\\", \\\"hardening\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/slugify-windows-path-sanitation.md
+++ b/lessons/contrib/slugify-windows-path-sanitation.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "slugify windows path sanitation",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Slugify filename sanitation crash on Windows and WSL\", \"domain\": \"scripts\", \"tags\": [\"slugify\", \"windows\", \"wsl\", \"sanitation\", \"path-errors\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "slugify windows path sanitation\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Slugify filename sanitation crash on Windows and WSL\\\", \\\"domain\\\": \\\"scripts\\\", \\\"tags\\\": [\\\"slugify\\\", \\\"windows\\\", \\\"wsl\\\", \\\"sanitation\\\", \\\"path-errors\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/squash-rebase-force-push-lease.md
+++ b/lessons/contrib/squash-rebase-force-push-lease.md
@@ -1,18 +1,16 @@
 ---
 {
-  "title": "Squash-rebase rewrites the patch base and breaks force-push expectations",
-  "domain": "development",
-  "tags": [
-    "git",
-    "rebase",
-    "squash",
-    "force-push",
-    "collaboration"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "Squash-rebase rewrites the patch base and breaks force-push expectations\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:55:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/ssh-host-key-verification-failed.md
+++ b/lessons/contrib/ssh-host-key-verification-failed.md
@@ -1,13 +1,18 @@
 ---
-title: "SSH host key verification failed when connecting to a remote server"
-domain: "devops"
-tags: [ssh, host-key, verification, remote, security]
-language: ja
-status: published
-source: "https://docs.github.com/en/authentication/troubleshooting-ssh/error-host-key-verification-failed"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "SSH host key verification failed when connecting to a remote server",
+  "domain": "devops",
+  "tags": "[ssh, host-key, verification, remote, security]",
+  "language": "ja",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:32:01-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/static-page-github-api-403-rate-limit.md
+++ b/lessons/contrib/static-page-github-api-403-rate-limit.md
@@ -1,11 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "static page github api 403 rate limit",
-  "verification": "metadata-normalized",
-  "{\"title\"": "静态页面调用外部 API 的容错设计原则\", \"domain\": \"frontend\", \"tags\": [\"api\", \"rate-limit\", \"static-site\", \"error-handling\", \"fault-tolerance\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "static page github api 403 rate limit\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "静态页面调用外部 API 的容错设计原则\\\", \\\"domain\\\": \\\"frontend\\\", \\\"tags\\\": [\\\"api\\\", \\\"rate-limit\\\", \\\"static-site\\\", \\\"error-handling\\\", \\\"fault-tolerance\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:21:02+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 

--- a/lessons/contrib/static-page-width-consistency.md
+++ b/lessons/contrib/static-page-width-consistency.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "static page width consistency",
-  "verification": "metadata-normalized",
-  "{\"title\"": "静态页面多组件宽度一致性——各自定义 max-width 导致视觉割裂\", \"domain\": \"frontend\", \"tags\": [\"css\", \"layout\", \"ux\", \"responsive\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "static page width consistency\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "静态页面多组件宽度一致性——各自定义 max-width 导致视觉割裂\\\", \\\"domain\\\": \\\"frontend\\\", \\\"tags\\\": [\\\"css\\\", \\\"layout\\\", \\\"ux\\\", \\\"responsive\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/supabase-capacity-constraints-project-operations.md
+++ b/lessons/contrib/supabase-capacity-constraints-project-operations.md
@@ -1,20 +1,18 @@
 ---
 {
-  "title": "Supabase capacity constraints caused project operation failures",
-  "domain": "database",
-  "tags": [
-    "incident",
-    "postmortem",
-    "capacity",
-    "supabase",
-    "database",
-    "operations"
-  ],
-  "status": "published",
-  "source": "hackernews",
-  "source_url": "https://status.supabase.com/incidents/3tx3nnmbwyh9",
-  "language": "en",
-  "created": "2026-07-06"
+  "\"title\"": "Supabase capacity constraints caused project operation failures\",",
+  "\"domain\"": "database\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"source\"": "hackernews\",",
+  "\"source_url\"": "https://status.supabase.com/incidents/3tx3nnmbwyh9\",",
+  "\"language\"": "en\",",
+  "\"created\"": "2026-07-06",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/superteam-earn-api-insufficient-credits.md
+++ b/lessons/contrib/superteam-earn-api-insufficient-credits.md
@@ -1,12 +1,16 @@
 ---
 {
-  "title": "Superteam Earn API returns Insufficient credits on submission create",
-  "domain": "web3",
-  "tags": ["superteam", "earn", "api", "credits", "bounty", "http-403"],
-  "status": "published",
-  "source": "uncledad96-glitch",
-  "created": "2026-07-20",
-  "updated": "2026-07-20"
+  "\"title\"": "Superteam Earn API returns Insufficient credits on submission create\",",
+  "\"domain\"": "web3\",",
+  "\"tags\"": "[\"superteam\", \"earn\", \"api\", \"credits\", \"bounty\", \"http-403\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "uncledad96-glitch\",",
+  "\"created\"": "2026-07-20\",",
+  "\"updated\"": "2026-07-20",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:16:40+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 

--- a/lessons/contrib/swarm-pr-battle-playbook.md
+++ b/lessons/contrib/swarm-pr-battle-playbook.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "Swarm PR Battle Playbook — Shipping env-var error hooks through AI-reviewed upstreams", "domain": "development", "tags": ["pr", "ai-review", "github-actions", "fatal-error", "spawn", "shell-injection", "esm", "ci", "playbook", "sop"], "status": "published", "confidence": "0.95", "source": "hermes_wsl2", "created": "2026-06-17", "updated": "2026-06-17"}---

--- a/lessons/contrib/taskbounty-payout-api-ok-readiness-still-fail.md
+++ b/lessons/contrib/taskbounty-payout-api-ok-readiness-still-fail.md
@@ -1,12 +1,16 @@
 ---
 {
-  "title": "TaskBounty payout POST succeeds but solver_readiness still fails",
-  "domain": "web3",
-  "tags": ["taskbounty", "payout", "api", "readiness", "solana", "usdc"],
-  "status": "published",
-  "source": "uncledad96-glitch",
-  "created": "2026-07-20",
-  "updated": "2026-07-20"
+  "\"title\"": "TaskBounty payout POST succeeds but solver_readiness still fails\",",
+  "\"domain\"": "web3\",",
+  "\"tags\"": "[\"taskbounty\", \"payout\", \"api\", \"readiness\", \"solana\", \"usdc\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "uncledad96-glitch\",",
+  "\"created\"": "2026-07-20\",",
+  "\"updated\"": "2026-07-20",
+  "author": "uncledad96-glitch",
+  "source": "manual",
+  "edited_at": "2026-07-20T23:18:49+02:00",
+  "merged_by": "uncledad96-glitch"
 }
 ---
 

--- a/lessons/contrib/testimonio-misakanet.md
+++ b/lessons/contrib/testimonio-misakanet.md
@@ -1,7 +1,13 @@
 ---
-title: "Testimonio: MisakaNet me ayudo a resolver ModuleNotFoundError"
-domain: devops
-evidence_level: E1
+{
+  "title": "Testimonio: MisakaNet me ayudo a resolver ModuleNotFoundError",
+  "domain": "devops",
+  "evidence_level": "E1",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-08-13T00:39:45+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # Testimonio: MisakaNet me ayudo a resolver ModuleNotFoundError

--- a/lessons/contrib/tmux-session-management.md
+++ b/lessons/contrib/tmux-session-management.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "tmux 终端复用 — 断开不丢失会话",
-  "verification": "metadata-normalized",
-  "{\"title\"": "tmux 终端复用 — 断开不丢失会话\", \"domain\": \"development\", \"tags\": [\"tmux\", \"terminal\", \"session\", \"background\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "tmux 终端复用 — 断开不丢失会话\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "tmux 终端复用 — 断开不丢失会话\\\", \\\"domain\\\": \\\"development\\\", \\\"tags\\\": [\\\"tmux\\\", \\\"terminal\\\", \\\"session\\\", \\\"background\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/tor-orbot-privacy-in-react-native-tr.md
+++ b/lessons/contrib/tor-orbot-privacy-in-react-native-tr.md
@@ -1,14 +1,19 @@
 ---
-title: "React Native uygulamasında Orbot (Tor) ile gizlilik akışı"
-domain: "mobile"
-tags: [tor, orbot, react-native, privacy, proxy, network, node:hermes-bounty-agent]
-language: tr
-status: published
-source: "https://guardianproject.info/apps/org.torproject.android/"
-created: 2026-08-01
-verified_date: 2026-08-01
-confidence: 0.93
-node_id: "hermes-bounty-agent"
+{
+  "title": "React Native uygulamasında Orbot (Tor) ile gizlilik akışı",
+  "domain": "mobile",
+  "tags": "[tor, orbot, react-native, privacy, proxy, network, node:hermes-bounty-agent]",
+  "language": "tr",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-08-01",
+  "verified_date": "2026-08-01",
+  "confidence": 0.93,
+  "node_id": "hermes-bounty-agent",
+  "author": "Rerzx",
+  "edited_at": "2026-08-01T03:58:53-05:00",
+  "merged_by": "Rerzx"
+}
 ---
 
 # React Native uygulamasında Orbot (Tor) ile gizlilik akışı

--- a/lessons/contrib/tts-chinese-encoding-powershell.md
+++ b/lessons/contrib/tts-chinese-encoding-powershell.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "tts chinese encoding powershell",
-  "verification": "metadata-normalized",
-  "{\"title\"": "TTS 中文编码：PowerShell 传参必须用 .txt 文件中转\", \"domain\": \"tts\", \"tags\": \"\", \"source\": \"hanged-man\", \"status\": \"published\", \"created\": \"2026-04-18\", \"confidence\": \"0.9\", \"scope\": \"broad\", \"domain_expert\": \"hanged-man\", \"verified_date\": \"2026-04-18\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "tts chinese encoding powershell\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "TTS 中文编码：PowerShell 传参必须用 .txt 文件中转\\\", \\\"domain\\\": \\\"tts\\\", \\\"tags\\\": \\\"\\\", \\\"source\\\": \\\"hanged-man\\\", \\\"status\\\": \\\"published\\\", \\\"created\\\": \\\"2026-04-18\\\", \\\"confidence\\\": \\\"0.9\\\", \\\"scope\\\": \\\"broad\\\", \\\"domain_expert\\\": \\\"hanged-man\\\", \\\"verified_date\\\": \\\"2026-04-18\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/two-evidence-loops-for-failure-lessons.md
+++ b/lessons/contrib/two-evidence-loops-for-failure-lessons.md
@@ -1,12 +1,16 @@
 ---
 {
-  "domain": "growth",
-  "title": "Two Evidence Loops for Failure Lessons",
-  "tags": ["evidence", "lessons", "reuse", "growth", "feedback"],
-  "status": "published",
-  "source": "generalized maintainer retrospective",
-  "created": "2026-07-17",
-  "confidence": "0.90"
+  "\"domain\"": "growth\",",
+  "\"title\"": "Two Evidence Loops for Failure Lessons\",",
+  "\"tags\"": "[\"evidence\", \"lessons\", \"reuse\", \"growth\", \"feedback\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "generalized maintainer retrospective\",",
+  "\"created\"": "2026-07-17\",",
+  "\"confidence\"": "0.90",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-07-17T01:09:07+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/typescript-solution-tsconfig-silent-nocheck.md
+++ b/lessons/contrib/typescript-solution-tsconfig-silent-nocheck.md
@@ -1,5 +1,11 @@
 ---
-{"title": "TypeScript solution-style tsconfig — tsc --noEmit checks nothing silently", "domain": "typescript", "tags": ["typescript", "tsconfig", "type_checking", "ci", "build"], "language": "en", "status": "published", "source": "https://dev.to/henry_dan_81513dd35a2f540/it-passed-because-it-never-looked-552l", "created": "2026-07-29", "confidence": "0.90"}
+{
+  "{\"title\"": "TypeScript solution-style tsconfig — tsc --noEmit checks nothing silently\", \"domain\": \"typescript\", \"tags\": [\"typescript\", \"tsconfig\", \"type_checking\", \"ci\", \"build\"], \"language\": \"en\", \"status\": \"published\", \"source\": \"https://dev.to/henry_dan_81513dd35a2f540/it-passed-because-it-never-looked-552l\", \"created\": \"2026-07-29\", \"confidence\": \"0.90\"}",
+  "author": "zsxh1990",
+  "source": "manual",
+  "edited_at": "2026-07-29T09:45:21+08:00",
+  "merged_by": "zsxh1990"
+}
 ---
 
 ## Problem

--- a/lessons/contrib/usdc-base-units-vs-human-amounts-agent-marketplaces-ru.md
+++ b/lessons/contrib/usdc-base-units-vs-human-amounts-agent-marketplaces-ru.md
@@ -1,16 +1,20 @@
 ---
 {
-  "title": "USDC: base units vs human amounts — агент платит 1000x или думает, что 1000 USDC это $1000",
-  "domain": "crypto-ops",
-  "tags": ["usdc", "base-units", "decimals", "taskmarket", "x402", "agent", "marketplace", "eip-712"],
-  "status": "published",
-  "lang": "ru",
-  "language": "ru",
-  "source": "https://taskmarket.dev/skill.md + live Base wallet ops 2026-07-30",
-  "created": "2026-07-30",
-  "updated": "2026-07-30",
-  "verified_date": "2026-07-30",
-  "confidence": "0.93"
+  "\"title\"": "USDC: base units vs human amounts — агент платит 1000x или думает, что 1000 USDC это $1000\",",
+  "\"domain\"": "crypto-ops\",",
+  "\"tags\"": "[\"usdc\", \"base-units\", \"decimals\", \"taskmarket\", \"x402\", \"agent\", \"marketplace\", \"eip-712\"],",
+  "\"status\"": "published\",",
+  "\"lang\"": "ru\",",
+  "\"language\"": "ru\",",
+  "\"source\"": "https://taskmarket.dev/skill.md + live Base wallet ops 2026-07-30\",",
+  "\"created\"": "2026-07-30\",",
+  "\"updated\"": "2026-07-30\",",
+  "\"verified_date\"": "2026-07-30\",",
+  "\"confidence\"": "0.93",
+  "author": "Brok Malkotsis",
+  "source": "manual",
+  "edited_at": "2026-07-30T02:53:42Z",
+  "merged_by": "Brok Malkotsis"
 }
 ---
 

--- a/lessons/contrib/usdc-ethereum-instead-of-base-zero-eth-gas.md
+++ b/lessons/contrib/usdc-ethereum-instead-of-base-zero-eth-gas.md
@@ -1,15 +1,19 @@
 ---
 {
-  "title": "USDC пришёл в Ethereum mainnet, а нужен Base — и 0 ETH на газ",
-  "domain": "crypto-ops",
-  "tags": ["usdc", "base", "ethereum", "bridge", "gas", "cow-protocol", "agent", "wallet"],
-  "status": "published",
-  "lang": "ru",
-  "language": "ru",
-  "source": "brok-best agent ops 2026-07-29 (live wallet bridge)",
-  "created": "2026-07-29",
-  "updated": "2026-07-29",
-  "confidence": "0.92"
+  "\"title\"": "USDC пришёл в Ethereum mainnet, а нужен Base — и 0 ETH на газ\",",
+  "\"domain\"": "crypto-ops\",",
+  "\"tags\"": "[\"usdc\", \"base\", \"ethereum\", \"bridge\", \"gas\", \"cow-protocol\", \"agent\", \"wallet\"],",
+  "\"status\"": "published\",",
+  "\"lang\"": "ru\",",
+  "\"language\"": "ru\",",
+  "\"source\"": "brok-best agent ops 2026-07-29 (live wallet bridge)\",",
+  "\"created\"": "2026-07-29\",",
+  "\"updated\"": "2026-07-29\",",
+  "\"confidence\"": "0.92",
+  "author": "Brok Malkotsis",
+  "source": "manual",
+  "edited_at": "2026-07-29T23:40:42Z",
+  "merged_by": "Brok Malkotsis"
 }
 ---
 

--- a/lessons/contrib/version-management-multiple-files.md
+++ b/lessons/contrib/version-management-multiple-files.md
@@ -1,11 +1,15 @@
 ---
 {
-  "title": "Version Management Across Multiple Files",
-  "domain": "devops",
-  "tags": ["version", "release", "changelog", "documentation", "metrics", "ssot", "frontend"],
-  "status": "published",
-  "source": "agent_experience",
-  "created": "2026-07-02"
+  "\"title\"": "Version Management Across Multiple Files\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[\"version\", \"release\", \"changelog\", \"documentation\", \"metrics\", \"ssot\", \"frontend\"],",
+  "\"status\"": "published\",",
+  "\"source\"": "agent_experience\",",
+  "\"created\"": "2026-07-02",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-07-04T11:55:07+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/contrib/vertical-kb-question-bank-strategy.md
+++ b/lessons/contrib/vertical-kb-question-bank-strategy.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study\", \"domain\": \"rag-knowledge-base\", \"source\": \"deepseek-tui\", \"status\": \"published\", \"tags\": [\"rag\", \"question-bank\", \"knowledge-base\", \"feishu-doc\", \"review\"], \"created\": \"2026-05-19\", \"updated\": \"2026-05-19\", \"domain_expert\": \"deepseek-tui\", \"verified_date\": \"2026-05-19\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "Vertical KB Question Bank Strategy — FANUC Robot KB Case Study\\\", \\\"domain\\\": \\\"rag-knowledge-base\\\", \\\"source\\\": \\\"deepseek-tui\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"rag\\\", \\\"question-bank\\\", \\\"knowledge-base\\\", \\\"feishu-doc\\\", \\\"review\\\"], \\\"created\\\": \\\"2026-05-19\\\", \\\"updated\\\": \\\"2026-05-19\\\", \\\"domain_expert\\\": \\\"deepseek-tui\\\", \\\"verified_date\\\": \\\"2026-05-19\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/wcferry-wechat-version-lock.md
+++ b/lessons/contrib/wcferry-wechat-version-lock.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "wcferry wechat version lock",
-  "verification": "metadata-normalized",
-  "{\"title\"": "wcferry 微信版本锁定 — 3.9.12.51 才能用\", \"domain\": \"devops\", \"subdomain\": \"wechat\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:windows\", \"node:hermes_wsl\", \"scope:narrow\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "wcferry wechat version lock\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "wcferry 微信版本锁定 — 3.9.12.51 才能用\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"wechat\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:rag\\\", \\\"platform:windows\\\", \\\"node:hermes_wsl\\\", \\\"scope:narrow\\\"], \\\"confidence\\\": \\\"0.85\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/webhook-duplicate-delivery-dedupe-scope.md
+++ b/lessons/contrib/webhook-duplicate-delivery-dedupe-scope.md
@@ -1,17 +1,16 @@
 ---
 {
-  "title": "Webhook duplicate delivery defeated by an over-broad dedupe key",
-  "domain": "development",
-  "tags": [
-    "webhook",
-    "deduplication",
-    "idempotency",
-    "ledger"
-  ],
-  "status": "published",
-  "evidence_level": "E2",
-  "created": "2026-08-11 00:00:00 UTC",
-  "updated": "2026-08-11 00:00:00 UTC"
+  "\"title\"": "Webhook duplicate delivery defeated by an over-broad dedupe key\",",
+  "\"domain\"": "development\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"evidence_level\"": "E2\",",
+  "\"created\"": "2026-08-11 00:00:00 UTC\",",
+  "\"updated\"": "2026-08-11 00:00:00 UTC",
+  "author": "ElevaSync Solutions",
+  "source": "manual",
+  "edited_at": "2026-08-11T03:00:00Z",
+  "merged_by": "ElevaSync Solutions"
 }
 ---
 

--- a/lessons/contrib/webmcp-chrome-ai-agent-protocol.md
+++ b/lessons/contrib/webmcp-chrome-ai-agent-protocol.md
@@ -1,14 +1,27 @@
 ---
-title: webMCP — Chrome's Experimental Protocol for AI Agents
-domain: mcp
-subdomain: web
-tags: ["webmcp", "chrome", "ai-agents", "web", "protocol", "experimental"]
-source: dev.to
-status: published
-confidence: 0.8
-created: 2026-07-01
-verified_date: 
-domain_expert: 
+{
+  "title": "webMCP — Chrome's Experimental Protocol for AI Agents",
+  "domain": "mcp",
+  "subdomain": "web",
+  "tags": [
+    "webmcp",
+    "chrome",
+    "ai-agents",
+    "web",
+    "protocol",
+    "experimental"
+  ],
+  "source": "pr",
+  "status": "published",
+  "confidence": 0.8,
+  "created": "2026-07-01",
+  "verified_date": "",
+  "domain_expert": "",
+  "author": "zsxh1990",
+  "edited_at": "2026-07-12T12:28:29+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 351
+}
 ---
 
 

--- a/lessons/contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md
+++ b/lessons/contrib/wechat-pubacct-fetch-separate-search-from-retrieval.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "wechat pubacct fetch separate search from retrieval",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "wechat pubacct fetch separate search from retrieval\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "微信公众号抓取失败Handling（搜索与抓取分离）", "domain": "wechat", "tags": ["wechat", "fetch", "search", "crawl"]}---

--- a/lessons/contrib/wecom-robot-long-connect-no-ngrok.md
+++ b/lessons/contrib/wecom-robot-long-connect-no-ngrok.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "wecom robot long connect no ngrok",
-  "verification": "metadata-normalized",
-  "{\"title\"": "企业微信机器人：长连接模式不需要 ngrok\", \"domain\": \"devops\", \"subdomain\": \"wecom\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:windows\", \"node:hermes_wsl\", \"scope:narrow\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "wecom robot long connect no ngrok\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "企业微信机器人：长连接模式不需要 ngrok\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"wecom\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:rag\\\", \\\"platform:windows\\\", \\\"node:hermes_wsl\\\", \\\"scope:narrow\\\"], \\\"confidence\\\": \\\"0.85\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/wsl-ntfs-sqlite-update-100x-slower.md
+++ b/lessons/contrib/wsl-ntfs-sqlite-update-100x-slower.md
@@ -1,5 +1,11 @@
 ---
-{"title": "WSL NTFS SQLite UPDATE 100x slower than ext4", "domain": "data-engineering", "tags": ["wsl", "sqlite", "performance", "ntfs", "windows"], "status": "published", "evidence_level": "E2", "created": "2026-08-06", "updated": "2026-08-06", "source": "b2-robot-utilization project", "verified_date": "2026-08-06"}
+{
+  "{\"title\"": "WSL NTFS SQLite UPDATE 100x slower than ext4\", \"domain\": \"data-engineering\", \"tags\": [\"wsl\", \"sqlite\", \"performance\", \"ntfs\", \"windows\"], \"status\": \"published\", \"evidence_level\": \"E2\", \"created\": \"2026-08-06\", \"updated\": \"2026-08-06\", \"source\": \"b2-robot-utilization project\", \"verified_date\": \"2026-08-06\"}",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-08-11T21:14:18+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # WSL NTFS SQLite UPDATE 100x slower than ext4

--- a/lessons/contrib/wsl-pip-gbk-hub-poller-crash.md
+++ b/lessons/contrib/wsl-pip-gbk-hub-poller-crash.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "wsl pip gbk hub poller crash",
-  "verification": "metadata-normalized",
-  "{\"title\"": "WSL pip install GBK 编码导致 hub_poller 崩溃\", \"domain\": \"devops\", \"subdomain\": \"wsl\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:agent-medici\", \"severity:critical\", \"platform:wsl\", \"node:hermes_wsl\"], \"confidence\": \"0.8\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "wsl pip gbk hub poller crash\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "WSL pip install GBK 编码导致 hub_poller 崩溃\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"wsl\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:agent-medici\\\", \\\"severity:critical\\\", \\\"platform:wsl\\\", \\\"node:hermes_wsl\\\"], \\\"confidence\\\": \\\"0.8\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/wsl-proxy-huggingface-external.md
+++ b/lessons/contrib/wsl-proxy-huggingface-external.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "wsl proxy huggingface external",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "wsl proxy huggingface external\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "WSL 需要代理Setup才能Access HuggingFace 和外部网络", "domain": "devops", "subdomain": "wsl", "source": "bootstrap", "status": "published", "tags": ["project:self-grow-wiki", "severity:high", "platform:wsl", "node:hermes_wsl"], "confidence": "0.8", "created": "2026-05-03"}---

--- a/lessons/contrib/wsl-proxy-setup.md
+++ b/lessons/contrib/wsl-proxy-setup.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "WSL 代理Setup — 通过 Windows 梯子Access外网",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "WSL 代理Setup — 通过 Windows 梯子Access外网\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "WSL 代理Setup — 通过 Windows 梯子Access外网", "domain": "devops", "tags": ["wsl", "proxy", "network", "windows"]}---

--- a/lessons/contrib/wsl-terminal-underscore-corruption.md
+++ b/lessons/contrib/wsl-terminal-underscore-corruption.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "WSL 终端编辑Setup危险 — TTy粘贴吞下划线",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "WSL 终端编辑Setup危险 — TTy粘贴吞下划线\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "WSL 终端编辑Setup危险 — TTy粘贴吞下划线", "domain": "devops", "source": "bootstrap", "bootstrapped": true, "author": "node2", "machine": "hermes-wsl", "original_date": "2026-04-24", "tags": "", "- node": "hermes_wsl", "- project": "wsl", "- severity": "high", "status": "published", "quality": "published", "created": "2026-04-01", "confidence": "0.7"}---

--- a/lessons/contrib/wsl-terminal-underscore-missing.md
+++ b/lessons/contrib/wsl-terminal-underscore-missing.md
@@ -1,10 +1,15 @@
 ---
 {
-  "domain": "contrib",
-  "title": "WSL Windows 终端复制粘贴吞下划线Issue",
-  "verification": "metadata-normalized",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "WSL Windows 终端复制粘贴吞下划线Issue\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 ---{"title": "WSL Windows 终端复制粘贴吞下划线Issue", "domain": "devops", "tags": ["wsl", "terminal", "windows", "encoding"]}---

--- a/lessons/contrib/wsl2-memory-leak-fix.md
+++ b/lessons/contrib/wsl2-memory-leak-fix.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "WSL2 内存泄漏 / 内存占用过高",
-  "verification": "metadata-normalized",
-  "{\"title\"": "WSL2 内存泄漏 / 内存占用过高\", \"domain\": \"devops\", \"tags\": [\"wsl\", \"memory\", \"leak\", \"performance\"], \"domain_expert\": \"unknown\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "WSL2 内存泄漏 / 内存占用过高\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "WSL2 内存泄漏 / 内存占用过高\\\", \\\"domain\\\": \\\"devops\\\", \\\"tags\\\": [\\\"wsl\\\", \\\"memory\\\", \\\"leak\\\", \\\"performance\\\"], \\\"domain_expert\\\": \\\"unknown\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/wxauto-im-feedback-collection-jsonl-queue.md
+++ b/lessons/contrib/wxauto-im-feedback-collection-jsonl-queue.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "IM 机器人反馈收集与 JSONL 队列审核模式",
-  "verification": "metadata-normalized",
-  "{\"title\"": "IM 机器人反馈收集与 JSONL 队列审核模式\", \"domain\": \"rag\", \"tags\": [\"rag\", \"feedback\", \"queue\", \"jsonl\", \"wechat\", \"wxauto\", \"workflow\"], \"confidence\": 0.9, \"created\": \"2026-05-21\", \"domain_expert\": \"unknown\", \"verified_date\": \"2026-05-21\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "IM 机器人反馈收集与 JSONL 队列审核模式\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "IM 机器人反馈收集与 JSONL 队列审核模式\\\", \\\"domain\\\": \\\"rag\\\", \\\"tags\\\": [\\\"rag\\\", \\\"feedback\\\", \\\"queue\\\", \\\"jsonl\\\", \\\"wechat\\\", \\\"wxauto\\\", \\\"workflow\\\"], \\\"confidence\\\": 0.9, \\\"created\\\": \\\"2026-05-21\\\", \\\"domain_expert\\\": \\\"unknown\\\", \\\"verified_date\\\": \\\"2026-05-21\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/wxauto-windows-python-not-wsl.md
+++ b/lessons/contrib/wxauto-windows-python-not-wsl.md
@@ -1,11 +1,16 @@
 ---
 {
-  "domain": "contrib",
-  "title": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip",
-  "verification": "metadata-normalized",
-  "{\"title\"": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip\", \"domain\": \"devops\", \"subdomain\": \"wechat\", \"source\": \"bootstrap\", \"status\": \"published\", \"tags\": [\"project:rag\", \"platform:windows\", \"node:hermes_wsl\", \"scope:narrow\"], \"confidence\": \"0.85\", \"created\": \"2026-05-03\", \"domain_expert\": \"bootstrap\", \"verified_date\": \"2026-05-03\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "\"domain\"": "contrib\",",
+  "\"title\"": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip\",",
+  "\"verification\"": "metadata-normalized\",",
+  "\"{\\\"title\\\"\"": "wxauto 必须在 Windows Python 下安装，不能走 WSL pip\\\", \\\"domain\\\": \\\"devops\\\", \\\"subdomain\\\": \\\"wechat\\\", \\\"source\\\": \\\"bootstrap\\\", \\\"status\\\": \\\"published\\\", \\\"tags\\\": [\\\"project:rag\\\", \\\"platform:windows\\\", \\\"node:hermes_wsl\\\", \\\"scope:narrow\\\"], \\\"confidence\\\": \\\"0.85\\\", \\\"created\\\": \\\"2026-05-03\\\", \\\"domain_expert\\\": \\\"bootstrap\\\", \\\"verified_date\\\": \\\"2026-05-03\\\"}\",",
+  "\"created\"": "2026-07-06\",",
+  "\"source\"": "unknown",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/contrib/zero-bounty-agent-competition-flywheel.md
+++ b/lessons/contrib/zero-bounty-agent-competition-flywheel.md
@@ -1,11 +1,16 @@
 ---
-title: "Zero-Bounty Agent Competition Flywheel: Issue Design for Crawler Attraction"
-domain: development
-tags: [open-source, community, issue-design, crawler, agent-competition, flywheel]
-status: published
-source: misakanet
-created: 2026-07-10
-updated: 2026-07-10
+{
+  "title": "Zero-Bounty Agent Competition Flywheel: Issue Design for Crawler Attraction",
+  "domain": "development",
+  "tags": "[open-source, community, issue-design, crawler, agent-competition, flywheel]",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-10",
+  "updated": "2026-07-10",
+  "author": "Ikalus1988",
+  "edited_at": "2026-07-10T17:56:48+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # Zero-Bounty Agent Competition Flywheel

--- a/lessons/contrib/자바-버전-불일치-빌드-오류.md
+++ b/lessons/contrib/자바-버전-불일치-빌드-오류.md
@@ -1,13 +1,18 @@
 ---
-title: "Java version mismatch causing UnsupportedClassVersionError in builds"
-domain: "java"
-tags: [java, maven, build, version, class]
-language: ko
-status: published
-source: "https://docs.oracle.com/en/java/javase/21/migrate/unsupportedclassversionerror.html"
-created: 2026-07-29
-confidence: 0.9
-verified_date: 2026-07-29
+{
+  "title": "Java version mismatch causing UnsupportedClassVersionError in builds",
+  "domain": "java",
+  "tags": "[java, maven, build, version, class]",
+  "language": "ko",
+  "status": "published",
+  "source": "manual",
+  "created": "2026-07-29",
+  "confidence": 0.9,
+  "verified_date": "2026-07-29",
+  "author": "tarotoads-debug",
+  "edited_at": "2026-07-29T09:31:41-07:00",
+  "merged_by": "tarotoads-debug"
+}
 ---
 
 ## Problem

--- a/lessons/core/auto-merge-ci-pipeline.md
+++ b/lessons/core/auto-merge-ci-pipeline.md
@@ -1,22 +1,18 @@
 ---
 {
-  "title": "Auto-Merge CI Pipeline — DCO, Quality Score, Shadow Branch, Dynamic Deps, Auto-Merge",
-  "domain": "devops",
-  "source": "codewhale",
-  "status": "published",
-  "tags": [
-    "github-actions",
-    "ci",
-    "auto-merge",
-    "shadow-branch",
-    "quality-score",
-    "ai-agent",
-    "fork-pr"
-  ],
-  "created": "2026-06-10 00:00:00 UTC",
-  "updated": "2026-06-10 00:00:00 UTC",
-  "domain_expert": "codewhale",
-  "verified_date": "2026-06-10"
+  "\"title\"": "Auto-Merge CI Pipeline — DCO, Quality Score, Shadow Branch, Dynamic Deps, Auto-Merge\",",
+  "\"domain\"": "devops\",",
+  "\"source\"": "codewhale\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"created\"": "2026-06-10 00:00:00 UTC\",",
+  "\"updated\"": "2026-06-10 00:00:00 UTC\",",
+  "\"domain_expert\"": "codewhale\",",
+  "\"verified_date\"": "2026-06-10",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-06-27T23:35:55+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/core/contributor-engagement-retention.md
+++ b/lessons/core/contributor-engagement-retention.md
@@ -1,21 +1,18 @@
 ---
 {
-  "title": "AI Agent Contributor Engagement — Lightweight Retention Strategy",
-  "domain": "devops",
-  "source": "codewhale",
-  "status": "published",
-  "tags": [
-    "open-source",
-    "community",
-    "contributor-retention",
-    "ai-agent",
-    "misakanet",
-    "social"
-  ],
-  "created": "2026-06-10 00:00:00 UTC",
-  "updated": "2026-06-10 00:00:00 UTC",
-  "domain_expert": "codewhale",
-  "verified_date": "2026-06-10"
+  "\"title\"": "AI Agent Contributor Engagement — Lightweight Retention Strategy\",",
+  "\"domain\"": "devops\",",
+  "\"source\"": "codewhale\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"created\"": "2026-06-10 00:00:00 UTC\",",
+  "\"updated\"": "2026-06-10 00:00:00 UTC\",",
+  "\"domain_expert\"": "codewhale\",",
+  "\"verified_date\"": "2026-06-10",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-06-27T23:35:55+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/core/cronjob-one-shot-race-condition-duplicate-execution.md
+++ b/lessons/core/cronjob-one-shot-race-condition-duplicate-execution.md
@@ -1,18 +1,22 @@
 ---
 {
-  "title": "Cronjob One-Shot Race Condition - Duplicate Execution",
-  "domain": "agent-network",
-  "source": "hermes_wsl2",
-  "status": "published",
-  "tags": [
-    "node:zka",
-    "project:hermes-agent",
-    "severity:critical"
-  ],
-  "created": "2026-06-05 00:48:38 UTC",
-  "updated": "2026-06-05 00:48:38 UTC",
-  "domain_expert": "hermes_wsl2",
-  "verified_date": "2026-06-05"
+  "\"title\"": "Cronjob One-Shot Race Condition - Duplicate Execution\",",
+  "\"domain\"": "agent-network\",",
+  "\"source\"": "hermes_wsl2\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"node": "zka\",",
+  "\"project": "hermes-agent\",",
+  "\"severity": "critical",
+  "\"created\"": "2026-06-05 00:48:38 UTC\",",
+  "\"updated\"": "2026-06-05 00:48:38 UTC\",",
+  "\"domain_expert\"": "hermes_wsl2\",",
+  "\"verified_date\"": "2026-06-05",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/core/dco-auto-fix-workflow.md
+++ b/lessons/core/dco-auto-fix-workflow.md
@@ -1,23 +1,19 @@
 ---
 {
-  "title": "DCO Auto-Fix Workflow — /fix-dco Command Design & Implementation",
-  "domain": "devops",
-  "tags": [
-    "github-actions",
-    "dco",
-    "signoff",
-    "issue-comment",
-    "auto-fix",
-    "fork-pr",
-    "plan-b",
-    "supply-chain"
-  ],
-  "status": "published",
-  "source": "codewhale",
-  "created": "2026-06-13 00:00:00 UTC",
-  "updated": "2026-06-14 00:00:00 UTC",
-  "domain_expert": "codewhale",
-  "verified_date": "2026-06-14"
+  "\"title\"": "DCO Auto-Fix Workflow — /fix-dco Command Design & Implementation\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"source\"": "codewhale\",",
+  "\"created\"": "2026-06-13 00:00:00 UTC\",",
+  "\"updated\"": "2026-06-14 00:00:00 UTC\",",
+  "\"domain_expert\"": "codewhale\",",
+  "\"verified_date\"": "2026-06-14",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/core/freellmapi-session-context-mixing-cross-thread-delivery.md
+++ b/lessons/core/freellmapi-session-context-mixing-cross-thread-delivery.md
@@ -1,18 +1,22 @@
 ---
 {
-  "title": "FReeLLMAPI Session Context Mixing - Cross-Thread Delivery",
-  "domain": "agent-network",
-  "source": "hermes_wsl2",
-  "status": "published",
-  "tags": [
-    "node:zka",
-    "project:hermes-agent",
-    "severity:high"
-  ],
-  "created": "2026-06-05 00:48:54 UTC",
-  "updated": "2026-06-05 00:48:54 UTC",
-  "domain_expert": "hermes_wsl2",
-  "verified_date": "2026-06-05"
+  "\"title\"": "FReeLLMAPI Session Context Mixing - Cross-Thread Delivery\",",
+  "\"domain\"": "agent-network\",",
+  "\"source\"": "hermes_wsl2\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"node": "zka\",",
+  "\"project": "hermes-agent\",",
+  "\"severity": "high",
+  "\"created\"": "2026-06-05 00:48:54 UTC\",",
+  "\"updated\"": "2026-06-05 00:48:54 UTC\",",
+  "\"domain_expert\"": "hermes_wsl2\",",
+  "\"verified_date\"": "2026-06-05",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/core/github-actions-code-injection.md
+++ b/lessons/core/github-actions-code-injection.md
@@ -1,20 +1,18 @@
 ---
 {
-  "title": "GitHub Actions Script Injection — Use env Variables Instead of Inline Interpolation",
-  "domain": "security",
-  "source": "codewhale",
-  "status": "published",
-  "tags": [
-    "github-actions",
-    "security",
-    "code-injection",
-    "codeql",
-    "ci"
-  ],
-  "created": "2026-06-10 00:00:00 UTC",
-  "updated": "2026-06-10 00:00:00 UTC",
-  "domain_expert": "codewhale",
-  "verified_date": "2026-06-10"
+  "\"title\"": "GitHub Actions Script Injection — Use env Variables Instead of Inline Interpolation\",",
+  "\"domain\"": "security\",",
+  "\"source\"": "codewhale\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"created\"": "2026-06-10 00:00:00 UTC\",",
+  "\"updated\"": "2026-06-10 00:00:00 UTC\",",
+  "\"domain_expert\"": "codewhale\",",
+  "\"verified_date\"": "2026-06-10",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-06-27T23:35:55+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/core/hermes-state-database-lock-issues-cleanup-protocol.md
+++ b/lessons/core/hermes-state-database-lock-issues-cleanup-protocol.md
@@ -1,18 +1,22 @@
 ---
 {
-  "title": "Hermes State Database Lock Issues - Cleanup Protocol",
-  "domain": "agent-network",
-  "source": "hermes_wsl2",
-  "status": "published",
-  "tags": [
-    "node:zka",
-    "project:hermes-agent",
-    "severity:high"
-  ],
-  "created": "2026-06-05 00:49:07 UTC",
-  "updated": "2026-06-05 00:49:07 UTC",
-  "domain_expert": "hermes_wsl2",
-  "verified_date": "2026-06-05"
+  "\"title\"": "Hermes State Database Lock Issues - Cleanup Protocol\",",
+  "\"domain\"": "agent-network\",",
+  "\"source\"": "hermes_wsl2\",",
+  "\"status\"": "published\",",
+  "\"tags\"": "[",
+  "\"node": "zka\",",
+  "\"project": "hermes-agent\",",
+  "\"severity": "high",
+  "\"created\"": "2026-06-05 00:49:07 UTC\",",
+  "\"updated\"": "2026-06-05 00:49:07 UTC\",",
+  "\"domain_expert\"": "hermes_wsl2\",",
+  "\"verified_date\"": "2026-06-05",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/core/pr-cleanup-sop.md
+++ b/lessons/core/pr-cleanup-sop.md
@@ -1,20 +1,18 @@
 ---
 {
-  "title": "PR Cleanup SOP — Stale/Duplicate/Resolved PR Disposition",
-  "domain": "devops",
-  "tags": [
-    "github-actions",
-    "pr-management",
-    "cleanup",
-    "maintenance",
-    "sop"
-  ],
-  "status": "published",
-  "source": "codewhale",
-  "created": "2026-06-13 00:00:00 UTC",
-  "updated": "2026-06-13 00:00:00 UTC",
-  "domain_expert": "codewhale",
-  "verified_date": "2026-06-13"
+  "\"title\"": "PR Cleanup SOP — Stale/Duplicate/Resolved PR Disposition\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"source\"": "codewhale\",",
+  "\"created\"": "2026-06-13 00:00:00 UTC\",",
+  "\"updated\"": "2026-06-13 00:00:00 UTC\",",
+  "\"domain_expert\"": "codewhale\",",
+  "\"verified_date\"": "2026-06-13",
+  "author": "Ikalus1988",
+  "source": "pr",
+  "edited_at": "2026-07-02T10:01:58+08:00",
+  "merged_by": "Ikalus1988"
 }
 ---
 

--- a/lessons/core/pull-request-welcome-trigger-trap.md
+++ b/lessons/core/pull-request-welcome-trigger-trap.md
@@ -1,21 +1,19 @@
 ---
 {
-  "title": "PR Welcome Not Triggering — author_association NONE vs FIRST_TIMER Trap",
-  "domain": "devops",
-  "tags": [
-    "github-actions",
-    "pull-request-target",
-    "author-association",
-    "first-time-contributor",
-    "welcome",
-    "debug"
-  ],
-  "status": "published",
-  "source": "codewhale",
-  "created": "2026-06-13 00:00:00 UTC",
-  "updated": "2026-06-13 00:00:00 UTC",
-  "domain_expert": "codewhale",
-  "verified_date": "2026-06-13"
+  "\"title\"": "PR Welcome Not Triggering — author_association NONE vs FIRST_TIMER Trap\",",
+  "\"domain\"": "devops\",",
+  "\"tags\"": "[",
+  "\"status\"": "published\",",
+  "\"source\"": "codewhale\",",
+  "\"created\"": "2026-06-13 00:00:00 UTC\",",
+  "\"updated\"": "2026-06-13 00:00:00 UTC\",",
+  "\"domain_expert\"": "codewhale\",",
+  "\"verified_date\"": "2026-06-13",
+  "author": "zsxh1990",
+  "source": "pr",
+  "edited_at": "2026-07-07T11:57:40+08:00",
+  "merged_by": "zsxh1990",
+  "pr": 382
 }
 ---
 

--- a/lessons/core/search-first-roadmap-loop.md
+++ b/lessons/core/search-first-roadmap-loop.md
@@ -1,5 +1,11 @@
 ---
-{"title":"Search-first roadmap loop for agent knowledge projects","domain":"development","status":"published","tags":["roadmap","search","onboarding","release","strategy"],"language":"en","source":"strategy-session-2026-07-02","created":"2026-07-02 00:00:00 UTC","updated":"2026-07-02 00:00:00 UTC"}
+{
+  "{\"title\"": "Search-first roadmap loop for agent knowledge projects\",\"domain\":\"development\",\"status\":\"published\",\"tags\":[\"roadmap\",\"search\",\"onboarding\",\"release\",\"strategy\"],\"language\":\"en\",\"source\":\"strategy-session-2026-07-02\",\"created\":\"2026-07-02 00:00:00 UTC\",\"updated\":\"2026-07-02 00:00:00 UTC\"}",
+  "author": "Ikalus1988",
+  "source": "manual",
+  "edited_at": "2026-07-02T23:29:49+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 ## Problem

--- a/lessons/user-rescue/archive-open-failure.md
+++ b/lessons/user-rescue/archive-open-failure.md
@@ -1,7 +1,13 @@
 ---
-title: "压缩包打不开？先别急，试这 3 步"
-domain: devops
-evidence_level: E1
+{
+  "title": "压缩包打不开？先别急，试这 3 步",
+  "domain": "devops",
+  "evidence_level": "E1",
+  "author": "Ikalus1988",
+  "source": "rescue",
+  "edited_at": "2026-08-13T00:39:45+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # 压缩包打不开？先别急，试这 3 步

--- a/lessons/user-rescue/fanuc-backup-extract-guide.md
+++ b/lessons/user-rescue/fanuc-backup-extract-guide.md
@@ -1,7 +1,13 @@
 ---
-title: "FANUC 备份打不开？先别急，试这 3 步"
-domain: fanuc
-evidence_level: E1
+{
+  "title": "FANUC 备份打不开？先别急，试这 3 步",
+  "domain": "fanuc",
+  "evidence_level": "E1",
+  "author": "Ikalus1988",
+  "source": "rescue",
+  "edited_at": "2026-08-13T00:39:45+08:00",
+  "merged_by": "Ikalus1988"
+}
 ---
 
 # FANUC 备份打不开？先别急，试这 3 步

--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -92,13 +92,19 @@ def _l2():
             CREATE TABLE IF NOT EXISTS file_cache (
                 path TEXT PRIMARY KEY, mtime REAL, size INT,
                 title TEXT, domain TEXT, status TEXT,
-                reference TEXT, scope TEXT, source TEXT, tags TEXT, language TEXT
+                reference TEXT, scope TEXT, source TEXT, tags TEXT, language TEXT,
+                author TEXT, pr TEXT, edited_at TEXT, merged_by TEXT
             )""")
         # Migration: add language column if upgrading from older schema
         try:
             _L2_CONN.execute("ALTER TABLE file_cache ADD COLUMN language TEXT")
         except sqlite3.OperationalError:
             pass  # column already exists
+        for column in ("author", "pr", "edited_at", "merged_by"):
+            try:
+                _L2_CONN.execute(f"ALTER TABLE file_cache ADD COLUMN {column} TEXT")
+            except sqlite3.OperationalError:
+                pass
         _L2_CONN.commit()
     return _L2_CONN
 
@@ -116,6 +122,10 @@ class CachedDoc:
     source: str = ""
     tags: list = field(default_factory=list)
     language: str = ""
+    author: str = ""
+    pr: str = ""
+    edited_at: str = ""
+    merged_by: str = ""
     mtime: float = 0.0
     is_lesson: bool = True
 
@@ -188,7 +198,7 @@ def _load_docs_cached(directory: Path, is_lesson: bool = True) -> list[CachedDoc
             cached = known.get(rel)
             if cached and cached[0] == st.st_mtime and cached[1] == st.st_size:
                 row = conn.execute(
-                    "SELECT title,domain,status,reference,scope,source,tags,language "
+                    "SELECT title,domain,status,reference,scope,source,tags,language,author,pr,edited_at,merged_by "
                     "FROM file_cache WHERE path=?",
                     (rel,),
                 ).fetchone()
@@ -208,6 +218,10 @@ def _load_docs_cached(directory: Path, is_lesson: bool = True) -> list[CachedDoc
                         source=row[5] or "",
                         tags=tags,
                         language=row[7] or "",
+                        author=row[8] or "",
+                        pr=row[9] or "",
+                        edited_at=row[10] or "",
+                        merged_by=row[11] or "",
                     )
                     doc.content = f.read_text(encoding="utf-8", errors="replace")
                     docs.append(doc)
@@ -231,13 +245,17 @@ def _load_docs_cached(directory: Path, is_lesson: bool = True) -> list[CachedDoc
             doc.scope = meta.get("scope", "")
             doc.source = meta.get("source", "")
             doc.language = meta.get("language", "")
+            doc.author = str(meta.get("author", "") or "")
+            doc.pr = str(meta.get("pr", "") or "")
+            doc.edited_at = str(meta.get("edited_at", "") or "")
+            doc.merged_by = str(meta.get("merged_by", "") or "")
             raw_tags = meta.get("tags", "")
             doc.tags = raw_tags if isinstance(raw_tags, list) else []
             docs.append(doc)
             conn.execute(
                 "INSERT OR REPLACE INTO file_cache "
-                "(path,mtime,size,title,domain,status,reference,scope,source,tags,language) "
-                "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                "(path,mtime,size,title,domain,status,reference,scope,source,tags,language,author,pr,edited_at,merged_by) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     rel,
                     st.st_mtime,
@@ -250,6 +268,10 @@ def _load_docs_cached(directory: Path, is_lesson: bool = True) -> list[CachedDoc
                     doc.source,
                     json.dumps(doc.tags, ensure_ascii=False),
                     doc.language,
+                    doc.author,
+                    doc.pr,
+                    doc.edited_at,
+                    doc.merged_by,
                 ),
             )
             changed += 1

--- a/schemas/lesson.json
+++ b/schemas/lesson.json
@@ -44,7 +44,25 @@
     },
     "source": {
       "type": "string",
-      "description": "Origin of this lesson"
+      "enum": ["intake", "pr", "manual", "rescue"],
+      "description": "Normalized provenance channel for this lesson"
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Git author or contributor identity"
+    },
+    "pr": {
+      "type": ["integer", "string"],
+      "description": "Pull request number or URL when the lesson came from a PR"
+    },
+    "edited_at": {
+      "type": "string",
+      "description": "Last provenance edit timestamp"
+    },
+    "merged_by": {
+      "type": "string",
+      "description": "GitHub user or maintainer who merged the source PR"
     },
     "created": {
       "type": "string",

--- a/scripts/backfill_provenance.py
+++ b/scripts/backfill_provenance.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Backfill lesson provenance from the Git history of each Markdown file.
+
+The default mode is a report. Use ``--write`` to update frontmatter. Existing
+provenance values are preserved unless ``--force`` is supplied, which makes
+the script safe to run repeatedly while still allowing a deliberate rebuild.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SOURCES = {"intake", "pr", "manual", "rescue"}
+NON_LESSON_DIRS = {"en", "hi", "id", "ru", "tr", "vi", "zh"}
+EXCLUDED_DIRS = {"_archive", "draft", "drafts", "templates"}
+EXCLUDED_FILES = {"index.md", "README.md", "TEMPLATE.md", "LESSON_QUALITY_SCORING.md"}
+
+
+def display_path(path: Path) -> str:
+    """Return a stable repository-relative path when possible."""
+    try:
+        return str(path.resolve().relative_to(REPO.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def is_candidate(path: Path, lessons_dir: Path) -> bool:
+    """Match the repository's lesson-lint scope when scanning the root tree."""
+    if path.name in EXCLUDED_FILES:
+        return False
+    if lessons_dir.name != "lessons":
+        return True
+    relative = path.relative_to(lessons_dir)
+    if len(relative.parts) < 2:
+        return False
+    return relative.parts[0] not in NON_LESSON_DIRS | EXCLUDED_DIRS
+
+
+def parse_yaml_value(value: str):
+    """Parse the small YAML subset used by lesson frontmatter."""
+    value = value.strip()
+    try:
+        # Lesson frontmatter commonly uses JSON-compatible arrays and quoted
+        # scalars, so JSON parsing preserves tags instead of flattening them.
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value.strip('"\'')
+
+
+def parse_frontmatter(text: str) -> tuple[dict | None, int, int]:
+    """Return metadata and character offsets for JSON/YAML frontmatter."""
+    if text.lstrip().startswith("{"):
+        depth = 0
+        end = None
+        for index, char in enumerate(text):
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end = index + 1
+                    break
+        if end:
+            try:
+                return json.loads(text[:end]), 0, end
+            except json.JSONDecodeError:
+                pass
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end > 0:
+            raw = text[3:end]
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    return parsed, 0, end + 3
+            except json.JSONDecodeError:
+                pass
+            data = {}
+            for line in raw.splitlines():
+                if ":" in line:
+                    key, value = (part.strip() for part in line.split(":", 1))
+                    data[key] = parse_yaml_value(value)
+            return data, 0, end + 3
+    return None, 0, 0
+
+
+def _git(path: Path, *args: str) -> str:
+    try:
+        relative = path.resolve().relative_to(REPO.resolve())
+        return subprocess.check_output(
+            ["git", "-C", str(REPO), *args, "--", str(relative)],
+            text=True, stderr=subprocess.DEVNULL, timeout=10,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    except ValueError:
+        return ""
+
+
+def infer_source(meta: dict, path: Path, commit_subject: str) -> str:
+    existing = str(meta.get("source", "")).lower()
+    if existing in SOURCES:
+        return existing
+    haystack = f"{existing} {path} {commit_subject}".lower()
+    if "rescue" in haystack or "tombstone" in haystack or "fatal-guard" in haystack:
+        return "rescue"
+    if re.search(r"\bpr\b|pull request|merge pull request|#\d+", haystack):
+        return "pr"
+    if "intake" in haystack or "feedback" in haystack or "capture" in haystack:
+        return "intake"
+    return "manual"
+
+
+def provenance_for(path: Path, meta: dict) -> dict:
+    subject = _git(path, "log", "-1", "--format=%s")
+    author = _git(path, "log", "-1", "--format=%an") or "unknown"
+    edited_at = _git(path, "log", "-1", "--format=%cI") or datetime.now(timezone.utc).isoformat()
+    source = infer_source(meta, path, subject)
+    matches = re.findall(r"(?:pull request|PR|#)\s*#?(\d+)", subject, flags=re.IGNORECASE)
+    result = {
+        "author": meta.get("author") or author,
+        "source": source,
+        "edited_at": meta.get("edited_at") or edited_at,
+        "merged_by": meta.get("merged_by") or author,
+    }
+    if matches or meta.get("pr"):
+        result["pr"] = meta.get("pr") or int(matches[-1])
+    return result
+
+
+def update_file(path: Path, write: bool = False, force: bool = False) -> dict:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    meta, start, end = parse_frontmatter(text)
+    if not isinstance(meta, dict):
+        return {"path": display_path(path), "status": "skipped", "reason": "no frontmatter"}
+    additions = provenance_for(path, meta)
+    changed = {}
+    for key, value in additions.items():
+        current = str(meta.get(key, "")).strip()
+        needs_normalization = key == "source" and current.lower() not in SOURCES
+        if force or needs_normalization or not current:
+            if meta.get(key) != value:
+                meta[key] = value
+                changed[key] = value
+    if write and changed:
+        new_frontmatter = json.dumps(meta, ensure_ascii=False, indent=2)
+        if text.startswith("---"):
+            # Preserve fenced frontmatter so YAML lessons remain valid after
+            # the migration. ``end`` already points just after the closing
+            # delimiter.
+            replacement = f"---\n{new_frontmatter}\n---" + text[end:]
+        else:
+            replacement = new_frontmatter + text[end:]
+        path.write_text(replacement, encoding="utf-8")
+    return {"path": display_path(path), "status": "changed" if changed else "ok", "fields": changed}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lessons-dir", type=Path, default=REPO / "lessons")
+    parser.add_argument("--write", action="store_true", help="Update files; default is report-only")
+    parser.add_argument("--force", action="store_true", help="Replace existing provenance values")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    lessons_dir = args.lessons_dir.resolve()
+    rows = [update_file(path, write=args.write, force=args.force)
+            for path in sorted(lessons_dir.rglob("*.md"))
+            if is_candidate(path, lessons_dir)]
+    changed = sum(row["status"] == "changed" for row in rows)
+    payload = {"write": args.write, "files": len(rows), "changed": changed, "results": rows}
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(f"provenance backfill: {changed} of {len(rows)} files would change" + (" (written)" if args.write else " (dry-run)"))
+        for row in rows:
+            if row["status"] == "changed":
+                print(f"  {row['path']}: {', '.join(row['fields'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_sag_index.py
+++ b/scripts/build_sag_index.py
@@ -57,7 +57,11 @@ def build_index(okf_path: Path, db_path: Path) -> int:
             path TEXT,
             timestamp TEXT,
             verified_date TEXT,
-            domain_expert TEXT
+            domain_expert TEXT,
+            author TEXT,
+            pr TEXT,
+            edited_at TEXT,
+            merged_by TEXT
         )
     """)
 
@@ -77,7 +81,7 @@ def build_index(okf_path: Path, db_path: Path) -> int:
     for r in records:
         tags_str = ", ".join(r.get("tags", []))
         conn.execute(
-            "INSERT INTO lessons (title, description, domain, tags, source, status, path, timestamp, verified_date, domain_expert) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO lessons (title, description, domain, tags, source, status, path, timestamp, verified_date, domain_expert, author, pr, edited_at, merged_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 r.get("title", ""),
                 r.get("description", ""),
@@ -89,6 +93,10 @@ def build_index(okf_path: Path, db_path: Path) -> int:
                 r.get("timestamp", ""),
                 r.get("verified_date", ""),
                 r.get("domain_expert", ""),
+                r.get("author", ""),
+                r.get("pr", ""),
+                r.get("edited_at", ""),
+                r.get("merged_by", ""),
             ),
         )
 
@@ -146,6 +154,10 @@ def search(db_path: Path, query: str, domain: str | None = None, top: int = 5) -
             "domain": r["domain"],
             "tags": r["tags"],
             "source": r["source"],
+            "author": r["author"] or "",
+            "pr": r["pr"] or "",
+            "edited_at": r["edited_at"] or "",
+            "merged_by": r["merged_by"] or "",
             "path": r["path"],
             "status": r["status"] or "",
             "score": round(abs(r["rank"]), 4) if r["rank"] else 0,

--- a/scripts/contribute.py
+++ b/scripts/contribute.py
@@ -326,7 +326,7 @@ def _wizard():
     # Write temp file and submit
     tmp = LESSONS_DIR / f"__tmp_{slug}.md"
     body = f"""---
-{{"title": "{title}", "domain": "{domain}", "tags": {json.dumps(tags)}, "status": "published", "created": "{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}", "updated": "{datetime.now(timezone.utc).strftime('%Y-%m-%d')}", "source": "contributor"}}
+{{"title": "{title}", "domain": "{domain}", "tags": {json.dumps(tags)}, "status": "published", "created": "{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}", "updated": "{datetime.now(timezone.utc).strftime('%Y-%m-%d')}", "source": "manual"}}
 ---
 
 {content}
@@ -362,7 +362,7 @@ def main():
         slug = _slugify(args.title)
         tmp = LESSONS_DIR / f"__tmp_{slug}.md"
         body = f"""---
-{{"title": "{args.title}", "domain": "{args.domain}", "tags": [], "status": "published", "created": "{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}", "source": "contribute-api"}}
+{{"title": "{args.title}", "domain": "{args.domain}", "tags": [], "status": "published", "created": "{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}", "source": "intake"}}
 ---
 
 {args.content}

--- a/scripts/export_okf.py
+++ b/scripts/export_okf.py
@@ -149,10 +149,9 @@ def lesson_to_okf(path: Path, domain_filter: str | None = None) -> dict | None:
     }
 
     # Optional fields
-    if meta.get("verified_date"):
-        okf["verified_date"] = meta["verified_date"]
-    if meta.get("domain_expert"):
-        okf["domain_expert"] = meta["domain_expert"]
+    for field in ("verified_date", "domain_expert", "author", "pr", "edited_at", "merged_by"):
+        if meta.get(field):
+            okf[field] = meta[field]
 
     return okf
 
@@ -179,7 +178,7 @@ def main():
         for lesson in lessons:
             if args.domain and lesson.get("domain") != args.domain:
                 continue
-            okf_records.append({
+            record = {
                 "type": "lesson",
                 "title": lesson.get("title", ""),
                 "description": lesson.get("summary", lesson.get("description", "")),
@@ -189,7 +188,11 @@ def main():
                 "source": lesson.get("source", ""),
                 "status": lesson.get("status", "published"),
                 "path": lesson.get("url", lesson.get("path", "")),
-            })
+            }
+            for field in ("author", "pr", "edited_at", "merged_by"):
+                if lesson.get(field):
+                    record[field] = lesson[field]
+            okf_records.append(record)
         # Write output
         if args.format == "jsonl":
             output_file = output_dir / "lessons.jsonl"

--- a/scripts/lesson_lint.py
+++ b/scripts/lesson_lint.py
@@ -41,6 +41,7 @@ EXCLUDE_DIRS = {
 NON_LESSON_DIRS = {
     "en", "hi", "id", "ru", "tr", "vi", "zh",
 }
+PROVENANCE_SOURCES = {"intake", "pr", "manual", "rescue"}
 
 
 def is_lesson_file(file_path: Path, lessons_dir: Path) -> bool:
@@ -98,6 +99,13 @@ def parse_frontmatter(content: str) -> tuple[dict | None, int]:
         end_idx = content.find("---", 3)
         if end_idx > 0:
             yaml_str = content[3:end_idx].strip()
+            try:
+                parsed = json.loads(yaml_str)
+                if isinstance(parsed, dict):
+                    body_start = content[:end_idx].count("\n") + 1
+                    return parsed, body_start
+            except json.JSONDecodeError:
+                pass
             # Simple YAML parsing (key: value pairs)
             data = {}
             for line in yaml_str.split("\n"):
@@ -130,6 +138,38 @@ def check_frontmatter(content: str, file_path: Path) -> list[dict[str, str]]:
             "severity": "high",
             "file": str(file_path),
             "message": "No frontmatter found (expected YAML --- or JSON {})"
+        })
+    return issues
+
+
+def check_provenance(content: str, file_path: Path) -> list[dict[str, str]]:
+    """Require an auditable provenance tuple on published lessons."""
+    frontmatter, _ = parse_frontmatter(content)
+    if not frontmatter or frontmatter.get("status") != "published":
+        return []
+    issues = []
+    source = str(frontmatter.get("source", "")).strip().lower()
+    if source not in PROVENANCE_SOURCES:
+        issues.append({
+            "rule": "invalid_provenance_source",
+            "severity": "medium",
+            "file": str(file_path),
+            "message": "Published lesson needs source=intake|pr|manual|rescue",
+        })
+    for field in ("author", "edited_at", "merged_by"):
+        if not str(frontmatter.get(field, "")).strip():
+            issues.append({
+                "rule": f"missing_{field}",
+                "severity": "medium",
+                "file": str(file_path),
+                "message": f"Published lesson is missing provenance field '{field}'",
+            })
+    if source == "pr" and not str(frontmatter.get("pr", "")).strip():
+        issues.append({
+            "rule": "missing_pr",
+            "severity": "medium",
+            "file": str(file_path),
+            "message": "source=pr requires a PR number or URL",
         })
     return issues
 
@@ -250,6 +290,7 @@ def lint_lesson(file_path: Path, lessons_dir: Path) -> list[dict[str, str]]:
     content = file_path.read_text(encoding="utf-8")
     issues = []
     issues.extend(check_frontmatter(content, file_path))
+    issues.extend(check_provenance(content, file_path))
     issues.extend(check_title(content, file_path))
     issues.extend(check_length(content, file_path))
     issues.extend(check_links(content, file_path, lessons_dir))

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -171,6 +171,13 @@ def handle_search(args: dict) -> dict:
                 "score": round(score, 3),
                 "domain": doc.domain,
                 "status": doc.status,
+                "author": doc.author,
+                "source": doc.source,
+                "provenance": {
+                    "pr": doc.pr,
+                    "edited_at": doc.edited_at,
+                    "merged_by": doc.merged_by,
+                },
             })
         voice = "lesson-found" if results else "failure-warning"
         return {"results": results, "source": "bm25", "voice": voice}
@@ -531,7 +538,7 @@ TOOLS = [
             "Input semantics: query is required; domain optionally filters by lesson domain; top limits "
             "ranked results and defaults to 5. Output schema: JSON with results[] and source; each "
             "result is a ranked lesson summary that may include path, title, domain/status, score/rank, "
-            "and match details depending on the active index. Error cases: missing query, unavailable "
+            "author/source provenance, and match details depending on the active index. Error cases: missing query, unavailable "
             "search index, or no matches (empty results). Side effects: none. Auth: none. Rate limits: "
             "local stdio process only; callers should keep result counts small. Do not use for private "
             "log collection; search only with redacted snippets. Use misakanet_get_lesson for full content."

--- a/scripts/misaka_search_json.py
+++ b/scripts/misaka_search_json.py
@@ -83,6 +83,12 @@ def search(query: str, top: int = 5, include_reference: bool = True) -> list[dic
                 "domain": doc.domain,
                 "status": doc.status,
                 "source": doc.source,
+                "author": doc.author,
+                "provenance": {
+                    "pr": doc.pr,
+                    "edited_at": doc.edited_at,
+                    "merged_by": doc.merged_by,
+                },
                 "snippet": make_snippet(doc.content, query),
             }
         )

--- a/scripts/new_lesson.py
+++ b/scripts/new_lesson.py
@@ -99,7 +99,11 @@ def interactive():
     fix = _input_or_default("  3. 怎么修复的")
     verify = _input_or_default("  4. 怎么验证修复结果")
 
-    source = os.environ.get("MISAKANET_NODE_ID", "manual")
+    source = os.environ.get("MISAKANET_SOURCE", "manual")
+    if source not in {"intake", "pr", "manual", "rescue"}:
+        source = "manual"
+    author = os.environ.get("MISAKANET_AUTHOR", "unknown")
+    merged_by = os.environ.get("MISAKANET_MERGED_BY", author)
     now = datetime.now(timezone.utc)
 
     frontmatter = {
@@ -110,7 +114,11 @@ def interactive():
         "tags": tags,
         "created": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "updated": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "edited_at": now.isoformat(),
+        "merged_by": merged_by,
     }
+    if author:
+        frontmatter["author"] = author
 
     body = f"""---
 {json.dumps(frontmatter, ensure_ascii=False)}
@@ -161,7 +169,11 @@ def interactive():
 
 def batch(title: str, domain: str, content: str, tags: list[str] = None):
     """非交互式快速创建，适合 agent 调用。"""
-    source = os.environ.get("MISAKANET_NODE_ID", "agent")
+    source = os.environ.get("MISAKANET_SOURCE", "manual")
+    if source not in {"intake", "pr", "manual", "rescue"}:
+        source = "manual"
+    author = os.environ.get("MISAKANET_AUTHOR", "unknown")
+    merged_by = os.environ.get("MISAKANET_MERGED_BY", author)
     now = datetime.now(timezone.utc)
 
     frontmatter = {
@@ -172,7 +184,11 @@ def batch(title: str, domain: str, content: str, tags: list[str] = None):
         "tags": tags or [],
         "created": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "updated": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "edited_at": now.isoformat(),
+        "merged_by": merged_by,
     }
+    if author:
+        frontmatter["author"] = author
 
     body = f"""---
 {json.dumps(frontmatter, ensure_ascii=False)}

--- a/scripts/queue_lesson.py
+++ b/scripts/queue_lesson.py
@@ -37,6 +37,7 @@ if _SCRIPTS_DIR.exists() and str(_SCRIPTS_DIR) not in sys.path:
 
 REPO = "Ikalus1988/MisakaNet"
 NODE_ID = os.environ.get("MISAKANET_NODE_ID", "hermes_wsl2")
+PROVENANCE_SOURCES = {"intake", "pr", "manual", "rescue"}
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 if str(REPO_ROOT) not in sys.path:
@@ -131,16 +132,21 @@ def _render_lesson(title, domain, tags, content, source=NODE_ID, status="publish
     filename = f"{slug}.md"
 
     now = datetime.now(timezone.utc)
+    normalized_source = source if source in PROVENANCE_SOURCES else "intake"
+    author = os.environ.get("MISAKANET_AUTHOR", NODE_ID)
     frontmatter = {
         "title": title,
         "domain": domain,
-        "source": source,
+        "source": normalized_source,
+        "author": author,
         "status": status,
         # New lessons start self-reported (#786); promotion is a maintainer action.
         "evidence_level": DEFAULT_EVIDENCE_LEVEL,
         "tags": tags,
         "created": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "updated": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "edited_at": now.isoformat(),
+        "merged_by": os.environ.get("MISAKANET_MERGED_BY", author),
     }
 
     body = f"---\n{json.dumps(frontmatter, ensure_ascii=False)}\n---\n\n{content}\n"
@@ -160,16 +166,21 @@ def write_lesson(title, domain, tags, content, source=NODE_ID, status="published
     mode = "更新" if filepath.exists() else "新建"
     existing_content = filepath.read_text(encoding="utf-8") if filepath.exists() else ""
 
+    normalized_source = source if source in PROVENANCE_SOURCES else "intake"
+    author = os.environ.get("MISAKANET_AUTHOR", NODE_ID)
     frontmatter = {
         "title": title,
         "domain": domain,
-        "source": source,
+        "source": normalized_source,
+        "author": author,
         "status": status,
         # New lessons start self-reported (#786); promotion is a maintainer action.
         "evidence_level": DEFAULT_EVIDENCE_LEVEL,
         "tags": tags,
         "created": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "updated": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "edited_at": now.isoformat(),
+        "merged_by": os.environ.get("MISAKANET_MERGED_BY", author),
     }
 
     body = f"---\n {json.dumps(frontmatter, ensure_ascii=False)}\n ---\n\n{content}\n"

--- a/scripts/tombstone_to_draft.py
+++ b/scripts/tombstone_to_draft.py
@@ -277,7 +277,7 @@ def _generate_draft(tombstone: dict, source_file: str = "", ai_hint: str = "") -
         "domain": domain,
         "tags": ["draft", "auto-generated", "agent-task", f"exit-code-{exit_code}"],
         "status": "draft",
-        "source": "fatal-guard",
+        "source": "rescue",
         "node_id": node,
         "tombstone_hash": tombstone_hash,
         "tombstone_ref": source_file if source_file else f"tombstone:{tombstone_hash}",

--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -48,6 +48,13 @@ def _json_result(score, doc, query: str = "", verbose: bool = False) -> dict:
         "title": doc.title,
         "domain": doc.domain,
         "tags": list(doc.tags),
+        "provenance": {
+            "author": doc.author,
+            "pr": doc.pr,
+            "source": doc.source,
+            "edited_at": doc.edited_at,
+            "merged_by": doc.merged_by,
+        },
         "score": round(float(score), 6),
         "path": path,
         "preview": preview,

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,83 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_lint_requires_published_provenance():
+    lint = _load(ROOT / "scripts/lesson_lint.py", "lesson_lint_provenance")
+    content = '{"title":"Example Lesson","domain":"python","status":"published"}\n# Example\n\n' + ('body\n' * 12)
+    rules = {item["rule"] for item in lint.check_provenance(content, Path("example.md"))}
+    assert {"invalid_provenance_source", "missing_author", "missing_edited_at", "missing_merged_by"} <= rules
+
+
+def test_backfill_preserves_existing_values(tmp_path):
+    backfill = _load(ROOT / "scripts/backfill_provenance.py", "backfill_provenance")
+    path = tmp_path / "lesson.md"
+    path.write_text('{"title":"Example","source":"pr","author":"Ada","pr":7,"edited_at":"2026-01-01","merged_by":"Maintainer"}\n# Example\n\nBody\n', encoding="utf-8")
+    result = backfill.update_file(path, write=False)
+    assert result["status"] == "ok"
+    assert result["fields"] == {}
+
+
+def test_backfill_dry_run_reports_missing_fields(tmp_path):
+    backfill = _load(ROOT / "scripts/backfill_provenance.py", "backfill_provenance_dry")
+    path = tmp_path / "lesson.md"
+    path.write_text('{"title":"Example","source":"unknown"}\n# Example\n\nBody\n', encoding="utf-8")
+    backfill.REPO = tmp_path
+    result = backfill.update_file(path, write=False)
+    assert result["status"] == "changed"
+    assert {"author", "source", "edited_at", "merged_by"} <= set(result["fields"])
+
+
+def test_backfill_write_preserves_fenced_frontmatter(tmp_path):
+    backfill = _load(ROOT / "scripts/backfill_provenance.py", "backfill_provenance_fenced")
+    path = tmp_path / "lesson.md"
+    path.write_text(
+        '---\n{"title":"Example","source":"unknown"}\n---\n\n# Example\n\nBody\n',
+        encoding="utf-8",
+    )
+    backfill.REPO = tmp_path
+    result = backfill.update_file(path, write=True)
+    written = path.read_text(encoding="utf-8")
+    assert result["status"] == "changed"
+    assert written.startswith("---\n")
+    assert "\n---\n\n# Example" in written
+    assert '"source": "manual"' in written
+
+
+def test_sag_index_round_trips_provenance(tmp_path):
+    sag = _load(ROOT / "scripts/build_sag_index.py", "build_sag_index_provenance")
+    okf_dir = tmp_path / "okf"
+    okf_dir.mkdir()
+    (okf_dir / "lessons.jsonl").write_text(
+        json.dumps({
+            "title": "Timeout recovery",
+            "description": "Recover a network timeout safely",
+            "tags": ["network"],
+            "domain": "devops",
+            "source": "pr",
+            "status": "published",
+            "path": "lessons/core/timeout.md",
+            "author": "Ada",
+            "pr": 42,
+            "edited_at": "2026-01-01T00:00:00Z",
+            "merged_by": "Maintainer",
+        }) + "\n",
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "sag.db"
+    assert sag.build_index(okf_dir, db_path) == 1
+    result = sag.search(db_path, "timeout", top=1)[0]
+    assert result["author"] == "Ada"
+    assert result["pr"] == "42"
+    assert result["source"] == "pr"


### PR DESCRIPTION
Closes #1002

## Summary
- extend lesson schema and linting with `author`, `pr`, `source`, `edited_at`, and `merged_by`
- add an idempotent Git-history backfill with report-only and `--write` modes; migrate 289 in-scope lessons without changing lesson bodies
- carry provenance through the SQLite cache, SAG index/export, CLI JSON, human search JSON, and MCP results
- normalize new lesson/intake/rescue writers to the provenance source enum
- document the migration and add focused backfill/SAG round-trip tests

## Validation
- `python3 -m py_compile` on all changed Python modules
- backfill dry-run after migration: 289 files scanned, 0 pending changes
- provenance lint check: 0 provenance issues
- body-preservation audit: 289 changed lessons, 0 body mismatches
- SQLite cache integration: 289 lessons loaded with provenance fields
- SAG provenance round-trip passed
- `git diff --check`
- `pytest` was not available in the local runtime (`No module named pytest`)
