### PR TITLE
feat: add contributor reputation leaderboard

### DIFF
--- a/docs/insights/reputation-leaderboard.html
+++ b/docs/insights/reputation-leaderboard.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MisakaNet — Contributor Reputation</title>
+<meta name="description" content="Public MisakaNet contributor reputation leaderboard. Points are internal recognition only and have no cash value.">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; min-height: 100vh;
+    display: flex; flex-direction: column; align-items: center; padding: 2rem 1rem;
+  }
+  .container { max-width: 820px; width: 100%; }
+  h1 { font-size: 1.5rem; font-weight: 600; color: #58a6ff; margin-bottom: 0.25rem; }
+  h2 { font-size: 1.05rem; font-weight: 600; color: #e6edf3; margin: 2rem 0 0.75rem; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 1.5rem; line-height: 1.6; }
+  .notice {
+    border: 1px solid #30363d; border-left: 3px solid #d29922; border-radius: 8px;
+    background: #161b22; padding: 0.9rem 1rem; font-size: 0.85rem; color: #8b949e; line-height: 1.7;
+  }
+  .toolbar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1.5rem; }
+  label { color: #8b949e; font-size: 0.85rem; }
+  select {
+    background: #161b22; color: #e6edf3; border: 1px solid #30363d; border-radius: 6px;
+    padding: 0.45rem 0.6rem; font: inherit;
+  }
+  .updated { color: #6e7681; font-size: 0.8rem; margin-left: auto; }
+  .table-wrap { overflow-x: auto; margin-top: 0.75rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.65rem 0.75rem; border-bottom: 1px solid #21262d; }
+  th { color: #8b949e; font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  tbody tr:hover { background: #161b22; }
+  .rank { width: 3rem; color: #8b949e; }
+  .login { color: #e6edf3; font-weight: 600; }
+  .points { color: #3fb950; font-weight: 600; }
+  .state { color: #8b949e; font-size: 0.9rem; padding: 1.25rem 0; }
+  .state.error { color: #f85149; }
+  a { color: #58a6ff; }
+  footer { margin-top: 2.5rem; font-size: 0.8rem; color: #6e7681; line-height: 1.8; }
+  @media (max-width: 520px) {
+    body { padding: 1.25rem 0.75rem; }
+    .toolbar { align-items: flex-start; flex-wrap: wrap; }
+    .updated { width: 100%; margin-left: 0; }
+    th, td { padding: 0.55rem 0.45rem; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>🏆 Contributor Reputation</h1>
+  <p class="subtitle">
+    The top MisakaNet contributors by the project's internal reputation points.
+    Choose a time window to see recent activity without losing the all-time ledger.
+  </p>
+
+  <div class="notice">
+    <strong>Important:</strong> reputation points are non-transferable recognition only.
+    They have no cash value, are not tokens, and cannot be exchanged.
+  </div>
+
+  <div class="toolbar">
+    <label for="period">Time window</label>
+    <select id="period">
+      <option value="all-time">All-time</option>
+      <option value="monthly">Last 30 days</option>
+      <option value="weekly">Last 7 days</option>
+    </select>
+    <span class="updated" id="updated">Loading…</span>
+  </div>
+
+  <h2>Top contributors</h2>
+  <div class="table-wrap">
+    <table id="leaderboard" hidden>
+      <thead><tr><th>Rank</th><th>Contributor</th><th class="num">Window points</th><th class="num">All-time</th><th class="num">Activity</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div class="state" id="state">Loading…</div>
+
+  <footer>
+    Source: <code>GET /api/insights/reputation-leaderboard</code> ·
+    <a href="https://github.com/Ikalus1988/MisakaNet/issues/908">issue #908</a> ·
+    <a href="../reputation.md">scoring and anti-gaming rules</a>
+  </footer>
+</div>
+
+<script>
+const API = window.location.origin + '/api/insights/reputation-leaderboard';
+const period = document.getElementById('period');
+
+function escapeHTML(value) {
+  return String(value).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function formatPoints(value) {
+  return Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function render(data) {
+  const table = document.getElementById('leaderboard');
+  const state = document.getElementById('state');
+  const rows = data.leaderboard || [];
+  document.getElementById('updated').textContent = data.updatedAt
+    ? 'Ledger updated ' + new Date(data.updatedAt).toLocaleString()
+    : 'Ledger update unavailable';
+  if (!rows.length) {
+    state.textContent = 'No reputation activity is available for this window.';
+    table.hidden = true;
+    return;
+  }
+  table.querySelector('tbody').innerHTML = rows.map(row =>
+    '<tr>' +
+      '<td class="rank">#' + escapeHTML(row.rank) + '</td>' +
+      '<td class="login">' + escapeHTML(row.login) + '</td>' +
+      '<td class="num points">' + formatPoints(row.points) + '</td>' +
+      '<td class="num">' + formatPoints(row.totalPoints) + '</td>' +
+      '<td class="num">' + escapeHTML(row.activityCount) + '</td>' +
+    '</tr>'
+  ).join('');
+  table.hidden = false;
+  state.hidden = true;
+}
+
+async function load() {
+  const state = document.getElementById('state');
+  state.hidden = false;
+  state.className = 'state';
+  state.textContent = 'Loading…';
+  try {
+    const response = await fetch(API + '?period=' + encodeURIComponent(period.value), { cache: 'no-store' });
+    const data = await response.json();
+    if (!response.ok || !data.success) throw new Error(data.error || 'request failed');
+    render(data);
+  } catch (error) {
+    state.textContent = 'Could not load the leaderboard. Try again later.';
+    state.className = 'state error';
+  }
+}
+
+period.addEventListener('change', load);
+load();
+</script>
+</body>
+</html>

--- a/tests/test_reputation_leaderboard.py
+++ b/tests/test_reputation_leaderboard.py
@@ -1,0 +1,44 @@
+"""Static contract tests for the contributor reputation leaderboard (#908)."""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PAGE = REPO_ROOT / "docs" / "insights" / "reputation-leaderboard.html"
+WORKER = REPO_ROOT / "workers" / "register-proxy-sw.js"
+
+
+class TestReputationLeaderboardPage(unittest.TestCase):
+    def setUp(self):
+        self.html = PAGE.read_text(encoding="utf-8")
+        self.worker = WORKER.read_text(encoding="utf-8")
+
+    def test_page_and_endpoint_are_wired(self):
+        self.assertTrue(PAGE.exists())
+        self.assertIn("/api/insights/reputation-leaderboard", self.html)
+        self.assertIn('value="all-time"', self.html)
+        self.assertIn('value="monthly"', self.html)
+        self.assertIn('value="weekly"', self.html)
+        self.assertIn('url.pathname === "/api/insights/reputation-leaderboard"', self.worker)
+
+    def test_page_is_responsive_and_self_contained(self):
+        self.assertIn("@media (max-width: 520px)", self.html)
+        self.assertNotIn("<script src=", self.html)
+        self.assertNotIn("cdn.", self.html)
+        self.assertIn("function escapeHTML", self.html)
+
+    def test_page_discloses_non_monetary_points(self):
+        self.assertIn("no cash value", self.html.lower())
+        self.assertIn('cashValue: false', self.worker)
+        self.assertIn('pointsSource: "data/contributor-points.json"', self.worker)
+
+    def test_backend_caps_and_filters_the_public_shape(self):
+        self.assertIn("REPUTATION_MAX_ENTRIES = 20", self.worker)
+        self.assertIn('"all-time": null', self.worker)
+        self.assertIn("historyPoints", self.worker)
+        self.assertIn("totalPoints", self.worker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workers/README.md
+++ b/workers/README.md
@@ -98,11 +98,16 @@ jobs:
 | 方法 | 路径 | 说明 |
 |------|------|------|
 | GET | `/api/insights/unsolved-map` | 公开、仅聚合：30 天窗口内各 task family 的未解决次数（`no_match` / `low_confidence` / `not_helpful`）+ 被标记为无用的 lesson |
+| GET | `/api/insights/reputation-leaderboard?period=all-time\|monthly\|weekly` | 公开贡献者声誉榜：最多 20 名，读取 `data/contributor-points.json`，按时间窗口聚合历史积分 |
 | POST | `/api/search-signal` | 前端在搜索无结果 / 低置信度时上报；Worker 在内存中把 query 归类到 task family 后**立即丢弃原文**，只写入聚合计数（IP 限流 30 次/分钟，body 上限 4KB） |
 
 隐私约束：只存储派生的 family 标签与固定枚举 reason，绝不写入原始 query、prompt、日志、路径或任何身份标识。
 `/api/feedback` 收到 `irrelevant` / `too_basic` 时同样只写入聚合信号 + 公开 lesson ID。
 公开页面：[`docs/insights/unsolved-map.html`](../docs/insights/unsolved-map.html) → https://misakanet.org/insights/unsolved-map.html
+
+公开声誉榜：[`docs/insights/reputation-leaderboard.html`](../docs/insights/reputation-leaderboard.html) → https://misakanet.org/insights/reputation-leaderboard.html
+
+声誉点数是项目内部、不可转让且无现金价值的贡献记录；接口返回的 `meta.cashValue` 和 `meta.transferable` 始终为 `false`。
 
 ```bash
 node --test workers/unsolved-map.test.mjs   # 分类 / 聚合 / 隐私 / 限流单测

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -5,6 +5,7 @@
 
 const REPO = "Ikalus1988/MisakaNet";
 const GITHUB_API = "https://api.github.com";
+const PUBLIC_DATA_BASE = "https://raw.githubusercontent.com/Ikalus1988/MisakaNet/main/data";
 const PROXY_CACHE_TTL = 30_000;
 const KEEPALIVE_ENDPOINTS = [
   { name: "health", url: "https://misakanet.org/api/health", json: true },
@@ -443,6 +444,136 @@ async function getWithCache(env, cacheKey, fetchFn) {
     try { await env.MISAKANET_KV.put(cacheKey, JSON.stringify({ ts: Date.now(), data }), { expirationTtl: Math.ceil(PROXY_CACHE_TTL / 1000) + 30 }); } catch {}
   }
   return data;
+}
+
+async function fetchPublicJson(path) {
+  const resp = await fetch(`${PUBLIC_DATA_BASE}/${path}`, {
+    headers: { "User-Agent": "MisakaNet-Insights/1.0", Accept: "application/json" },
+  });
+  if (!resp.ok) throw new Error(`Public data ${resp.status}`);
+  return resp.json();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Contributor reputation leaderboard (Issue #908)
+//
+// The source of truth is data/contributor-points.json, the same non-transferable
+// point ledger used by scripts/update_contributor_points.py. Period filters are
+// calculated from its history so the public view does not confuse all-time
+// totals with recent activity.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const REPUTATION_MAX_ENTRIES = 20;
+const REPUTATION_PERIODS = {
+  "all-time": null,
+  monthly: 30,
+  weekly: 7,
+};
+
+function normalizeReputationPeriod(value) {
+  const period = String(value || "all-time").toLowerCase();
+  if (period === "all_time" || period === "alltime") return "all-time";
+  if (period === "month") return "monthly";
+  if (period === "week") return "weekly";
+  return Object.prototype.hasOwnProperty.call(REPUTATION_PERIODS, period) ? period : null;
+}
+
+function parseTimestamp(value) {
+  const timestamp = Date.parse(String(value || ""));
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function roundPoints(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function buildReputationLeaderboard(source, period = "all-time", now = Date.now()) {
+  const normalizedPeriod = normalizeReputationPeriod(period);
+  if (!normalizedPeriod) throw new Error("Unsupported reputation period");
+
+  const contributors = source && typeof source.contributors === "object"
+    ? source.contributors
+    : {};
+  const windowDays = REPUTATION_PERIODS[normalizedPeriod];
+  const cutoff = windowDays === null ? null : now - windowDays * 86_400_000;
+  const rows = [];
+
+  for (const [login, record] of Object.entries(contributors)) {
+    if (!record || typeof record !== "object") continue;
+    const history = Array.isArray(record.history) ? record.history : [];
+    const events = history.filter((event) => {
+      if (cutoff === null) return true;
+      const timestamp = parseTimestamp(event && event.timestamp);
+      return timestamp !== null && timestamp >= cutoff;
+    });
+    const historyPoints = events.reduce((sum, event) => {
+      const points = Number(event && event.points);
+      return Number.isFinite(points) ? sum + points : sum;
+    }, 0);
+    const ledgerTotal = Number(record.total_points);
+    const totalPoints = Number.isFinite(ledgerTotal)
+      ? ledgerTotal
+      : history.reduce((sum, event) => {
+        const points = Number(event && event.points);
+        return Number.isFinite(points) ? sum + points : sum;
+      }, 0);
+    const points = cutoff === null ? totalPoints : historyPoints;
+
+    // A monthly/weekly leaderboard should contain contributors with activity
+    // in that window, while all-time preserves a ledger entry even at zero.
+    if (cutoff !== null && events.length === 0) continue;
+    rows.push({
+      login: String(login).slice(0, 64),
+      points: roundPoints(points),
+      totalPoints: roundPoints(totalPoints),
+      activityCount: events.length,
+      lastActivity: typeof record.last_activity === "string" ? record.last_activity : null,
+    });
+  }
+
+  rows.sort((a, b) => b.points - a.points || b.totalPoints - a.totalPoints || a.login.localeCompare(b.login));
+  return rows.slice(0, REPUTATION_MAX_ENTRIES).map((row, index) => ({ ...row, rank: index + 1 }));
+}
+
+async function handleReputationLeaderboard(request, env) {
+  const requested = new URL(request.url).searchParams.get("period") || "all-time";
+  const period = normalizeReputationPeriod(requested);
+  if (!period) {
+    return jsonResponse({
+      success: false,
+      error: "Unsupported period",
+      supportedPeriods: Object.keys(REPUTATION_PERIODS),
+    }, 400);
+  }
+
+  try {
+    let source = env.REPUTATION_DATA;
+    if (typeof source === "string") source = JSON.parse(source);
+    if (!source || typeof source !== "object") {
+      source = await getWithCache(
+        env,
+        "insights:reputation-points",
+        () => fetchPublicJson("contributor-points.json"),
+      );
+    }
+    const contributors = source && typeof source.contributors === "object" ? source.contributors : {};
+    return jsonResponse({
+      success: true,
+      period,
+      windowDays: REPUTATION_PERIODS[period],
+      updatedAt: typeof source._last_updated === "string" ? source._last_updated : null,
+      totalContributors: Object.keys(contributors).length,
+      leaderboard: buildReputationLeaderboard(source, period),
+      meta: {
+        pointsSource: "data/contributor-points.json",
+        cashValue: false,
+        transferable: false,
+      },
+    });
+  } catch (error) {
+    console.error("[reputation] source unavailable", error && error.message);
+    return jsonResponse({ success: false, error: "Reputation data unavailable", period }, 502);
+  }
 }
 
 function sanitizeIdentifier(val, maxLen) {
@@ -933,6 +1064,11 @@ export default {
       return handleUnsolvedMap(env);
     }
 
+    // GET /api/insights/reputation-leaderboard — public points leaderboard (#908)
+    if (request.method === "GET" && url.pathname === "/api/insights/reputation-leaderboard") {
+      return handleReputationLeaderboard(request, env);
+    }
+
     // GET /api/insights/demand-board — public aggregate view of intake clusters
     if (request.method === "GET" && url.pathname === "/api/insights/demand-board") {
       if (!env.MISAKANET_KV) return jsonResponse({ success: true, available: false, summary: [] });
@@ -1346,8 +1482,10 @@ export {
   UNSOLVED_WINDOW_DAYS,
   buildUnsolvedMap,
   classifyTaskFamily,
+  buildReputationLeaderboard,
   getIdentityAura,
   handleSearchSignal,
+  handleReputationLeaderboard,
   handleUnsolvedMap,
   recordStaleLesson,
   recordUnsolvedSearch,

--- a/workers/reputation-leaderboard.test.mjs
+++ b/workers/reputation-leaderboard.test.mjs
@@ -1,0 +1,78 @@
+// Unit tests for the public reputation leaderboard (Issue #908).
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import worker, {
+  buildReputationLeaderboard,
+  handleReputationLeaderboard,
+} from './register-proxy-sw.js';
+
+const NOW = Date.parse('2026-08-13T12:00:00Z');
+const SOURCE = {
+  _last_updated: '2026-08-13T11:00:00Z',
+  contributors: {
+    alice: {
+      total_points: 15,
+      last_activity: '2026-08-12T12:00:00Z',
+      history: [
+        { timestamp: '2026-07-01T12:00:00Z', points: 10 },
+        { timestamp: '2026-08-12T12:00:00Z', points: 5 },
+      ],
+    },
+    bob: {
+      total_points: 20,
+      last_activity: '2026-08-13T10:00:00Z',
+      history: [{ timestamp: '2026-08-13T10:00:00Z', points: 20 }],
+    },
+    carol: {
+      total_points: 3,
+      last_activity: '2026-08-01T10:00:00Z',
+      history: [{ timestamp: '2026-08-01T10:00:00Z', points: 3 }],
+    },
+  },
+};
+
+test('all-time ranks by the ledger total and adds stable ranks', () => {
+  const rows = buildReputationLeaderboard(SOURCE, 'all-time', NOW);
+  assert.deepEqual(rows.map((row) => row.login), ['bob', 'alice', 'carol']);
+  assert.deepEqual(rows.map((row) => row.rank), [1, 2, 3]);
+  assert.equal(rows[1].points, 15);
+  assert.equal(rows[1].totalPoints, 15);
+});
+
+test('monthly and weekly filters use timestamped history', () => {
+  const monthly = buildReputationLeaderboard(SOURCE, 'monthly', NOW);
+  assert.deepEqual(monthly.map((row) => row.login), ['bob', 'alice', 'carol']);
+  assert.deepEqual(monthly.map((row) => row.points), [20, 5, 3]);
+
+  const weekly = buildReputationLeaderboard(SOURCE, 'weekly', NOW);
+  assert.deepEqual(weekly.map((row) => row.login), ['bob', 'alice']);
+  assert.deepEqual(weekly.map((row) => row.points), [20, 5]);
+});
+
+test('handler validates periods and exposes the canonical source contract', async () => {
+  const invalid = await handleReputationLeaderboard(
+    new Request('https://misakanet.org/api/insights/reputation-leaderboard?period=yearly'),
+    { REPUTATION_DATA: SOURCE },
+  );
+  assert.equal(invalid.status, 400);
+
+  const response = await handleReputationLeaderboard(
+    new Request('https://misakanet.org/api/insights/reputation-leaderboard?period=weekly'),
+    { REPUTATION_DATA: SOURCE },
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.period, 'weekly');
+  assert.equal(body.meta.pointsSource, 'data/contributor-points.json');
+  assert.equal(body.meta.cashValue, false);
+  assert.ok(body.leaderboard.every((row) => row.rank <= 20));
+});
+
+test('public worker route works without REGISTER_TOKEN', async () => {
+  const response = await worker.fetch(
+    new Request('https://misakanet.org/api/insights/reputation-leaderboard'),
+    { REPUTATION_DATA: SOURCE },
+  );
+  assert.equal(response.status, 200);
+});


### PR DESCRIPTION
## Summary

Implements the public contributor reputation leaderboard requested in #908.

## Changes

- Adds `GET /api/insights/reputation-leaderboard?period=all-time|monthly|weekly` to the deployed Worker.
- Reads the canonical `data/contributor-points.json` ledger and caches the public source for 30 seconds.
- Calculates monthly and weekly views from timestamped history, keeps all-time totals separate, and caps output at the top 20 contributors.
- Returns an explicit non-monetary/non-transferable metadata contract.
- Adds a self-contained responsive page at `docs/insights/reputation-leaderboard.html`.
- Documents the endpoint and page in `workers/README.md`.
- Adds Node and Python regression coverage for sorting, time windows, route behavior, privacy/disclosure, and responsive page wiring.

## Validation

```text
$ node --test workers/reputation-leaderboard.test.mjs
4 passed

$ python3 tests/test_reputation_leaderboard.py
Ran 4 tests ... OK

$ node --check workers/register-proxy-sw.js
passed
```

Closes #908
