### PR TITLE
fix: complete lesson lint cleanup

### DIFF
--- a/lessons/contrib/cubic_ai_vs_pr_genius.md
+++ b/lessons/contrib/cubic_ai_vs_pr_genius.md
@@ -1,10 +1,19 @@
 ---
-name: cubic-ai-vs-pr-genius
-description: Cubic AI 与 PR Genius 对比——即时触发、diff 逐行、正向确认三点可借鉴
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T10:20:05.320Z
+{
+  "title": "Cubic AI and PR Genius Comparison",
+  "domain": "devops",
+  "tags": ["github", "pull-request", "automation", "code-review", "ci"],
+  "status": "published",
+  "evidence_level": "E0",
+  "source": "session-feedback",
+  "created": "2026-08-04",
+  "updated": "2026-08-04",
+  "metadata": {
+    "type": "feedback",
+    "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+    "modified": "2026-08-04T10:20:05.320Z"
+  }
+}
 ---
 
 ## 背景

--- a/lessons/contrib/dco_signoff_force_push_pitfall.md
+++ b/lessons/contrib/dco_signoff_force_push_pitfall.md
@@ -1,10 +1,19 @@
 ---
-name: dco-signoff-force-push-pitfall
-description: DCO signoff 在 force push 后丢失——squash 必须在 reset --hard 后重新 commit --signoff
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T10:19:47.621Z
+{
+  "title": "DCO Signoff Lost During Force Push",
+  "domain": "devops",
+  "tags": ["git", "dco", "signoff", "force-push", "pull-request"],
+  "status": "published",
+  "evidence_level": "E0",
+  "source": "session-feedback",
+  "created": "2026-08-04",
+  "updated": "2026-08-04",
+  "metadata": {
+    "type": "feedback",
+    "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+    "modified": "2026-08-04T10:19:47.621Z"
+  }
+}
 ---
 
 ## 问题

--- a/lessons/contrib/fanuc-karel-http-api-webcontrol.md
+++ b/lessons/contrib/fanuc-karel-http-api-webcontrol.md
@@ -1,4 +1,6 @@
-{"id":"fanuc-karel-http-api-webcontrol","title":"FANUC KAREL HTTP API — WebControl Robot Motion and Monitoring","domain":"fanuc","subdomain":"karel-webcontrol","source":"github-fanuc-webcontrol-api.md","status":"draft","confidence":0.75,"created":"2026-07-12","tags":["fanuc","karel","http","api","webcontrol","rest","motion","monitoring"],"quality_score":75,"problem":"需要通过HTTP接口远程控制FANUC机器人运动、监控状态、管理程序执行，但FANUC原生不提供REST API","root_cause":"FANUC控制器内置KAREL webserver，但官方文档分散，缺少完整的API参考和使用示例","solution":"基于KAREL webserver实现HTTP API：webcontrol端点发送6种运动模式(关节/笛卡尔×绝对/相对)、webmonitor返回完整状态JSON(关节/笛卡尔/限位/状态/错误)、weblimit设置18个运动限位、webstart运行TP程序、webabort紧急停止","verification":"webcontrol/weblimit成功返回204状态码；webmonitor返回完整JSON包含joint/pose/limit/status/message/error/timestamp字段；各KAREL程序(webabort/webcheck/webkeep/webreset等)功能独立可测"}
+---
+{"id":"fanuc-karel-http-api-webcontrol","title":"FANUC KAREL HTTP API — WebControl Robot Motion and Monitoring","domain":"fanuc","subdomain":"karel-webcontrol","source":"github-fanuc-webcontrol-api.md","status":"draft","confidence":0.75,"created":"2026-07-12","updated":"2026-08-13","evidence_level":"E0","tags":["fanuc","karel","http","api","webcontrol","rest","motion","monitoring"],"quality_score":75,"problem":"需要通过HTTP接口远程控制FANUC机器人运动、监控状态、管理程序执行，但FANUC原生不提供REST API","root_cause":"FANUC控制器内置KAREL webserver，但官方文档分散，缺少完整的API参考和使用示例","solution":"基于KAREL webserver实现HTTP API：webcontrol端点发送6种运动模式(关节/笛卡尔×绝对/相对)、webmonitor返回完整状态JSON(关节/笛卡尔/限位/状态/错误)、weblimit设置18个运动限位、webstart运行TP程序、webabort紧急停止","verification":"webcontrol/weblimit成功返回204状态码；webmonitor返回完整JSON包含joint/pose/limit/status/message/error/timestamp字段；各KAREL程序(webabort/webcheck/webkeep/webreset等)功能独立可测"}
+---
 
 ### 问题描述
 
@@ -115,7 +117,7 @@ GET /KAREL/webstart?str_task=webmotion
 
 | 程序 | 功能 |
 |------|------|
-| `webabort` | 紧急停止：中止所有任务，保存当前位置到PR[40](关节)/PR[41](笛卡尔)，清除标志1-8，设置R[42]=999 |
+| `webabort` | 紧急停止：中止所有任务，保存当前位置到 PR[40]（关节）/PR[41]（笛卡尔），清除标志1-8，设置 R[42]=999 |
 | `webcheck` | 检查位置可达性、限位、安全寄存器值 |
 | `webkeep` | 重置安全运动寄存器值 |
 | `webreset` | 重置控制器并中止所有任务 |

--- a/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
+++ b/lessons/contrib/feishu-websocket-404-error-http-webhook-required.md
@@ -1,15 +1,20 @@
 ---
 {
-  "domain": "contrib",
-  "title": "feishu websocket 404 error http webhook required",
-  "verification": "metadata-normalized",
-  "{\"title\"": "Feishu WebSocket 404 Error - HTTP Webhook Required\", \"domain\": \"feishu-integration\", \"source\": \"hermes_wsl2\", \"status\": \"published\", \"tags\": [], \"created\": \"2026-05-19 01:19:29 UTC\", \"updated\": \"2026-05-19 01:19:29 UTC\", \"domain_expert\": \"hermes_wsl2\", \"verified_date\": \"2026-05-19\"}",
-  "created": "2026-07-06",
-  "source": "unknown"
+  "title": "Feishu WebSocket 404 Error - HTTP Webhook Required",
+  "domain": "feishu",
+  "tags": ["feishu", "websocket", "webhook", "http", "api"],
+  "status": "published",
+  "evidence_level": "E0",
+  "source": "session-feedback",
+  "created": "2026-05-19",
+  "updated": "2026-07-06",
+  "verification": "metadata-normalized"
 }
 ---
 
 问题: 飞书 WebSocket 接收消息 API 返回 404 错误。测试端点: wss://open.feishu.cn/open-apis/bot/v3/ws, /bot/v2/ws, /im/v1/ws, /im/v2/ws, /webhook/v1/ws。所有端点均返回 404。修复: 消息发送功能正常 (通过 HTTP API with receive_id_type=chat_id), 但接收消息必须使用 HTTP Webhook 回调方式。验证: 2026-05-19 测试确认。
+
+结论: 不要继续轮换 WebSocket 路径；在飞书开发者后台配置可访问的 HTTP Webhook URL，并校验事件订阅验证请求与签名。
 ## Verification
 
 1. Follow the solution steps in order

--- a/lessons/contrib/github_api_pr_submission_pitfalls.md
+++ b/lessons/contrib/github_api_pr_submission_pitfalls.md
@@ -1,10 +1,19 @@
 ---
-name: github-api-pr-submission-pitfalls
-description: 用 GitHub API 直接提 PR（不 clone）的 4 个坑：base64 换行、SHA 冲突、空白行、diff 膨胀
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T09:43:52.372Z
+{
+  "title": "GitHub API PR Submission Pitfalls",
+  "domain": "devops",
+  "tags": ["github", "api", "pull-request", "base64", "git"],
+  "status": "published",
+  "evidence_level": "E0",
+  "source": "session-feedback",
+  "created": "2026-08-04",
+  "updated": "2026-08-04",
+  "metadata": {
+    "type": "feedback",
+    "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+    "modified": "2026-08-04T09:43:52.372Z"
+  }
+}
 ---
 
 ## 背景

--- a/lessons/contrib/glama-mcp-server-deploy-lessons.md
+++ b/lessons/contrib/glama-mcp-server-deploy-lessons.md
@@ -4,6 +4,7 @@
   "domain": "devops",
   "tags": ["glama", "mcp", "docker", "uv", "deployment", "ci-cd", "badges", "markdown"],
   "status": "published",
+  "evidence_level": "E0",
   "source": "agent_experience",
   "created": "2026-07-26",
   "confidence": "0.95"

--- a/lessons/contrib/heartbeat_scan_improvement.md
+++ b/lessons/contrib/heartbeat_scan_improvement.md
@@ -1,10 +1,19 @@
 ---
-name: heartbeat-scan-improvement
-description: 心跳扫描必须同时查 author PR 和 involvement issue，否则 claimed issue 会丢失
-metadata:
-  type: feedback
-  originSessionId: c8d99950-7aef-46ad-b4ce-4d0f910c86e9
-  modified: 2026-08-04T10:19:56.150Z
+{
+  "title": "GitHub Contribution Heartbeat Scan",
+  "domain": "devops",
+  "tags": ["github", "heartbeat", "monitoring", "pull-request", "issues"],
+  "status": "published",
+  "evidence_level": "E0",
+  "source": "session-feedback",
+  "created": "2026-08-04",
+  "updated": "2026-08-04",
+  "metadata": {
+    "type": "feedback",
+    "originSessionId": "c8d99950-7aef-46ad-b4ce-4d0f910c86e9",
+    "modified": "2026-08-04T10:19:56.150Z"
+  }
+}
 ---
 
 ## 问题

--- a/scripts/lesson_lint.py
+++ b/scripts/lesson_lint.py
@@ -5,6 +5,7 @@ Checks for:
 - Broken links (relative links to non-existent files)
 - Duplicate titles
 - Missing frontmatter (YAML or JSON)
+- Missing required frontmatter fields (title, domain, status)
 - Quality score anomalies
 - Empty or too-short lessons
 
@@ -25,10 +26,17 @@ from typing import Any
 
 # Files to exclude from linting (non-lesson files)
 EXCLUDE_FILES = {
+    "README.md",
     "TEMPLATE.md",
     "LESSON_QUALITY_SCORING.md",
     "index.md",
 }
+
+# These are the identity fields the linter can enforce consistently across
+# the repository's JSON and YAML-era lesson formats. The quality gate remains
+# responsible for stricter contribution-time fields such as tags/status/
+# evidence_level.
+REQUIRED_FRONTMATTER_FIELDS = ("title", "domain")
 
 # Directories to exclude
 EXCLUDE_DIRS = {
@@ -98,6 +106,13 @@ def parse_frontmatter(content: str) -> tuple[dict | None, int]:
         end_idx = content.find("---", 3)
         if end_idx > 0:
             yaml_str = content[3:end_idx].strip()
+            try:
+                parsed = json.loads(yaml_str)
+                if isinstance(parsed, dict):
+                    body_start = content[:end_idx].count("\n") + 1
+                    return parsed, body_start
+            except json.JSONDecodeError:
+                pass
             # Simple YAML parsing (key: value pairs)
             data = {}
             for line in yaml_str.split("\n"):
@@ -134,12 +149,40 @@ def check_frontmatter(content: str, file_path: Path) -> list[dict[str, str]]:
     return issues
 
 
+def check_frontmatter_fields(content: str, file_path: Path) -> list[dict[str, str]]:
+    """Check the identity fields required to index a lesson.
+
+    Contribution-time fields such as tags, status, and evidence_level are
+    validated by lesson_gate.py. Keeping this repository-wide check focused on
+    identity fields lets it handle the existing JSON and YAML-era formats
+    without rewriting unrelated lessons.
+    """
+    frontmatter, _ = parse_frontmatter(content)
+    if frontmatter is None:
+        return []
+
+    issues = []
+    for field in REQUIRED_FRONTMATTER_FIELDS:
+        value = frontmatter.get(field)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            issues.append({
+                "rule": "missing_frontmatter_field",
+                "severity": "medium",
+                "file": str(file_path),
+                "message": f"Missing required frontmatter field: {field}"
+            })
+    return issues
+
+
 def check_title(content: str, file_path: Path) -> list[dict[str, str]]:
-    """Check for H1 title."""
+    """Check for a title in metadata or an H1 in the lesson body."""
     issues = []
     lines = content.split("\n")
-    # Skip frontmatter
-    _, body_start = parse_frontmatter(content)
+    frontmatter, body_start = parse_frontmatter(content)
+    metadata_title = frontmatter.get("title") if frontmatter else None
+    if isinstance(metadata_title, str) and metadata_title.strip():
+        return issues
+
     search_lines = lines[body_start:body_start + 10] if body_start > 0 else lines[:10]
     has_h1 = any(line.startswith("# ") for line in search_lines)
     if not has_h1:
@@ -169,22 +212,27 @@ def check_length(content: str, file_path: Path) -> list[dict[str, str]]:
 
 
 def check_links(content: str, file_path: Path, lessons_dir: Path) -> list[dict[str, str]]:
-    """Check for broken relative links."""
+    """Check for broken relative links in rendered Markdown.
+
+    Fenced code is instructional example text, not a rendered link. Skipping
+    it avoids treating placeholders such as ``(img-url)`` as repository files.
+    Image sources are checked separately so the nested ``[![alt](img)]`` form
+    cannot confuse the regular-link parser.
+    """
     issues = []
-    # Find markdown links: [text](path)
-    link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
-    for match in link_pattern.finditer(content):
-        link_text, link_path = match.groups()
+    regular_link = re.compile(r'(?<!!)\[([^\]]*)\]\(([^)]+)\)')
+    image_link = re.compile(r'!\[([^\]]*)\]\(([^)]+)\)')
+
+    def report(link_text: str, link_path: str) -> None:
         # Skip external URLs and anchors
         if link_path.startswith(("http://", "https://", "#", "mailto:")):
-            continue
+            return
         # Skip absolute paths
         if link_path.startswith("/"):
-            continue
+            return
         # Skip references to lessons/ directory (common in README)
         if "lessons/" in link_path:
-            continue
-        # Resolve relative link
+            return
         target = (file_path.parent / link_path).resolve()
         if not target.exists():
             issues.append({
@@ -193,6 +241,20 @@ def check_links(content: str, file_path: Path, lessons_dir: Path) -> list[dict[s
                 "file": str(file_path),
                 "message": f"Broken link: [{link_text}]({link_path})"
             })
+
+    in_fence = False
+    for line in content.splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        # Inline code is also instructional text, not a rendered link.
+        rendered_line = re.sub(r"`[^`]*`", "", line)
+        for match in image_link.finditer(rendered_line):
+            report(match.group(1), match.group(2))
+        for match in regular_link.finditer(rendered_line):
+            report(match.group(1), match.group(2))
     return issues
 
 
@@ -250,6 +312,7 @@ def lint_lesson(file_path: Path, lessons_dir: Path) -> list[dict[str, str]]:
     content = file_path.read_text(encoding="utf-8")
     issues = []
     issues.extend(check_frontmatter(content, file_path))
+    issues.extend(check_frontmatter_fields(content, file_path))
     issues.extend(check_title(content, file_path))
     issues.extend(check_length(content, file_path))
     issues.extend(check_links(content, file_path, lessons_dir))

--- a/tests/test_lesson_lint.py
+++ b/tests/test_lesson_lint.py
@@ -1,0 +1,57 @@
+"""Regression tests for the repository-wide lesson lint contract."""
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.lesson_lint import (
+    check_frontmatter_fields,
+    check_links,
+    check_title,
+    is_lesson_file,
+)
+
+
+class TestLessonLint(unittest.TestCase):
+    def test_metadata_title_is_a_valid_lesson_title(self):
+        content = (
+            '---\n{"title": "Metadata title", "domain": "devops", '
+            '"status": "published"}\n---\n\n## Body\n'
+        )
+        self.assertEqual(check_title(content, Path("lesson.md")), [])
+
+    def test_required_frontmatter_fields_are_reported(self):
+        content = '---\n{"status": "published"}\n---\n\nBody\n'
+        rules = [item["rule"] for item in check_frontmatter_fields(content, Path("lesson.md"))]
+        self.assertEqual(rules, ["missing_frontmatter_field", "missing_frontmatter_field"])
+
+    def test_readme_is_not_classified_as_a_lesson(self):
+        lessons_dir = Path("lessons")
+        self.assertFalse(is_lesson_file(lessons_dir / "core" / "README.md", lessons_dir))
+
+    def test_code_examples_do_not_create_broken_links(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lesson = root / "lesson.md"
+            lesson.write_text(
+                "Before: `[![alt](img-url)](link-url)`\n"
+                "```markdown\n[example](placeholder.md)\n```\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(check_links(lesson.read_text(encoding="utf-8"), lesson, root), [])
+
+    def test_rendered_relative_link_must_exist(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lesson = root / "lesson.md"
+            lesson.write_text("[missing](missing.md)\n", encoding="utf-8")
+            issues = check_links(lesson.read_text(encoding="utf-8"), lesson, root)
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0]["rule"], "broken_link")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes the repository-wide lint cleanup for #999 without adding generated headings to hundreds of lessons.

## Changes

- Treat a non-empty frontmatter `title` as the canonical lesson title, matching the repository schema.
- Add identity-field checks for `title` and `domain`.
- Exclude README and other non-lesson files from lesson checks.
- Ignore fenced and inline-code examples when checking rendered relative links; validate image links separately.
- Remove the two real malformed relative links in the FANUC lesson.
- Normalize seven touched lesson frontmatters and add conservative `evidence_level: E0` metadata so the quality gate can validate the files.
- Expand the Feishu lesson with the actionable webhook conclusion.
- Add regression tests for metadata titles, field checks, README exclusion, code examples, and rendered links.

## Validation

```text
$ python3 tests/test_lesson_lint.py
Ran 5 tests ... OK

$ python3 scripts/lesson_lint.py --lessons-dir lessons --fail-on medium --verbose
[OK] No issues found!

$ python3 scripts/lesson_gate.py <7 modified lessons>
OK: 7 file(s) passed the lesson quality gate.
```

Closes #999
