### PR TITLE
feat: add lesson coverage dashboard

### DIFF
--- a/docs/insights/lesson-coverage.html
+++ b/docs/insights/lesson-coverage.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MisakaNet — Lesson Coverage</title>
+<meta name="description" content="Public dashboard of MisakaNet lesson coverage, unsolved failure gaps, and lessons needing review.">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; min-height: 100vh;
+    display: flex; flex-direction: column; align-items: center; padding: 2rem 1rem;
+  }
+  .container { max-width: 900px; width: 100%; }
+  h1 { font-size: 1.5rem; font-weight: 600; color: #58a6ff; margin-bottom: 0.25rem; }
+  h2 { font-size: 1.05rem; font-weight: 600; color: #e6edf3; margin: 2rem 0 0.75rem; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 1.5rem; line-height: 1.6; }
+  .privacy {
+    border: 1px solid #30363d; border-left: 3px solid #3fb950; border-radius: 8px;
+    background: #161b22; padding: 0.9rem 1rem; font-size: 0.85rem; color: #8b949e; line-height: 1.7;
+  }
+  .cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; margin-top: 1.5rem; }
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 0.85rem; }
+  .card-label { color: #8b949e; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  .card-value { color: #e6edf3; font-size: 1.45rem; font-weight: 600; margin-top: 0.35rem; }
+  .chart { display: grid; gap: 0.7rem; }
+  .family-row { display: grid; grid-template-columns: 150px 1fr 55px; gap: 0.75rem; align-items: center; font-size: 0.85rem; }
+  .family-name { color: #e6edf3; overflow-wrap: anywhere; }
+  .track { height: 9px; background: #21262d; border-radius: 5px; overflow: hidden; }
+  .bar { height: 100%; border-radius: 5px; background: #3fb950; min-width: 2px; }
+  .bar.review { background: #d29922; }
+  .bar.uncovered { background: #f85149; }
+  .count { color: #8b949e; text-align: right; font-variant-numeric: tabular-nums; }
+  .status { font-size: 0.72rem; margin-left: 0.35rem; white-space: nowrap; }
+  .status.covered { color: #3fb950; }
+  .status.needs-review { color: #d29922; }
+  .status.uncovered { color: #f85149; }
+  .table-wrap { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.6rem 0.75rem; border-bottom: 1px solid #21262d; }
+  th { color: #8b949e; font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  tbody tr:hover { background: #161b22; }
+  .state { color: #8b949e; font-size: 0.9rem; padding: 1.25rem 0; }
+  .state.error { color: #f85149; }
+  a { color: #58a6ff; }
+  footer { margin-top: 2.5rem; font-size: 0.8rem; color: #6e7681; line-height: 1.8; }
+  @media (max-width: 700px) {
+    .cards { grid-template-columns: repeat(2, 1fr); }
+    .family-row { grid-template-columns: 125px 1fr 45px; }
+  }
+  @media (max-width: 460px) {
+    body { padding: 1.25rem 0.75rem; }
+    .family-row { grid-template-columns: 1fr 80px; }
+    .family-name { grid-column: 1 / -1; }
+    .track { grid-column: 1; }
+    .count { grid-column: 2; grid-row: 2; }
+    th, td { padding: 0.55rem 0.45rem; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>🗺️ Lesson Coverage</h1>
+  <p class="subtitle">
+    Which failure families have reusable lessons, and where recent unsolved signals
+    suggest that existing coverage needs review? The dashboard uses the public lesson index
+    plus aggregate signals from the last 30 days.
+  </p>
+
+  <div class="privacy">
+    <strong>Privacy:</strong> this view contains public lesson metadata and aggregate family counts only.
+    Raw search queries, prompts, logs, paths, and personal identifiers are never returned.
+  </div>
+
+  <div class="cards" id="cards" hidden>
+    <div class="card"><div class="card-label">Published lessons</div><div class="card-value" id="published">—</div></div>
+    <div class="card"><div class="card-label">Family coverage</div><div class="card-value" id="coverage">—</div></div>
+    <div class="card"><div class="card-label">Coverage gaps</div><div class="card-value" id="gaps">—</div></div>
+    <div class="card"><div class="card-label">Unsolved families</div><div class="card-value" id="unsolved">—</div></div>
+  </div>
+
+  <div class="state" id="state">Loading…</div>
+  <section id="content" hidden>
+    <h2>Coverage by failure family</h2>
+    <div class="chart" id="chart"></div>
+
+    <h2>Prioritized gaps</h2>
+    <div class="table-wrap">
+      <table id="gaps-table">
+        <thead><tr><th>Family</th><th>Status</th><th class="num">Lessons</th><th class="num">Unsolved (30d)</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <h2>Lessons reported as not helpful</h2>
+    <div class="table-wrap">
+      <table id="stale-table">
+        <thead><tr><th>Lesson</th><th class="num">Reports (30d)</th><th>Last seen</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  <footer>
+    Source: <code>GET /api/insights/lesson-coverage</code> ·
+    <a href="https://github.com/Ikalus1988/MisakaNet/issues/905">issue #905</a> ·
+    <a href="unsolved-map.html">unsolved failure map</a>
+  </footer>
+</div>
+
+<script>
+const API = window.location.origin + '/api/insights/lesson-coverage';
+
+function escapeHTML(value) {
+  return String(value).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function statusLabel(value) {
+  return String(value || '').replace('-', ' ');
+}
+
+function render(data) {
+  const metrics = data.metrics || {};
+  document.getElementById('published').textContent = metrics.publishedLessons || 0;
+  document.getElementById('coverage').textContent = (metrics.coveragePercent || 0) + '%';
+  document.getElementById('gaps').textContent = metrics.gapCount || 0;
+  document.getElementById('unsolved').textContent = metrics.unsolvedFamilyCount || 0;
+  document.getElementById('cards').hidden = false;
+
+  const families = data.families || [];
+  const maxLessons = Math.max(1, ...families.map(f => Number(f.lessonCount) || 0));
+  document.getElementById('chart').innerHTML = families.map(f => {
+    const status = escapeHTML(f.coverageStatus || 'uncovered');
+    const width = Math.round(((Number(f.lessonCount) || 0) / maxLessons) * 100);
+    return '<div class="family-row">' +
+      '<div class="family-name">' + escapeHTML(f.taskFamily) + '<span class="status ' + status + '">' + escapeHTML(statusLabel(f.coverageStatus)) + '</span></div>' +
+      '<div class="track"><div class="bar ' + status + '" style="width:' + width + '%"></div></div>' +
+      '<div class="count">' + escapeHTML(f.lessonCount) + '</div>' +
+    '</div>';
+  }).join('');
+
+  document.querySelector('#gaps-table tbody').innerHTML = (data.gaps || []).map(f =>
+    '<tr><td>' + escapeHTML(f.taskFamily) + '</td>' +
+      '<td class="status ' + escapeHTML(f.coverageStatus) + '">' + escapeHTML(statusLabel(f.coverageStatus)) + '</td>' +
+      '<td class="num">' + escapeHTML(f.lessonCount) + '</td>' +
+      '<td class="num">' + escapeHTML(f.unsolved30d) + '</td></tr>'
+  ).join('') || '<tr><td colspan="4">No coverage gaps in the current family set.</td></tr>';
+
+  document.querySelector('#stale-table tbody').innerHTML = (data.staleLessons || []).map(l =>
+    '<tr><td>' + escapeHTML(l.lessonId) + '</td>' +
+      '<td class="num">' + escapeHTML(l.notHelpful30d) + '</td>' +
+      '<td>' + escapeHTML(l.lastSeen || '—') + '</td></tr>'
+  ).join('') || '<tr><td colspan="3">No lessons flagged as not helpful in the current window.</td></tr>';
+
+  document.getElementById('content').hidden = false;
+  document.getElementById('state').hidden = true;
+}
+
+fetch(API, { cache: 'no-store' })
+  .then(response => response.json().then(data => ({ response, data })))
+  .then(({ response, data }) => {
+    if (!response.ok || !data.success) throw new Error(data.error || 'request failed');
+    render(data);
+  })
+  .catch(() => {
+    const state = document.getElementById('state');
+    state.textContent = 'Could not load coverage data. Try again later.';
+    state.className = 'state error';
+  });
+</script>
+</body>
+</html>

--- a/tests/test_lesson_coverage.py
+++ b/tests/test_lesson_coverage.py
@@ -1,0 +1,43 @@
+"""Static contract tests for the lesson coverage dashboard (#905)."""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PAGE = REPO_ROOT / "docs" / "insights" / "lesson-coverage.html"
+WORKER = REPO_ROOT / "workers" / "register-proxy-sw.js"
+
+
+class TestLessonCoverageDashboard(unittest.TestCase):
+    def setUp(self):
+        self.html = PAGE.read_text(encoding="utf-8")
+        self.worker = WORKER.read_text(encoding="utf-8")
+
+    def test_endpoint_and_page_are_wired(self):
+        self.assertTrue(PAGE.exists())
+        self.assertIn("/api/insights/lesson-coverage", self.html)
+        self.assertIn('url.pathname === "/api/insights/lesson-coverage"', self.worker)
+        self.assertIn("buildLessonCoverage", self.worker)
+
+    def test_dashboard_has_metrics_chart_and_gaps_table(self):
+        for marker in ("publishedLessons", "coveragePercent", "gapCount", "unsolvedFamilyCount", "id=\"chart\"", "gaps-table"):
+            self.assertIn(marker, self.html)
+        self.assertIn("needs-review", self.html)
+        self.assertIn("uncovered", self.html)
+
+    def test_page_is_responsive_self_contained_and_escaped(self):
+        self.assertIn("@media (max-width: 700px)", self.html)
+        self.assertIn("@media (max-width: 460px)", self.html)
+        self.assertNotIn("<script src=", self.html)
+        self.assertNotIn("cdn.", self.html)
+        self.assertIn("function escapeHTML", self.html)
+
+    def test_privacy_contract_is_explicit(self):
+        self.assertIn("Raw search queries", self.html)
+        self.assertIn('raw_query: false', self.worker)
+        self.assertIn('pii: false', self.worker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workers/README.md
+++ b/workers/README.md
@@ -98,11 +98,14 @@ jobs:
 | 方法 | 路径 | 说明 |
 |------|------|------|
 | GET | `/api/insights/unsolved-map` | 公开、仅聚合：30 天窗口内各 task family 的未解决次数（`no_match` / `low_confidence` / `not_helpful`）+ 被标记为无用的 lesson |
+| GET | `/api/insights/lesson-coverage` | 公开 lesson 覆盖看板：发布 lesson 数、family 覆盖率、`covered` / `needs-review` / `uncovered` gaps，以及 not-helpful lessons |
 | POST | `/api/search-signal` | 前端在搜索无结果 / 低置信度时上报；Worker 在内存中把 query 归类到 task family 后**立即丢弃原文**，只写入聚合计数（IP 限流 30 次/分钟，body 上限 4KB） |
 
 隐私约束：只存储派生的 family 标签与固定枚举 reason，绝不写入原始 query、prompt、日志、路径或任何身份标识。
 `/api/feedback` 收到 `irrelevant` / `too_basic` 时同样只写入聚合信号 + 公开 lesson ID。
 公开页面：[`docs/insights/unsolved-map.html`](../docs/insights/unsolved-map.html) → https://misakanet.org/insights/unsolved-map.html
+
+公开覆盖看板：[`docs/insights/lesson-coverage.html`](../docs/insights/lesson-coverage.html) → https://misakanet.org/insights/lesson-coverage.html
 
 ```bash
 node --test workers/unsolved-map.test.mjs   # 分类 / 聚合 / 隐私 / 限流单测

--- a/workers/lesson-coverage.test.mjs
+++ b/workers/lesson-coverage.test.mjs
@@ -1,0 +1,61 @@
+// Unit tests for the public lesson coverage dashboard (Issue #905).
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import worker, {
+  buildLessonCoverage,
+  handleLessonCoverage,
+} from './register-proxy-sw.js';
+
+const LESSONS = [
+  { id: 'python-pip', title: 'Python pip timeout recovery', domain: 'devops', tags: ['pip', 'venv'], status: 'published' },
+  { id: 'github-auth', title: 'GitHub token 401 recovery', domain: 'devops', tags: ['github', 'token'], status: 'published' },
+  { id: 'draft-docker', title: 'Docker draft', domain: 'devops', tags: ['docker'], status: 'draft' },
+];
+
+const SIGNALS = {
+  families: [
+    { taskFamily: 'python-env', unsolved7d: 2, unsolved30d: 3, lastSeen: '2026-08-13' },
+  ],
+  staleLessons: [{ lessonId: 'python-pip', notHelpful30d: 2, lastSeen: '2026-08-12' }],
+};
+
+test('coverage classifies covered, review, and uncovered families', () => {
+  const report = buildLessonCoverage(LESSONS, SIGNALS);
+  assert.equal(report.metrics.totalLessons, 3);
+  assert.equal(report.metrics.publishedLessons, 2);
+  assert.equal(report.metrics.coveredFamilies, 2);
+  assert.equal(report.metrics.coveragePercent, 16.7);
+  assert.equal(report.metrics.gapCount, 11);
+
+  const python = report.families.find((family) => family.taskFamily === 'python-env');
+  assert.equal(python.coverageStatus, 'needs-review');
+  assert.equal(python.lessonCount, 1);
+  assert.equal(python.unsolved30d, 3);
+
+  const glama = report.families.find((family) => family.taskFamily === 'glama-release');
+  assert.equal(glama.coverageStatus, 'uncovered');
+  assert.ok(report.gaps.some((family) => family.taskFamily === 'glama-release'));
+});
+
+test('handler returns valid JSON with explicit privacy metadata', async () => {
+  const response = await handleLessonCoverage({
+    LESSON_DATA: LESSONS,
+    UNSOLVED_DATA: SIGNALS,
+  });
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.success, true);
+  assert.equal(body.meta.lessonSource, 'data/lessons.json');
+  assert.equal(body.meta.raw_query, false);
+  assert.equal(body.meta.pii, false);
+  assert.equal(body.staleLessons[0].lessonId, 'python-pip');
+});
+
+test('public worker route works without REGISTER_TOKEN or KV', async () => {
+  const response = await worker.fetch(
+    new Request('https://misakanet.org/api/insights/lesson-coverage'),
+    { LESSON_DATA: LESSONS, UNSOLVED_DATA: SIGNALS },
+  );
+  assert.equal(response.status, 200);
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -5,6 +5,7 @@
 
 const REPO = "Ikalus1988/MisakaNet";
 const GITHUB_API = "https://api.github.com";
+const PUBLIC_DATA_BASE = "https://raw.githubusercontent.com/Ikalus1988/MisakaNet/main/data";
 const PROXY_CACHE_TTL = 30_000;
 const KEEPALIVE_ENDPOINTS = [
   { name: "health", url: "https://misakanet.org/api/health", json: true },
@@ -445,6 +446,14 @@ async function getWithCache(env, cacheKey, fetchFn) {
   return data;
 }
 
+async function fetchPublicJson(path) {
+  const resp = await fetch(`${PUBLIC_DATA_BASE}/${path}`, {
+    headers: { "User-Agent": "MisakaNet-Insights/1.0", Accept: "application/json" },
+  });
+  if (!resp.ok) throw new Error(`Public data ${resp.status}`);
+  return resp.json();
+}
+
 function sanitizeIdentifier(val, maxLen) {
   if (!val) return "";
   if (val.length > maxLen) val = val.slice(0, maxLen);
@@ -623,6 +632,109 @@ async function handleUnsolvedMap(env) {
     staleLessons: data.staleLessons,
     meta: { privacy: "aggregate-only", raw_query: false, prompts: false, logs: false, paths: false, pii: false },
   });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Lesson coverage dashboard (Issue #905)
+//
+// Coverage is calculated from the public lesson index and the aggregate
+// unsolved-family signals above. It never needs raw search queries: a family is
+// covered when at least one published lesson matches its public keyword cluster.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function lessonSearchText(lesson) {
+  if (!lesson || typeof lesson !== "object") return "";
+  const tags = Array.isArray(lesson.tags) ? lesson.tags.join(" ") : "";
+  return [lesson.id, lesson.title, lesson.domain, tags, lesson.summary]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function buildLessonCoverage(lessons, unsolved = { families: [], staleLessons: [] }) {
+  const allLessons = Array.isArray(lessons) ? lessons : [];
+  const publishedLessons = allLessons.filter((lesson) => lesson && lesson.status === "published");
+  const unsolvedFamilies = new Map(
+    (Array.isArray(unsolved.families) ? unsolved.families : [])
+      .map((family) => [family.taskFamily, family]),
+  );
+
+  const families = UNSOLVED_FAMILIES.map(([taskFamily, keywords]) => {
+    const matching = publishedLessons.filter((lesson) => {
+      const text = lessonSearchText(lesson);
+      return keywords.some((keyword) => text.includes(keyword));
+    });
+    const signal = unsolvedFamilies.get(taskFamily) || {};
+    const unsolved30d = Number(signal.unsolved30d) || 0;
+    const coverageStatus = matching.length === 0
+      ? "uncovered"
+      : unsolved30d > 0 ? "needs-review" : "covered";
+    return {
+      taskFamily,
+      lessonCount: matching.length,
+      coverageStatus,
+      unsolved7d: Number(signal.unsolved7d) || 0,
+      unsolved30d,
+      lastSeen: signal.lastSeen || null,
+    };
+  });
+
+  const coveredFamilies = families.filter((family) => family.lessonCount > 0).length;
+  const gaps = families
+    .filter((family) => family.coverageStatus !== "covered")
+    .sort((a, b) => b.unsolved30d - a.unsolved30d || a.lessonCount - b.lessonCount || a.taskFamily.localeCompare(b.taskFamily));
+
+  return {
+    metrics: {
+      totalLessons: allLessons.length,
+      publishedLessons: publishedLessons.length,
+      totalFamilies: families.length,
+      coveredFamilies,
+      coveragePercent: families.length ? Math.round((coveredFamilies / families.length) * 1000) / 10 : 0,
+      gapCount: gaps.length,
+      unsolvedFamilyCount: unsolvedFamilies.size,
+      staleLessonCount: Array.isArray(unsolved.staleLessons) ? unsolved.staleLessons.length : 0,
+    },
+    families,
+    gaps,
+    staleLessons: Array.isArray(unsolved.staleLessons) ? unsolved.staleLessons : [],
+  };
+}
+
+async function handleLessonCoverage(env) {
+  try {
+    let lessons = env.LESSON_DATA;
+    if (typeof lessons === "string") lessons = JSON.parse(lessons);
+    if (!Array.isArray(lessons)) {
+      lessons = await getWithCache(env, "insights:lesson-index", () => fetchPublicJson("lessons.json"));
+    }
+
+    let unsolved = env.UNSOLVED_DATA;
+    if (typeof unsolved === "string") unsolved = JSON.parse(unsolved);
+    if (!unsolved || typeof unsolved !== "object") {
+      unsolved = env.MISAKANET_KV
+        ? await buildUnsolvedMap(env)
+        : { families: [], staleLessons: [] };
+    }
+
+    return jsonResponse({
+      success: true,
+      available: true,
+      signalsAvailable: !!env.MISAKANET_KV || !!env.UNSOLVED_DATA,
+      generatedAt: new Date().toISOString(),
+      ...buildLessonCoverage(lessons, unsolved),
+      meta: {
+        lessonSource: "data/lessons.json",
+        signalSource: "/api/insights/unsolved-map",
+        privacy: "public-metadata-and-aggregate-signals",
+        raw_query: false,
+        pii: false,
+      },
+    });
+  } catch (error) {
+    console.error("[coverage] source unavailable", error && error.message);
+    return jsonResponse({ success: false, error: "Coverage data unavailable" }, 502);
+  }
 }
 
 // POST /api/search-signal — records that a search went unsolved. The query is
@@ -931,6 +1043,11 @@ export default {
     // GET /api/insights/unsolved-map — public aggregate failure map (#788)
     if (request.method === "GET" && url.pathname === "/api/insights/unsolved-map") {
       return handleUnsolvedMap(env);
+    }
+
+    // GET /api/insights/lesson-coverage — public lesson coverage dashboard (#905)
+    if (request.method === "GET" && url.pathname === "/api/insights/lesson-coverage") {
+      return handleLessonCoverage(env);
     }
 
     // GET /api/insights/demand-board — public aggregate view of intake clusters
@@ -1345,9 +1462,11 @@ export {
   UNSOLVED_REASONS,
   UNSOLVED_WINDOW_DAYS,
   buildUnsolvedMap,
+  buildLessonCoverage,
   classifyTaskFamily,
   getIdentityAura,
   handleSearchSignal,
+  handleLessonCoverage,
   handleUnsolvedMap,
   recordStaleLesson,
   recordUnsolvedSearch,


### PR DESCRIPTION
## Summary

Implements the public lesson coverage dashboard requested in #905.

## Changes

- Adds `GET /api/insights/lesson-coverage` to the deployed Worker.
- Computes coverage from the public `data/lessons.json` index and combines it with aggregate unsolved-family signals.
- Classifies each family as `covered`, `needs-review`, or `uncovered`.
- Returns lesson counts, coverage percentage, prioritized gaps, unsolved counts, stale/not-helpful lessons, and an explicit privacy contract.
- Uses the existing 30-second KV cache and keeps the endpoint public without requiring `REGISTER_TOKEN`.
- Adds a self-contained responsive dashboard at `docs/insights/lesson-coverage.html` with summary cards, native CSS bars, gaps table, and stale-lesson table.
- Documents the endpoint and page in `workers/README.md`.
- Adds Node and Python regression coverage plus a performance check against the 289-lesson index.

## Validation

```text
$ node --test workers/lesson-coverage.test.mjs
3 passed

$ python3 tests/test_lesson_coverage.py
Ran 4 tests ... OK

$ node --test workers/lesson-coverage.test.mjs workers/unsolved-map.test.mjs
23 passed

$ node --check workers/register-proxy-sw.js
passed

$ buildLessonCoverage(data/lessons.json)
1.645 ms for 289 lessons (local)
```

Closes #905
