### PR TITLE
fix: replace bare excepts and remove duplicate hashlib import

### DIFF
--- a/hub/orchestrator/skill_indexer.py
+++ b/hub/orchestrator/skill_indexer.py
@@ -186,7 +186,7 @@ class SkillIndexer:
                     with os.fdopen(fd, 'w') as f:
                         json.dump(self.index, f, indent=2, default=str)
                     shutil.move(tmp_path, self.index_path)
-                except:
+                except BaseException:
                     if os.path.exists(tmp_path):
                         os.unlink(tmp_path)
                     raise

--- a/hub/storage/knowledge_graph.py
+++ b/hub/storage/knowledge_graph.py
@@ -57,7 +57,7 @@ class KnowledgeGraph:
                 with os.fdopen(fd, 'w') as f:
                     json.dump(data, f, default=str)
                 shutil.move(tmp_path, self.persist_path)
-            except:
+            except BaseException:
                 if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
                 raise

--- a/hub/storage/vector_store.py
+++ b/hub/storage/vector_store.py
@@ -195,7 +195,6 @@ def generate_embedding(text: str, model: str = "BAAI/bge-base-zh-v1.5") -> list[
     # Dev fallback: hash-based pseudo-embedding (meaningless similarity — for testing only)
     import logging as _log
     _log.warning("[Embedding] ⚠️ Using SHA256 hash pseudo-embedding (dev mode). Semantic search results are NOT meaningful.")
-    import hashlib
     hash_bytes = hashlib.sha256(text.encode()).digest()
     arr = np.frombuffer(hash_bytes, dtype=np.float32)
     arr = arr / np.linalg.norm(arr)

--- a/scripts/sync_h1.py
+++ b/scripts/sync_h1.py
@@ -6,7 +6,7 @@ for f in sorted(Path(__file__).resolve().parent.parent.joinpath('lessons').glob(
     if not c.startswith('---'): continue
     end = c.index('---', 3)
     try: fm = json.loads(c[3:end].strip())
-    except: continue
+    except (ValueError, json.JSONDecodeError): continue
     eng = fm.get('title', '')
     if not eng: continue
     lines = c.split('\n')


### PR DESCRIPTION
## Summary

Four small lint/correctness cleanups (ruff E722 / F811):

1. **`hub/storage/knowledge_graph.py`** and **`hub/orchestrator/skill_indexer.py`** — the atomic-write cleanup blocks used bare `except:` before re-raising. Changed to `except BaseException:` — identical behavior (the temp file is still cleaned up on `KeyboardInterrupt` etc., and the exception still propagates), but explicit and lint-clean.

2. **`scripts/sync_h1.py`** — the frontmatter parse used `except: continue`, which would also swallow `KeyboardInterrupt`. Narrowed to `except (ValueError, json.JSONDecodeError):`, matching the style already used in `scripts/batch_lesson_upgrade.py`.

3. **`hub/storage/vector_store.py`** — removed a duplicate `import hashlib` inside `generate_embedding()`; the module already imports it at the top.

## Testing
No behavior change — `python -m py_compile` passes on all four files and `ruff check --select E722,F811` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)