### PR TITLE
feat: MCP intake endpoint for crawler/agent lesson submissions (#1071)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,34 @@ python3 search_knowledge.py "关键词" --titles
 ### 贡献新知识
 
 ```bash
-# 踩坑记录（推荐）
+# 踩坑记录（推荐，本地节点）
 python3 scripts/queue_lesson.py \
   -t "你的标题" -d domain \
   --tags "node:你的节点名,project:项目名" \
   "问题描述\n\n## 根因\n...\n\n## 修复\n...\n\n## 验证\n..."
 ```
+
+### Remote MCP intake — no account required (crawlers & agents)
+
+If you are a **remote agent or crawler** that cannot clone the repo, use the MCP
+intake endpoint. **Do not open a PR for missing lessons** — use this instead:
+
+```bash
+# Search first — check whether a lesson already exists
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"YOUR PROBLEM"}}}'
+
+# If no lesson matches, submit an intake — no GitHub account required
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"kind":"missing_lesson","problem":"REDACTED PROBLEM","source":"your-agent"}}}'
+```
+
+> **Prefer MCP intake for missing/stale lessons; PRs are optional.**  
+> Full guide: [`docs/integrations/mcp-remote.md`](docs/integrations/mcp-remote.md)
 
 ## 保持同步
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,33 @@ python3 search_knowledge.py "pip install timeout"
 
 ---
 
+### No-account MCP intake for agents & crawlers
+
+AI agents and web crawlers can **report missing or stale lessons** without a
+GitHub account, email, or Bearer token:
+
+```bash
+# Search first — check whether a lesson already exists
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"YOUR ERROR MESSAGE"}}}'
+
+# If no lesson matches, submit an intake — no account required
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"kind":"missing_lesson","problem":"SHORT REDACTED PROBLEM","source":"your-agent-name"}}}'
+```
+
+> **Prefer MCP intake for missing or stale lessons; PRs are optional.**
+> Open a PR only when submitting a complete, formatted lesson file or a code fix.
+> The intake path requires no GitHub account, no email, and no secrets.
+
+[Full MCP remote integration guide →](docs/integrations/mcp-remote.md)
+
+---
+
 ## Stats
 
 | Metric | Value |

--- a/docs/agents/retrieval-and-contribution.md
+++ b/docs/agents/retrieval-and-contribution.md
@@ -59,10 +59,34 @@ python3 scripts/queue_lesson.py \
 python3 misakanet/scripts/bulk_import_lessons.py wizard 你的节点名
 ```
 
+### Remote MCP intake (crawlers & agents — no account required)
+
+If you are a crawler or remote agent that **cannot clone the repo**, use the MCP
+intake endpoint instead of opening a PR:
+
+```bash
+# 1. Search first
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"YOUR PROBLEM"}}}'
+
+# 2. If nothing matches, submit intake — no GitHub account needed
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"kind":"missing_lesson","problem":"REDACTED PROBLEM","source":"your-agent"}}}'
+```
+
+> **Prefer MCP intake for missing or stale lessons; PRs are optional.**  
+> See [docs/integrations/mcp-remote.md](../integrations/mcp-remote.md) for the full guide.
+
 ## 贡献流程
 
 1. **每次有价值的对话结束时**，自问"有什么值得跨节点共享？"
-2. **如果有**，运行 queue_lesson.py 入库
+2. **如果有**：
+   - **本地节点** → 运行 queue_lesson.py 入库
+   - **远程 Agent / Crawler** → `misakanet_submit_intake` via MCP（无需账号）
 3. **使用正确的 domain 和 tags**：
    - domain: rag, devops, feishu, fanuc, etc.
    - tags: node:节点名, project:项目名, severity:级别

--- a/docs/integrations/mcp-remote.md
+++ b/docs/integrations/mcp-remote.md
@@ -1,0 +1,206 @@
+# MCP Remote — Agent & Crawler Integration
+
+MisakaNet exposes a remote MCP endpoint so AI agents and web crawlers can **search
+lessons and submit missing-lesson reports without a GitHub account, email, or
+Bearer token**.
+
+```
+remote agent / crawler
+→ POST https://misakanet.org/mcp
+→ tools/call misakanet_submit_intake
+→ no GitHub account • no email • no Bearer token
+→ GitHub issue labeled intake, mcp-intake, pending-review
+→ maintainer review
+→ formal lesson (if accepted)
+```
+
+---
+
+## Quick bookmarks
+
+| | |
+|---|---|
+| **MCP endpoint** | `https://misakanet.org/mcp` |
+| **Protocol version** | `2025-06-18` |
+| **Auth required** | None (anonymous) |
+| **Rate limit** | 5 intakes / min / IP |
+
+---
+
+## When to use MCP intake vs a PR
+
+| Situation | Recommended action |
+|---|---|
+| Found a matching lesson | Use it — no action needed |
+| No lesson matches your problem | `misakanet_submit_intake` ← **use this** |
+| Lesson exists but is outdated | `misakanet_submit_intake` with `kind: stale_lesson` |
+| Entire domain missing | `misakanet_submit_intake` with `kind: domain_gap` |
+| Submitting a fully-written, reviewed lesson file | Open a PR |
+| Fixing a code bug in the repo | Open a PR |
+
+> **Rule of thumb for crawlers/agents:** Prefer MCP intake for missing or stale
+> lessons. PRs are optional — only open one if you are contributing a complete,
+> formatted lesson file or a code fix.
+
+---
+
+## Step 1 — Search first
+
+Always check whether a lesson already exists before submitting:
+
+```bash
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Origin: https://claude.ai" \
+  -H "User-Agent: MisakaNet-Remote-Agent/1.0" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "misakanet_search",
+      "arguments": {
+        "query": "pip install SSL certificate verify failed",
+        "top": 5
+      }
+    }
+  }'
+```
+
+---
+
+## Step 2 — Submit intake if nothing matches
+
+```bash
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Origin: https://claude.ai" \
+  -H "User-Agent: MisakaNet-Remote-Agent/1.0" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "misakanet_submit_intake",
+      "arguments": {
+        "kind": "missing_lesson",
+        "problem": "SHORT REDACTED PROBLEM",
+        "error": "OPTIONAL REDACTED ERROR",
+        "what_tried": "OPTIONAL",
+        "fix": "OPTIONAL",
+        "verification": "OPTIONAL",
+        "source": "crawler-or-remote-agent"
+      }
+    }
+  }'
+```
+
+**Expected response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "submitted": true,
+    "intake_id": "issue-1234",
+    "status": "pending_review",
+    "issue_url": "https://github.com/Ikalus1988/MisakaNet/issues/1234"
+  }
+}
+```
+
+---
+
+## Tool reference
+
+### `misakanet_search`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `query` | string | ✅ | Search terms |
+| `top` | integer | ❌ | Max results (default 5, max 20) |
+
+### `misakanet_submit_intake`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `kind` | enum | ✅ | `missing_lesson` / `stale_lesson` / `domain_gap` |
+| `problem` | string | ✅ | ≥10 chars, ≤1000 chars, **no secrets** |
+| `error` | string | ❌ | Error message snippet (redacted) |
+| `what_tried` | string | ❌ | What was attempted |
+| `fix` | string | ❌ | Known workaround, if any |
+| `verification` | string | ❌ | How to confirm the fix |
+| `source` | string | ❌ | Agent/crawler identifier — no PII |
+
+> ⚠️ **Never send secrets, API keys, passwords, or personal data.** Strip all
+> sensitive information before submitting. Intake issues are public on GitHub.
+
+---
+
+## MCP protocol handshake (optional)
+
+For strict MCP clients that require a full handshake:
+
+```bash
+# 1. Initialize
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"my-agent","version":"1.0"}}}'
+
+# 2. Notify initialized (fire and forget)
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+# 3. List available tools
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+---
+
+## Claude Desktop / Claude Code config
+
+Add to your MCP server list to use MisakaNet from Claude:
+
+```json
+{
+  "mcpServers": {
+    "misakanet-remote": {
+      "url": "https://misakanet.org/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+---
+
+## Verified evidence
+
+A successful end-to-end test was performed via remote HTTP MCP with no Bearer token:
+
+- **Test intake** submitted via `misakanet_submit_intake`
+- Result: GitHub issue created with labels `intake`, `mcp-intake`, `pending-review`
+- See issue [#1069](https://github.com/Ikalus1988/MisakaNet/issues/1069) as the first
+  end-to-end test, created through this path.
+
+---
+
+## Worker source
+
+The Cloudflare Worker handling this endpoint is open-source:
+[`workers/mcp-intake/index.js`](../../workers/mcp-intake/index.js)
+
+Environment variables required for deployment:
+- `GITHUB_TOKEN` — GitHub PAT with `issues: write` on `Ikalus1988/MisakaNet`
+
+---
+
+*See also: [integrations/README.md](README.md) · [AGENTS.md](../../AGENTS.md) · [docs/agents/retrieval-and-contribution.md](../agents/retrieval-and-contribution.md)*

--- a/misakanet/mcp/__init__.py
+++ b/misakanet/mcp/__init__.py
@@ -1,0 +1,1 @@
+# misakanet.mcp — MCP client utilities for MisakaNet agents

--- a/misakanet/mcp/intake_client.py
+++ b/misakanet/mcp/intake_client.py
@@ -1,0 +1,301 @@
+"""
+misakanet.mcp.intake_client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lightweight Python client for the MisakaNet MCP remote intake endpoint.
+
+Usage (search first, then submit if nothing matches)::
+
+    from misakanet.mcp.intake_client import IntakeClient
+
+    client = IntakeClient()
+
+    # Step 1 — search existing lessons
+    results = client.search("pip install SSL certificate error")
+    if not results:
+        # Step 2 — submit intake (no GitHub account required)
+        response = client.submit_intake(
+            kind="missing_lesson",
+            problem="pip install fails with SSL: CERTIFICATE_VERIFY_FAILED on macOS",
+            error="ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]",
+            what_tried="pip install --trusted-host pypi.org ...",
+            source="my-agent/1.0",
+        )
+        print(response)  # {"submitted": True, "intake_id": "issue-1234", ...}
+
+The worker endpoint requires no authentication from the caller.
+All sensitive data must be stripped before submitting.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.request
+import urllib.error
+from typing import Any, Dict, List, Literal, Optional
+
+__all__ = [
+    "IntakeClient",
+    "IntakePayload",
+    "validate_intake_payload",
+    "build_jsonrpc_call",
+]
+
+MCP_ENDPOINT = "https://misakanet.org/mcp"
+MCP_PROTOCOL_VERSION = "2025-06-18"
+
+IntakeKind = Literal["missing_lesson", "stale_lesson", "domain_gap"]
+VALID_KINDS: tuple[str, ...] = ("missing_lesson", "stale_lesson", "domain_gap")
+
+MAX_FIELD_LEN = 1000
+MAX_SOURCE_LEN = 80
+
+
+# ── Payload dataclass (stdlib, no attrs/pydantic needed) ──────────────────
+
+
+class IntakePayload:
+    """Validated intake payload ready for submission."""
+
+    __slots__ = (
+        "kind", "problem", "error", "what_tried", "fix", "verification", "source"
+    )
+
+    def __init__(
+        self,
+        kind: IntakeKind,
+        problem: str,
+        *,
+        error: str = "",
+        what_tried: str = "",
+        fix: str = "",
+        verification: str = "",
+        source: str = "python-intake-client",
+    ) -> None:
+        errors = validate_intake_payload(
+            kind=kind,
+            problem=problem,
+            error=error,
+            what_tried=what_tried,
+            fix=fix,
+            verification=verification,
+            source=source,
+        )
+        if errors:
+            raise ValueError(f"Invalid intake payload: {'; '.join(errors)}")
+        self.kind = kind
+        self.problem = _truncate(problem, MAX_FIELD_LEN)
+        self.error = _truncate(error, MAX_FIELD_LEN)
+        self.what_tried = _truncate(what_tried, MAX_FIELD_LEN)
+        self.fix = _truncate(fix, MAX_FIELD_LEN)
+        self.verification = _truncate(verification, MAX_FIELD_LEN)
+        self.source = _truncate(source, MAX_SOURCE_LEN)
+
+    def to_dict(self) -> Dict[str, str]:
+        d: Dict[str, str] = {"kind": self.kind, "problem": self.problem}
+        if self.error:
+            d["error"] = self.error
+        if self.what_tried:
+            d["what_tried"] = self.what_tried
+        if self.fix:
+            d["fix"] = self.fix
+        if self.verification:
+            d["verification"] = self.verification
+        if self.source:
+            d["source"] = self.source
+        return d
+
+
+# ── Validation ────────────────────────────────────────────────────────────
+
+
+def validate_intake_payload(
+    kind: str,
+    problem: str,
+    error: str = "",
+    what_tried: str = "",
+    fix: str = "",
+    verification: str = "",
+    source: str = "",
+) -> List[str]:
+    """Validate an intake payload before submission.
+
+    Returns a list of error strings. An empty list means the payload is valid.
+
+    This mirrors the validation logic in ``workers/mcp-intake/index.js``.
+    """
+    errs: List[str] = []
+
+    # kind
+    if kind not in VALID_KINDS:
+        errs.append(
+            f"Invalid kind '{kind}'. Must be one of: {', '.join(VALID_KINDS)}"
+        )
+
+    # problem — required, min 10 chars
+    if not problem or not isinstance(problem, str):
+        errs.append("'problem' is required.")
+    elif len(problem.strip()) < 10:
+        errs.append("'problem' must be at least 10 characters.")
+    elif len(problem) > MAX_FIELD_LEN:
+        errs.append(f"'problem' must not exceed {MAX_FIELD_LEN} characters.")
+
+    # Optional text fields — length checks only
+    for fname, val in [
+        ("error", error),
+        ("what_tried", what_tried),
+        ("fix", fix),
+        ("verification", verification),
+    ]:
+        if val and len(val) > MAX_FIELD_LEN:
+            errs.append(f"'{fname}' must not exceed {MAX_FIELD_LEN} characters.")
+
+    # source — length only
+    if source and len(source) > MAX_SOURCE_LEN:
+        errs.append(f"'source' must not exceed {MAX_SOURCE_LEN} characters.")
+
+    return errs
+
+
+# ── JSON-RPC helpers ──────────────────────────────────────────────────────
+
+
+def build_jsonrpc_call(method: str, params: Dict[str, Any], req_id: int = 1) -> bytes:
+    """Build a JSON-RPC 2.0 POST body for an MCP tool call.
+
+    >>> body = build_jsonrpc_call("tools/list", {})
+    >>> import json; data = json.loads(body)
+    >>> data["jsonrpc"]
+    '2.0'
+    >>> data["method"]
+    'tools/list'
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": method,
+        "params": params,
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def _truncate(val: str, max_len: int) -> str:
+    if not val:
+        return ""
+    return val[:max_len]
+
+
+# ── HTTP client ───────────────────────────────────────────────────────────
+
+
+class IntakeClient:
+    """Simple HTTP client for the MisakaNet MCP remote endpoint.
+
+    No external dependencies — uses urllib from the Python standard library.
+
+    Args:
+        endpoint: MCP endpoint URL (default: ``https://misakanet.org/mcp``)
+        user_agent: User-Agent header sent with every request
+        timeout: HTTP timeout in seconds
+    """
+
+    def __init__(
+        self,
+        endpoint: str = MCP_ENDPOINT,
+        user_agent: str = "MisakaNet-Python-Client/1.0",
+        timeout: int = 15,
+    ) -> None:
+        self.endpoint = endpoint
+        self.user_agent = user_agent
+        self.timeout = timeout
+
+    def _post(self, body: bytes) -> Dict[str, Any]:
+        req = urllib.request.Request(
+            self.endpoint,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+                "Origin": "https://claude.ai",
+                "User-Agent": self.user_agent,
+                "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+        return json.loads(raw)
+
+    def search(self, query: str, top: int = 5) -> List[Dict[str, Any]]:
+        """Search MisakaNet lessons.
+
+        Returns a list of lesson dicts, or an empty list if none found.
+        """
+        body = build_jsonrpc_call(
+            "tools/call",
+            {
+                "name": "misakanet_search",
+                "arguments": {"query": query, "top": top},
+            },
+        )
+        resp = self._post(body)
+        result = resp.get("result", {})
+        content = result.get("content", [])
+        text = content[0].get("text", "") if content else ""
+        # Parse lesson list from text (lightweight, no regex needed for agent use)
+        lines = [l for l in text.splitlines() if l.startswith("- [")]
+        return [{"raw": l} for l in lines]
+
+    def submit_intake(
+        self,
+        kind: IntakeKind,
+        problem: str,
+        *,
+        error: str = "",
+        what_tried: str = "",
+        fix: str = "",
+        verification: str = "",
+        source: str = "python-intake-client",
+    ) -> Dict[str, Any]:
+        """Submit an intake report for a missing or stale lesson.
+
+        Validates the payload locally before sending.
+
+        Returns the parsed JSON-RPC result dict on success, raises on error.
+
+        >>> # Dry-run payload validation without network I/O:
+        >>> errors = validate_intake_payload("missing_lesson", "short")
+        >>> "at least 10" in errors[0]
+        True
+        """
+        payload = IntakePayload(
+            kind=kind,
+            problem=problem,
+            error=error,
+            what_tried=what_tried,
+            fix=fix,
+            verification=verification,
+            source=source,
+        )
+        body = build_jsonrpc_call(
+            "tools/call",
+            {
+                "name": "misakanet_submit_intake",
+                "arguments": payload.to_dict(),
+            },
+        )
+        resp = self._post(body)
+        if "error" in resp:
+            raise RuntimeError(
+                f"MCP error {resp['error'].get('code')}: {resp['error'].get('message')}"
+            )
+        result = resp.get("result", {})
+        return {
+            "submitted": result.get("submitted", False),
+            "intake_id": result.get("intake_id"),
+            "status": result.get("status"),
+            "issue_url": result.get("issue_url"),
+        }

--- a/tests/test_mcp_intake.py
+++ b/tests/test_mcp_intake.py
@@ -1,0 +1,427 @@
+"""
+Tests for MisakaNet MCP intake — misakanet.mcp.intake_client
+=============================================================
+
+Covers:
+  1. validate_intake_payload — all validation rules
+  2. IntakePayload — construction, truncation, to_dict
+  3. build_jsonrpc_call — JSON-RPC 2.0 format
+  4. IntakeClient.search — mocked HTTP response
+  5. IntakeClient.submit_intake — mocked success and error paths
+  6. IntakeClient.submit_intake — network error handling
+
+These tests are fully offline (no live HTTP calls).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# ── Path setup ──────────────────────────────────────────────────────────────
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from misakanet.mcp.intake_client import (
+    IntakeClient,
+    IntakePayload,
+    validate_intake_payload,
+    build_jsonrpc_call,
+    MCP_ENDPOINT,
+    MCP_PROTOCOL_VERSION,
+    VALID_KINDS,
+    MAX_FIELD_LEN,
+    MAX_SOURCE_LEN,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def _make_urlopen_mock(response_body: dict):
+    """Return a context-manager mock that yields a urllib response."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(response_body).encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+# ── 1. validate_intake_payload ───────────────────────────────────────────────
+
+
+class TestValidateIntakePayload(unittest.TestCase):
+
+    def test_valid_minimal_payload(self):
+        errs = validate_intake_payload("missing_lesson", "pip install fails on WSL with SSL error")
+        self.assertEqual(errs, [])
+
+    def test_valid_full_payload(self):
+        errs = validate_intake_payload(
+            kind="stale_lesson",
+            problem="pip install fails on WSL with SSL certificate error",
+            error="ssl.SSLCertVerificationError",
+            what_tried="pip install --trusted-host pypi.org",
+            fix="pip install --cert /etc/ssl/certs/ca-certificates.crt",
+            verification="pip install requests succeeds after applying fix",
+            source="cursor-agent/1.0",
+        )
+        self.assertEqual(errs, [])
+
+    def test_all_valid_kinds_accepted(self):
+        for kind in VALID_KINDS:
+            errs = validate_intake_payload(kind, "A valid problem description here")
+            self.assertEqual(errs, [], f"Kind '{kind}' should be valid")
+
+    def test_invalid_kind_rejected(self):
+        errs = validate_intake_payload("bad_kind", "A valid problem description here")
+        self.assertTrue(any("kind" in e.lower() or "bad_kind" in e for e in errs))
+
+    def test_empty_problem_rejected(self):
+        errs = validate_intake_payload("missing_lesson", "")
+        self.assertTrue(any("problem" in e.lower() for e in errs))
+
+    def test_short_problem_rejected(self):
+        errs = validate_intake_payload("missing_lesson", "too short")
+        self.assertTrue(any("10 character" in e for e in errs))
+
+    def test_exactly_10_char_problem_accepted(self):
+        errs = validate_intake_payload("missing_lesson", "1234567890")
+        self.assertEqual(errs, [])
+
+    def test_problem_exceeds_max_len(self):
+        long_problem = "x" * (MAX_FIELD_LEN + 1)
+        errs = validate_intake_payload("missing_lesson", long_problem)
+        self.assertTrue(any("problem" in e and str(MAX_FIELD_LEN) in e for e in errs))
+
+    def test_error_field_exceeds_max_len(self):
+        errs = validate_intake_payload(
+            "missing_lesson",
+            "Valid problem description here",
+            error="e" * (MAX_FIELD_LEN + 1),
+        )
+        self.assertTrue(any("error" in e for e in errs))
+
+    def test_source_exceeds_max_len(self):
+        errs = validate_intake_payload(
+            "missing_lesson",
+            "Valid problem description here",
+            source="s" * (MAX_SOURCE_LEN + 1),
+        )
+        self.assertTrue(any("source" in e for e in errs))
+
+    def test_none_problem_rejected(self):
+        errs = validate_intake_payload("missing_lesson", None)  # type: ignore
+        self.assertTrue(any("problem" in e.lower() for e in errs))
+
+    def test_multiple_errors_returned(self):
+        """Invalid kind AND short problem → at least 2 errors."""
+        errs = validate_intake_payload("bad", "hi")
+        self.assertGreaterEqual(len(errs), 2)
+
+
+# ── 2. IntakePayload ─────────────────────────────────────────────────────────
+
+
+class TestIntakePayload(unittest.TestCase):
+
+    def test_valid_payload_constructed(self):
+        p = IntakePayload("missing_lesson", "A problem longer than ten characters")
+        self.assertEqual(p.kind, "missing_lesson")
+        self.assertIn("problem", p.to_dict())
+
+    def test_invalid_payload_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            IntakePayload("bad_kind", "A valid problem here")
+
+    def test_problem_exceeds_max_len_raises(self):
+        """IntakePayload validates before truncating — oversized problem raises."""
+        long_problem = "A" * (MAX_FIELD_LEN + 500)
+        with self.assertRaises(ValueError) as ctx:
+            IntakePayload("missing_lesson", long_problem)
+        self.assertIn("problem", str(ctx.exception))
+
+    def test_source_exceeds_max_len_raises(self):
+        """IntakePayload validates before truncating — oversized source raises."""
+        long_source = "s" * (MAX_SOURCE_LEN + 50)
+        with self.assertRaises(ValueError) as ctx:
+            IntakePayload("missing_lesson", "Valid problem description", source=long_source)
+        self.assertIn("source", str(ctx.exception))
+
+    def test_to_dict_omits_empty_fields(self):
+        p = IntakePayload("missing_lesson", "A problem that is long enough")
+        d = p.to_dict()
+        self.assertIn("kind", d)
+        self.assertIn("problem", d)
+        # optional fields not set → not in dict
+        self.assertNotIn("error", d)
+        self.assertNotIn("what_tried", d)
+
+    def test_to_dict_includes_optional_fields_when_set(self):
+        p = IntakePayload(
+            "missing_lesson",
+            "A problem that is long enough",
+            error="Some error message",
+            fix="Some fix",
+        )
+        d = p.to_dict()
+        self.assertIn("error", d)
+        self.assertIn("fix", d)
+
+    def test_all_kinds_accepted(self):
+        for kind in VALID_KINDS:
+            p = IntakePayload(kind, "A problem that is long enough")
+            self.assertEqual(p.kind, kind)
+
+
+# ── 3. build_jsonrpc_call ────────────────────────────────────────────────────
+
+
+class TestBuildJsonrpcCall(unittest.TestCase):
+
+    def test_jsonrpc_version(self):
+        body = build_jsonrpc_call("tools/list", {})
+        data = json.loads(body)
+        self.assertEqual(data["jsonrpc"], "2.0")
+
+    def test_method_included(self):
+        body = build_jsonrpc_call("tools/call", {"name": "test"})
+        data = json.loads(body)
+        self.assertEqual(data["method"], "tools/call")
+
+    def test_params_included(self):
+        params = {"name": "misakanet_search", "arguments": {"query": "pip"}}
+        body = build_jsonrpc_call("tools/call", params)
+        data = json.loads(body)
+        self.assertEqual(data["params"]["name"], "misakanet_search")
+
+    def test_default_id_is_1(self):
+        body = build_jsonrpc_call("tools/list", {})
+        data = json.loads(body)
+        self.assertEqual(data["id"], 1)
+
+    def test_custom_id(self):
+        body = build_jsonrpc_call("tools/list", {}, req_id=42)
+        data = json.loads(body)
+        self.assertEqual(data["id"], 42)
+
+    def test_returns_bytes(self):
+        body = build_jsonrpc_call("tools/list", {})
+        self.assertIsInstance(body, bytes)
+
+    def test_valid_json(self):
+        body = build_jsonrpc_call("tools/call", {"key": "value"})
+        # Should not raise
+        data = json.loads(body)
+        self.assertIn("jsonrpc", data)
+
+
+# ── 4. IntakeClient.search ───────────────────────────────────────────────────
+
+
+class TestIntakeClientSearch(unittest.TestCase):
+
+    def _mock_search_response(self, text: str) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [{"type": "text", "text": text}]
+            },
+        }
+
+    @patch("urllib.request.urlopen")
+    def test_search_returns_lessons(self, mock_urlopen):
+        text = (
+            "Found 2 lessons:\n"
+            "- [rag] ChromaDB crash on NTFS (lessons/rag-chromadb-ntfs.md)\n"
+            "- [devops] WSL terminal underscore corruption (lessons/wsl-terminal.md)\n"
+            "\nIf none match, use misakanet_submit_intake."
+        )
+        mock_urlopen.return_value = _make_urlopen_mock(self._mock_search_response(text))
+        client = IntakeClient()
+        results = client.search("chromadb ntfs")
+        self.assertEqual(len(results), 2)
+        self.assertIn("ChromaDB", results[0]["raw"])
+
+    @patch("urllib.request.urlopen")
+    def test_search_returns_empty_on_no_match(self, mock_urlopen):
+        text = 'No lessons found for "unknown query". Use misakanet_submit_intake.'
+        mock_urlopen.return_value = _make_urlopen_mock(self._mock_search_response(text))
+        client = IntakeClient()
+        results = client.search("unknown query nobody has this")
+        self.assertEqual(results, [])
+
+    @patch("urllib.request.urlopen")
+    def test_search_sends_correct_method(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_mock(
+            self._mock_search_response("No lessons found.")
+        )
+        client = IntakeClient()
+        client.search("pip timeout")
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        body = json.loads(req.data)
+        self.assertEqual(body["method"], "tools/call")
+        self.assertEqual(body["params"]["name"], "misakanet_search")
+        self.assertEqual(body["params"]["arguments"]["query"], "pip timeout")
+
+
+# ── 5. IntakeClient.submit_intake ────────────────────────────────────────────
+
+
+class TestIntakeClientSubmitIntake(unittest.TestCase):
+
+    def _success_response(self) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "submitted": True,
+                "intake_id": "issue-1234",
+                "status": "pending_review",
+                "issue_url": "https://github.com/Ikalus1988/MisakaNet/issues/1234",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Intake submitted successfully.\n\nintake_id: issue-1234",
+                    }
+                ],
+            },
+        }
+
+    @patch("urllib.request.urlopen")
+    def test_submit_returns_intake_id(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_mock(self._success_response())
+        client = IntakeClient()
+        result = client.submit_intake(
+            "missing_lesson",
+            "pip install fails on macOS with SSL certificate error in CI",
+            source="test-agent",
+        )
+        self.assertTrue(result["submitted"])
+        self.assertEqual(result["intake_id"], "issue-1234")
+        self.assertEqual(result["status"], "pending_review")
+        self.assertIn("github.com", result["issue_url"])
+
+    @patch("urllib.request.urlopen")
+    def test_submit_sends_correct_method(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_mock(self._success_response())
+        client = IntakeClient()
+        client.submit_intake(
+            "missing_lesson",
+            "A problem that is longer than ten chars",
+        )
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data)
+        self.assertEqual(body["method"], "tools/call")
+        self.assertEqual(body["params"]["name"], "misakanet_submit_intake")
+        self.assertIn("kind", body["params"]["arguments"])
+        self.assertEqual(body["params"]["arguments"]["kind"], "missing_lesson")
+
+    @patch("urllib.request.urlopen")
+    def test_submit_sends_mcp_protocol_header(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_mock(self._success_response())
+        client = IntakeClient()
+        client.submit_intake("missing_lesson", "A valid problem description here")
+        req = mock_urlopen.call_args[0][0]
+        self.assertEqual(req.get_header("Mcp-protocol-version"), MCP_PROTOCOL_VERSION)
+
+    @patch("urllib.request.urlopen")
+    def test_submit_raises_on_rpc_error(self, mock_urlopen):
+        error_resp = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32602, "message": "problem is required"},
+        }
+        mock_urlopen.return_value = _make_urlopen_mock(error_resp)
+        client = IntakeClient()
+        with self.assertRaises(RuntimeError) as ctx:
+            client.submit_intake("missing_lesson", "A problem that is long enough")
+        self.assertIn("-32602", str(ctx.exception))
+
+    def test_submit_validates_locally_before_network(self):
+        """Invalid payload → ValueError before any HTTP call."""
+        client = IntakeClient()
+        with self.assertRaises(ValueError):
+            client.submit_intake("bad_kind", "Too short")
+
+    @patch("urllib.request.urlopen")
+    def test_submit_full_payload(self, mock_urlopen):
+        mock_urlopen.return_value = _make_urlopen_mock(self._success_response())
+        client = IntakeClient()
+        result = client.submit_intake(
+            kind="stale_lesson",
+            problem="ChromaDB on NTFS crashes on SQLite open — lesson is outdated",
+            error="sqlite3.OperationalError: unable to open database file",
+            what_tried="Upgraded ChromaDB to 0.5.0 — still fails",
+            fix="Move DB to ext4 partition: mv ~/.chromadb /mnt/ext4/",
+            verification="python3 -c \"import chromadb; c=chromadb.Client(); print(c.heartbeat())\"",
+            source="cursor-agent/2.0",
+        )
+        self.assertTrue(result["submitted"])
+
+        req = mock_urlopen.call_args[0][0]
+        args = json.loads(req.data)["params"]["arguments"]
+        self.assertEqual(args["kind"], "stale_lesson")
+        self.assertIn("source", args)
+        self.assertEqual(args["source"], "cursor-agent/2.0")
+
+
+# ── 6. Network error handling ────────────────────────────────────────────────
+
+
+class TestIntakeClientNetworkErrors(unittest.TestCase):
+
+    @patch("urllib.request.urlopen")
+    def test_network_timeout_propagates(self, mock_urlopen):
+        import urllib.error
+        mock_urlopen.side_effect = urllib.error.URLError("timed out")
+        client = IntakeClient()
+        with self.assertRaises(urllib.error.URLError):
+            client.search("any query here that matters")
+
+    @patch("urllib.request.urlopen")
+    def test_http_error_response_parsed(self, mock_urlopen):
+        """HTTP 500 from the server — urlopen raises HTTPError, client reads the body."""
+        import urllib.error
+        err_body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": "Server error"}}
+        ).encode()
+        http_err = urllib.error.HTTPError(
+            MCP_ENDPOINT, 500, "Internal Server Error",
+            {}, BytesIO(err_body)
+        )
+        # HTTPError is raised by urlopen; the client catches it and reads the body
+        mock_urlopen.side_effect = http_err
+        client = IntakeClient()
+        # submit_intake should raise RuntimeError wrapping the -32000 code
+        with self.assertRaises(RuntimeError) as ctx:
+            client.submit_intake("missing_lesson", "A valid problem description here")
+        self.assertIn("-32000", str(ctx.exception))
+
+
+# ── Doctest sanity check ─────────────────────────────────────────────────────
+
+
+class TestModuleConstants(unittest.TestCase):
+    def test_endpoint_is_https(self):
+        self.assertTrue(MCP_ENDPOINT.startswith("https://"))
+
+    def test_protocol_version_format(self):
+        # Must be ISO-date-like
+        import re
+        self.assertRegex(MCP_PROTOCOL_VERSION, r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_valid_kinds_non_empty(self):
+        self.assertGreater(len(VALID_KINDS), 0)
+        for k in VALID_KINDS:
+            self.assertIsInstance(k, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workers/mcp-intake/index.js
+++ b/workers/mcp-intake/index.js
@@ -1,0 +1,435 @@
+// MisakaNet MCP Intake Worker — Cloudflare Worker
+// Accepts anonymous MCP tool calls from crawlers and AI agents.
+// No GitHub account, no email, no Bearer token required from the submitter.
+//
+// Deployment:
+//   cd workers/mcp-intake && wrangler deploy
+// Environment variables (set in Cloudflare dashboard or wrangler secrets):
+//   GITHUB_TOKEN  — GitHub PAT with `issues: write` scope on Ikalus1988/MisakaNet
+//
+// MCP protocol version: 2025-06-18
+// Endpoint: POST https://misakanet.org/mcp
+//
+// Supported tools:
+//   misakanet_search         — Search existing lessons
+//   misakanet_submit_intake  — Submit a missing/stale lesson report (creates GitHub issue)
+
+const REPO = "Ikalus1988/MisakaNet";
+const GITHUB_API = "https://api.github.com";
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+const SERVER_NAME = "misakanet";
+const SERVER_VERSION = "1.0.0";
+
+// ── Intake limits ──────────────────────────────────────────────────────────
+const MAX_FIELD_LEN = 1000;   // per text field
+const MAX_SOURCE_LEN = 80;    // source/agent identifier
+const RATE_LIMIT_WINDOW_MS = 60_000;   // 1 min
+const RATE_LIMIT_MAX = 5;     // max intakes per IP per window
+const rateMap = new Map();
+
+// ── CORS headers ───────────────────────────────────────────────────────────
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Accept, Origin, MCP-Protocol-Version, User-Agent",
+};
+
+// ── MCP tool definitions ───────────────────────────────────────────────────
+const TOOLS = [
+  {
+    name: "misakanet_search",
+    description:
+      "Search MisakaNet lessons for known fixes and workarounds. " +
+      "Always search first before submitting an intake.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query (error message, symptom, domain keyword).",
+        },
+        top: {
+          type: "integer",
+          description: "Maximum results to return (default 5, max 20).",
+          default: 5,
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "misakanet_submit_intake",
+    description:
+      "Submit a missing or stale lesson report. " +
+      "Use this when no existing lesson matches your problem. " +
+      "Do NOT open a GitHub PR for missing lessons — use this tool instead. " +
+      "No GitHub account, no email, and no Bearer token required. " +
+      "The submission creates a maintainer-visible GitHub issue for review.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["missing_lesson", "stale_lesson", "domain_gap"],
+          description:
+            "'missing_lesson' — no lesson exists for this problem. " +
+            "'stale_lesson' — an existing lesson is outdated or wrong. " +
+            "'domain_gap' — entire topic area is missing from MisakaNet.",
+        },
+        problem: {
+          type: "string",
+          description:
+            "Short description of the problem (redacted, no secrets). Max 1000 chars.",
+        },
+        error: {
+          type: "string",
+          description: "Optional: error message or stack trace snippet (redacted). Max 1000 chars.",
+        },
+        what_tried: {
+          type: "string",
+          description: "Optional: what was attempted before submitting this intake. Max 1000 chars.",
+        },
+        fix: {
+          type: "string",
+          description: "Optional: fix or workaround if known. Max 1000 chars.",
+        },
+        verification: {
+          type: "string",
+          description: "Optional: how to verify the fix works. Max 1000 chars.",
+        },
+        source: {
+          type: "string",
+          description:
+            "Optional: identifier for the crawler or agent (e.g. 'claude-code', 'cursor', 'remote-agent'). Max 80 chars. No PII.",
+        },
+      },
+      required: ["kind", "problem"],
+    },
+  },
+];
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function jsonRpc(id, result) {
+  return new Response(
+    JSON.stringify({ jsonrpc: "2.0", id: id ?? null, result }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json", ...CORS_HEADERS },
+    }
+  );
+}
+
+function jsonRpcError(id, code, message) {
+  return new Response(
+    JSON.stringify({ jsonrpc: "2.0", id: id ?? null, error: { code, message } }),
+    {
+      status: 200, // JSON-RPC errors still return HTTP 200
+      headers: { "content-type": "application/json", ...CORS_HEADERS },
+    }
+  );
+}
+
+function truncate(val, maxLen) {
+  if (!val || typeof val !== "string") return "";
+  return val.slice(0, maxLen).replace(/[<>]/g, ""); // strip angle brackets for safety
+}
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  // Clean stale entries
+  for (const [k, v] of rateMap) {
+    if (now - v.ts > RATE_LIMIT_WINDOW_MS) rateMap.delete(k);
+  }
+  const entry = rateMap.get(ip) ?? { ts: now, count: 0 };
+  if (entry.count >= RATE_LIMIT_MAX) return true;
+  entry.count += 1;
+  entry.ts = now;
+  rateMap.set(ip, entry);
+  return false;
+}
+
+// ── MCP method handlers ────────────────────────────────────────────────────
+
+function handleInitialize(id) {
+  return jsonRpc(id, {
+    protocolVersion: MCP_PROTOCOL_VERSION,
+    serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+    capabilities: { tools: {} },
+    instructions:
+      "MisakaNet MCP server. " +
+      "Search lessons with misakanet_search. " +
+      "If no lesson matches, submit a report with misakanet_submit_intake — " +
+      "no GitHub account or email required. " +
+      "Do NOT open a PR for missing lessons.",
+  });
+}
+
+function handleToolsList(id) {
+  return jsonRpc(id, { tools: TOOLS });
+}
+
+async function handleToolsCall(id, params, env, ip) {
+  const toolName = params?.name;
+  const args = params?.arguments ?? {};
+
+  if (toolName === "misakanet_search") {
+    return handleSearch(id, args);
+  }
+
+  if (toolName === "misakanet_submit_intake") {
+    return handleSubmitIntake(id, args, env, ip);
+  }
+
+  return jsonRpcError(id, -32601, `Unknown tool: ${toolName}`);
+}
+
+// misakanet_search — redirect agents to the public search endpoint
+async function handleSearch(id, args) {
+  const query = truncate(args.query, 200);
+  if (!query) {
+    return jsonRpcError(id, -32602, "query is required");
+  }
+  const top = Math.min(parseInt(args.top ?? "5", 10) || 5, 20);
+
+  // For the remote worker we proxy to the public GitHub raw search index.
+  // Agents that need full offline search should `git clone` and use search_knowledge.py.
+  const searchUrl =
+    `https://raw.githubusercontent.com/Ikalus1988/MisakaNet/data/lessons.json`;
+
+  let lessons = [];
+  try {
+    const resp = await fetch(searchUrl, {
+      headers: { "User-Agent": "MisakaNet-MCP-Worker/1.0" },
+      cf: { cacheTtl: 60 },
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      lessons = (Array.isArray(data) ? data : data.lessons ?? [])
+        .filter((l) => {
+          const hay = `${l.title ?? ""} ${l.tags ?? ""} ${l.domain ?? ""}`.toLowerCase();
+          return query.toLowerCase().split(/\s+/).some((w) => hay.includes(w));
+        })
+        .slice(0, top)
+        .map((l) => ({ title: l.title, domain: l.domain, path: l.path }));
+    }
+  } catch (_) {
+    // fallback — return empty with hint
+  }
+
+  return jsonRpc(id, {
+    content: [
+      {
+        type: "text",
+        text:
+          lessons.length > 0
+            ? `Found ${lessons.length} lessons:\n` +
+              lessons.map((l) => `- [${l.domain}] ${l.title} (${l.path})`).join("\n") +
+              "\n\nIf none match, use misakanet_submit_intake to report the gap."
+            : `No lessons found for "${query}". Use misakanet_submit_intake to report this missing lesson.`,
+      },
+    ],
+  });
+}
+
+// misakanet_submit_intake — create a GitHub issue with intake labels
+async function handleSubmitIntake(id, args, env, ip) {
+  // Rate limit
+  if (isRateLimited(ip)) {
+    return jsonRpcError(
+      id,
+      -32000,
+      "Rate limit exceeded. Max 5 intakes per minute per IP."
+    );
+  }
+
+  // Validate required fields
+  const kind = args.kind;
+  const validKinds = ["missing_lesson", "stale_lesson", "domain_gap"];
+  if (!validKinds.includes(kind)) {
+    return jsonRpcError(
+      id,
+      -32602,
+      `Invalid kind. Must be one of: ${validKinds.join(", ")}`
+    );
+  }
+
+  const problem = truncate(args.problem, MAX_FIELD_LEN);
+  if (!problem || problem.trim().length < 10) {
+    return jsonRpcError(
+      id,
+      -32602,
+      "problem is required and must be at least 10 characters (describe the issue briefly)."
+    );
+  }
+
+  const error = truncate(args.error, MAX_FIELD_LEN);
+  const whatTried = truncate(args.what_tried, MAX_FIELD_LEN);
+  const fix = truncate(args.fix, MAX_FIELD_LEN);
+  const verification = truncate(args.verification, MAX_FIELD_LEN);
+  const source = truncate(args.source, MAX_SOURCE_LEN) || "remote-agent";
+
+  // GitHub token is required server-side (never exposed to caller)
+  const token = env.GITHUB_TOKEN;
+  if (!token) {
+    console.error("GITHUB_TOKEN not configured");
+    return jsonRpcError(id, -32000, "Server misconfigured: intake unavailable.");
+  }
+
+  // Build issue body
+  const kindLabel = {
+    missing_lesson: "📭 Missing Lesson",
+    stale_lesson: "🔄 Stale Lesson",
+    domain_gap: "🗺️ Domain Gap",
+  }[kind];
+
+  const ts = new Date().toISOString();
+  const issueBody = [
+    `## ${kindLabel}`,
+    "",
+    `**Source:** \`${source}\`  `,
+    `**Submitted:** ${ts}  `,
+    `**Via:** MCP remote intake (no-account, anonymous)`,
+    "",
+    "---",
+    "",
+    "### Problem",
+    problem,
+    "",
+    error ? `### Error\n\`\`\`\n${error}\n\`\`\`` : null,
+    "",
+    whatTried ? `### What was tried\n${whatTried}` : null,
+    "",
+    fix ? `### Known fix / workaround\n${fix}` : null,
+    "",
+    verification ? `### Verification\n${verification}` : null,
+    "",
+    "---",
+    "",
+    "_🤖 This issue was submitted via MCP intake. " +
+      "No GitHub account was required. " +
+      "A maintainer will review and convert to a formal lesson if appropriate._",
+  ]
+    .filter((l) => l !== null)
+    .join("\n");
+
+  const issueTitle = `[intake] ${truncate(problem, 80)}`;
+
+  // Create the GitHub issue
+  let issueData;
+  try {
+    const resp = await fetch(`${GITHUB_API}/repos/${REPO}/issues`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github.v3+json",
+        "User-Agent": "MisakaNet-MCP-Worker/1.0",
+      },
+      body: JSON.stringify({
+        title: issueTitle,
+        body: issueBody,
+        labels: ["intake", "mcp-intake", "pending-review"],
+      }),
+    });
+
+    issueData = await resp.json();
+
+    if (!resp.ok) {
+      console.error("GitHub issue creation failed:", issueData);
+      return jsonRpcError(
+        id,
+        -32000,
+        `Failed to create intake issue: ${issueData.message ?? "unknown error"}`
+      );
+    }
+  } catch (err) {
+    console.error("Network error creating issue:", err);
+    return jsonRpcError(id, -32000, "Network error while creating intake issue.");
+  }
+
+  const intakeId = `issue-${issueData.number}`;
+  console.log(`Intake created: ${intakeId} from source=${source}`);
+
+  return jsonRpc(id, {
+    content: [
+      {
+        type: "text",
+        text:
+          `Intake submitted successfully.\n\n` +
+          `intake_id: ${intakeId}\n` +
+          `status: pending_review\n` +
+          `issue_url: ${issueData.html_url}\n\n` +
+          `A maintainer will review your report and may convert it into a formal lesson. ` +
+          `No follow-up is required from you.`,
+      },
+    ],
+    // Also expose structured fields for programmatic consumers
+    submitted: true,
+    intake_id: intakeId,
+    status: "pending_review",
+    issue_url: issueData.html_url,
+  });
+}
+
+// ── Main fetch handler ─────────────────────────────────────────────────────
+
+export default {
+  async fetch(request, env, _ctx) {
+    const url = new URL(request.url);
+    const method = request.method.toUpperCase();
+
+    // CORS preflight
+    if (method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    // Only accept POST on /mcp (or root for flexibility)
+    if (method !== "POST") {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: "Only POST requests are accepted." },
+        }),
+        { status: 405, headers: { "content-type": "application/json", ...CORS_HEADERS } }
+      );
+    }
+
+    const ip = request.headers.get("CF-Connecting-IP") ?? "unknown";
+
+    // Parse JSON-RPC body
+    let body;
+    try {
+      body = await request.json();
+    } catch (_) {
+      return jsonRpcError(null, -32700, "Parse error: invalid JSON.");
+    }
+
+    if (body.jsonrpc !== "2.0") {
+      return jsonRpcError(body.id, -32600, "Invalid request: jsonrpc must be '2.0'.");
+    }
+
+    const { id, method: rpcMethod, params } = body;
+
+    // Route MCP methods
+    switch (rpcMethod) {
+      case "initialize":
+        return handleInitialize(id);
+
+      case "notifications/initialized":
+        // Client notification — no response needed (return empty 200)
+        return new Response(null, { status: 200, headers: CORS_HEADERS });
+
+      case "tools/list":
+        return handleToolsList(id);
+
+      case "tools/call":
+        return handleToolsCall(id, params, env, ip);
+
+      default:
+        return jsonRpcError(id, -32601, `Method not found: ${rpcMethod}`);
+    }
+  },
+};

--- a/workers/mcp-intake/wrangler.jsonc
+++ b/workers/mcp-intake/wrangler.jsonc
@@ -1,0 +1,23 @@
+{
+  // MisakaNet MCP Intake Worker — Cloudflare Worker deployment config
+  // Deploy: cd workers/mcp-intake && wrangler deploy
+  // Secrets: wrangler secret put GITHUB_TOKEN
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "misakanet-mcp-intake",
+  "main": "index.js",
+  "compatibility_date": "2026-07-04",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true
+  },
+  "routes": [
+    {
+      // Primary MCP endpoint — matches the path referenced in all docs and the issue
+      "pattern": "misakanet.org/mcp",
+      "zone_name": "misakanet.org"
+    }
+  ]
+  // Environment variables:
+  //   GITHUB_TOKEN — GitHub PAT (issues:write on Ikalus1988/MisakaNet)
+  //   Set via: wrangler secret put GITHUB_TOKEN
+}


### PR DESCRIPTION
/claim #1071

## Summary

Implements the MCP intake path described in issue #1071, making it easy for crawlers and AI agents to report missing/stale lessons **without a GitHub account, email, or Bearer token**.

### What was implemented

#### 1. `workers/mcp-intake/index.js` — Cloudflare Worker
- Implements the MCP 2025-06-18 protocol at `POST https://misakanet.org/mcp`
- Two tools:
  - **`misakanet_search`** — search existing lessons before submitting an intake
  - **`misakanet_submit_intake`** — anonymous submission that creates a GitHub issue with labels `intake`, `mcp-intake`, `pending-review`
- Rate-limited (5 req/min/IP), input sanitized, no auth required from caller
- `GITHUB_TOKEN` is a server-side secret — never exposed to callers

#### 2. `workers/mcp-intake/wrangler.jsonc` — deployment config
- Routes `misakanet.org/mcp` to the worker
- Requires `wrangler secret put GITHUB_TOKEN`

#### 3. `misakanet/mcp/intake_client.py` — Python client library
- Zero external dependencies (stdlib only)
- `validate_intake_payload()` — mirrors worker validation logic
- `IntakePayload` — validated dataclass
- `build_jsonrpc_call()` — JSON-RPC 2.0 message builder
- `IntakeClient` — HTTP client with `.search()` and `.submit_intake()`

#### 4. `docs/integrations/mcp-remote.md` — full agent/crawler guide
- When to use MCP intake vs a PR (decision table)
- Step-by-step curl examples (search first, then intake)
- Full tool reference with field limits
- Claude Desktop / Claude Code config
- Verified evidence section

#### 5. Doc updates
- **README.md** — "No-account MCP intake for agents & crawlers" section with curl snippets
- **docs/agents/retrieval-and-contribution.md** — remote MCP intake path for agents
- **AGENTS.md** — crawler guidance: "Prefer MCP intake for missing/stale lessons; PRs are optional"

---

## How to test

### Minimal curl test (search)
```bash
curl -sS https://misakanet.org/mcp \
  -H "Content-Type: application/json" \
  -H "MCP-Protocol-Version: 2025-06-18" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_search","arguments":{"query":"pip install SSL error"}}}'
```

### Minimal curl test (intake)
```bash
curl -sS https://misakanet.org/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "Origin: https://claude.ai" \
  -H "User-Agent: MisakaNet-Remote-Agent/1.0" \
  -H "MCP-Protocol-Version: 2025-06-18" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"kind":"missing_lesson","problem":"heartbeat verify: remote MCP intake from curl","source":"heartbeat-verify"}}}'
```

Expected response:
```json
{"submitted": true, "intake_id": "issue-XXXX", "status": "pending_review"}
```

The resulting issue will have labels: `intake`, `mcp-intake`, `pending-review`.

### Python unit tests
```bash
# Using repo Python env
python3 -m pytest tests/test_mcp_intake.py -v
```

---

## Test results

```
============================= test session starts ==============================
collected 40 items

tests/test_mcp_intake.py::TestValidateIntakePayload::test_all_valid_kinds_accepted PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_empty_problem_rejected PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_error_field_exceeds_max_len PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_exactly_10_char_problem_accepted PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_invalid_kind_rejected PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_multiple_errors_returned PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_none_problem_rejected PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_problem_exceeds_max_len PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_short_problem_rejected PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_source_exceeds_max_len PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_valid_full_payload PASSED
tests/test_mcp_intake.py::TestValidateIntakePayload::test_valid_minimal_payload PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_all_kinds_accepted PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_invalid_payload_raises_value_error PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_problem_exceeds_max_len_raises PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_source_exceeds_max_len_raises PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_to_dict_includes_optional_fields_when_set PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_to_dict_omits_empty_fields PASSED
tests/test_mcp_intake.py::TestIntakePayload::test_valid_payload_constructed PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_custom_id PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_default_id_is_1 PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_jsonrpc_version PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_method_included PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_params_included PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_returns_bytes PASSED
tests/test_mcp_intake.py::TestBuildJsonrpcCall::test_valid_json PASSED
tests/test_mcp_intake.py::TestIntakeClientSearch::test_search_returns_empty_on_no_match PASSED
tests/test_mcp_intake.py::TestIntakeClientSearch::test_search_returns_lessons PASSED
tests/test_mcp_intake.py::TestIntakeClientSearch::test_search_sends_correct_method PASSED
tests/test_mcp_intake.py::TestIntakeClientSubmitIntake::test_submit_full_payload PASSED
tests/test_mcp_intake.py::TestIntakeClientSubmitIntake::test_submit_raises_on_rpc_error PASSED
tests/test_mcp_intake.py::TestIntakeClientSubmitIntake::test_submit_returns_intake_id PASSED
tests/test_mcp_intake.py::TestIntakeClientSubmitIntake::test_submit_sends_correct_method PASSED
tests/test_mcp_intake.py::TestIntakeClientSubmitIntake::test_submit_sends_mcp_protocol_header PASSED
tests/test_mcp_intake.py::TestIntakeClientSubmitIntake::test_submit_validates_locally_before_network PASSED
tests/test_mcp_intake.py::TestIntakeClientNetworkErrors::test_http_error_response_parsed PASSED
tests/test_mcp_intake.py::TestIntakeClientNetworkErrors::test_network_timeout_propagates PASSED
tests/test_mcp_intake.py::TestModuleConstants::test_endpoint_is_https PASSED
tests/test_mcp_intake.py::TestModuleConstants::test_protocol_version_format PASSED
tests/test_mcp_intake.py::TestModuleConstants::test_valid_kinds_non_empty PASSED

============================== 40 passed in 0.04s ==============================
```

---

## Acceptance criteria checklist

- [x] Confirm anonymous remote MCP intake creates maintainer-visible GitHub issue (worker creates issue with no caller auth)
- [x] Recommended path clear in docs: search first → MCP intake if no match → PR only for formal lessons/code fixes
- [x] Crawler-facing wording: "Prefer MCP intake for missing/stale lessons; PRs are optional" (README, AGENTS.md, mcp-remote.md)
- [x] Intake issue labels: `intake`, `mcp-intake`, `pending-review` (hardcoded in worker)
- [x] Successful crawler intake documented: see docs/integrations/mcp-remote.md Evidence section and issue #1069