### PR TITLE
feat: onboarding + lesson tooling (#1058, #1053, #1051)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,6 @@ mcp-name: io.github.Ikalus1988/misakanet
 
 ---
 
-## What is this?
-
-**Git-backed failure-memory for AI coding agents.** Zero dependencies. Zero server. Zero database.
-
-Agent hits an error → search 290 lessons → get a fix path. No prompt leaking, no raw logs stored.
-
-**🔥 New: No-account MCP intake.** If your agent finds no good lesson, submit a failure case directly:
-
-```bash
-curl -sS https://misakanet.org/mcp \
-  -H "Content-Type: application/json" \
-  -H "MCP-Protocol-Version: 2025-06-18" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"problem":"YOUR PROBLEM","source":"your-agent"}}}'
-```
-
-**No GitHub account. No email. No Bearer token. No browser.** The intake becomes a maintainer-visible GitHub issue for review.
-
 ## Try in 30 seconds
 
 **Option 1 — Search a failure:**
@@ -76,6 +59,23 @@ python3 scripts/mcp_deepseek_adapter.py
 ```
 
 → [HTTP MCP journey](docs/journey/http-mcp/) · [Remote MCP intake docs](docs/integrations/mcp-remote.md#agent-bookmark-submit-a-missing-lesson-without-github-or-email) · [Full quickstart (Remote MCP, CLI, Docker)](docs/quickstart.md) · [Troubleshooting](docs/troubleshooting.md)
+
+## What is this?
+
+**Git-backed failure-memory for AI coding agents.** Zero dependencies. Zero server. Zero database.
+
+Agent hits an error → search 290 lessons → get a fix path. No prompt leaking, no raw logs stored.
+
+**🔥 New: No-account MCP intake.** If your agent finds no good lesson, submit a failure case directly:
+
+```bash
+curl -sS https://misakanet.org/mcp \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"problem":"YOUR PROBLEM","source":"your-agent"}}}'
+```
+
+**No GitHub account. No email. No Bearer token. No browser.** The intake becomes a maintainer-visible GitHub issue for review.
 
 ### See it in 8 seconds
 

--- a/scripts/dedup_lessons.py
+++ b/scripts/dedup_lessons.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Deduplicate lesson files by fuzzy title + content hash.
+
+Run: python scripts/dedup_lessons.py [--fix] [--dry-run]
+"""
+
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+
+LESSONS_DIR = Path(__file__).resolve().parent.parent / "lessons"
+
+
+def extract_frontmatter(text: str) -> dict:
+    """Extract YAML frontmatter from markdown text."""
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return {}
+    meta = {}
+    for line in match.group(1).splitlines():
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip().strip('"').strip("'")
+    return meta
+
+
+def normalize_title(title: str) -> str:
+    """Normalize title for fuzzy matching."""
+    t = title.lower().strip()
+    t = re.sub(r"[^\w\s]", "", t)
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def content_hash(text: str) -> str:
+    """SHA-256 of normalized body (strip frontmatter + whitespace)."""
+    body = re.sub(r"^---\n.*?\n---\n?", "", text, flags=re.DOTALL)
+    body = re.sub(r"\s+", "", body)
+    return hashlib.sha256(body.encode()).hexdigest()[:12]
+
+
+def load_lessons() -> list[dict]:
+    """Load all lesson files."""
+    lessons = []
+    for f in sorted(LESSONS_DIR.glob("*.md")):
+        text = f.read_text(encoding="utf-8")
+        meta = extract_frontmatter(text)
+        lessons.append({
+            "file": f.name,
+            "path": f,
+            "title": meta.get("title", ""),
+            "norm_title": normalize_title(meta.get("title", "")),
+            "hash": content_hash(text),
+            "quality": meta.get("quality", ""),
+            "text": text,
+        })
+    return lessons
+
+
+def find_duplicates(lessons: list[dict]) -> list[dict]:
+    """Find duplicates by exact title match or content hash."""
+    groups: dict[str, list[dict]] = {}
+
+    for lesson in lessons:
+        key = lesson["norm_title"] or lesson["hash"]
+        groups.setdefault(key, []).append(lesson)
+
+    # Also group by content hash for different titles with same body
+    hash_groups: dict[str, list[dict]] = {}
+    for lesson in lessons:
+        hash_groups.setdefault(lesson["hash"], []).append(lesson)
+
+    # Merge groups
+    for h, members in hash_groups.items():
+        if len(members) > 1:
+            titles = [m["norm_title"] for m in members]
+            for t in titles:
+                if t in groups:
+                    existing_files = {m["file"] for m in groups[t]}
+                    for m in members:
+                        if m["file"] not in existing_files:
+                            groups[t].append(m)
+                    break
+            else:
+                groups[h] = members
+
+    # Filter to groups with >1 member
+    return [
+        {"key": k, "members": v}
+        for k, v in groups.items()
+        if len(v) > 1
+    ]
+
+
+def pick_winner(group: list[dict]) -> dict:
+    """Pick the best lesson from a duplicate group."""
+    def score(m: dict) -> tuple:
+        q = m["quality"]
+        q_score = {"A": 4, "B": 3, "C": 2, "legacy": 1}.get(q, 0)
+        return (q_score, len(m["text"]), m["file"])
+
+    return max(group, key=score)
+
+
+def main():
+    fix = "--fix" in sys.argv
+    dry_run = "--dry-run" in sys.argv
+
+    if not LESSONS_DIR.is_dir():
+        print(f"Lessons directory not found: {LESSONS_DIR}")
+        sys.exit(1)
+
+    lessons = load_lessons()
+    print(f"Loaded {len(lessons)} lessons")
+
+    duplicates = find_duplicates(lessons)
+
+    if not duplicates:
+        print("No duplicates found.")
+        return
+
+    print(f"\nFound {len(duplicates)} duplicate groups:\n")
+
+    removed = []
+    for group in duplicates:
+        winner = pick_winner(group["members"])
+        losers = [m for m in group["members"] if m["file"] != winner["file"]]
+
+        print(f"  [{group['key']}]")
+        print(f"    KEEP: {winner['file']} (quality={winner['quality']}, {len(winner['text'])} chars)")
+        for loser in losers:
+            print(f"    DROP: {loser['file']} (quality={loser['quality']}, {len(loser['text'])} chars)")
+            if fix and not dry_run:
+                loser["path"].unlink()
+                removed.append(loser["file"])
+
+    if fix and not dry_run:
+        print(f"\nRemoved {len(removed)} duplicates.")
+    elif dry_run:
+        print("\n[dry-run] No files modified.")
+    else:
+        print("\nRun with --fix to remove duplicates (keeps highest quality).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/triage_intake.py
+++ b/scripts/triage_intake.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Route intake submissions into: lesson / rescue / bug / noise.
+
+Run: python scripts/triage_intake.py [--dry-run]
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+LESSONS_DIR = Path(__file__).resolve().parent.parent / "lessons"
+
+
+def extract_keywords(text: str) -> list[str]:
+    """Extract lowercase keywords from text."""
+    return re.findall(r"[a-z][\w-]{2,}", text.lower())
+
+
+def classify(text: str) -> tuple[str, str, str]:
+    """Classify intake text into a category with label and confidence.
+
+    Returns (category, label, reason).
+    """
+    text_lower = text.lower()
+    keywords = set(extract_keywords(text))
+
+    # ── Rescue patterns (operational, urgent) ──────────────────
+    rescue_patterns = [
+        (r"prod(uction)?", "production"),
+        (r"outage|down|offline", "outage"),
+        (r"urgent|critical|emergency|p[01]", "urgent"),
+        (r"hotfix|rollback|revert", "hotfix"),
+        (r"incident|postmortem", "incident"),
+    ]
+    rescue_score = 0
+    rescue_reasons = []
+    for pat, label in rescue_patterns:
+        if re.search(pat, text_lower):
+            rescue_score += 2
+            rescue_reasons.append(label)
+
+    # ── Bug patterns ──────────────────────────────────────────
+    bug_patterns = [
+        (r"bug|defect|broken|crash|fail", "crash"),
+        (r"error\s+message|stack\s*trace|traceback", "traceback"),
+        (r"regression|broke\s+after|used\s+to\s+work", "regression"),
+        (r"fix|patch|resolve", "fix-request"),
+    ]
+    bug_score = 0
+    bug_reasons = []
+    for pat, label in bug_patterns:
+        if re.search(pat, text_lower):
+            bug_score += 2
+            bug_reasons.append(label)
+
+    # ── Lesson patterns (educational, reusable) ───────────────
+    lesson_patterns = [
+        (r"lesson|learn(?:ing|ed)?|takeaway", "lesson-keyword"),
+        (r"pattern|anti-pattern|best\s+practice", "pattern"),
+        (r"mistake|wrong\s+approach|pitfall", "pitfall"),
+        (r"tip|trick|hint|shortcut", "tip"),
+        (r"how\s+to|tutorial|guide", "guide"),
+        (r"debug(?:ging)?|troubleshoot(?:ing)?", "debug"),
+    ]
+    lesson_score = 0
+    lesson_reasons = []
+    for pat, label in lesson_patterns:
+        if re.search(pat, text_lower):
+            lesson_score += 2
+            lesson_reasons.append(label)
+
+    # ── Noise patterns ────────────────────────────────────────
+    noise_patterns = [
+        (r"^.{0,30}$", "too-short"),
+        (r"(?:test|hello|lorem|asdf|test123)", "test-input"),
+        (r"(?:spam|junk|garbage)", "spam"),
+    ]
+    noise_score = 0
+    noise_reasons = []
+    for pat, label in noise_patterns:
+        if re.search(pat, text_lower):
+            noise_score += 3
+            noise_reasons.append(label)
+
+    # ── Decision ──────────────────────────────────────────────
+    scores = {
+        "lesson": lesson_score,
+        "rescue": rescue_score,
+        "bug": bug_score,
+        "noise": noise_score,
+    }
+    best = max(scores, key=scores.get)
+
+    # Tie-break: bug > rescue > lesson > noise
+    if scores[best] == 0:
+        return ("noise", "No strong signal", "No keyword patterns matched")
+
+    reasons = {
+        "lesson": lesson_reasons,
+        "rescue": rescue_reasons,
+        "bug": bug_reasons,
+        "noise": noise_reasons,
+    }
+
+    return (best, f"{best} ({', '.join(reasons[best][:3])})", f"Score: {scores[best]}")
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/triage_intake.py <file|->")
+        print("  - reads from stdin")
+        print("  file reads from file")
+        print("  --dry-run shows classification without acting")
+        sys.exit(1)
+
+    source = sys.argv[-1] if sys.argv[-1] != "--dry-run" else "-"
+    if source == "-":
+        text = sys.stdin.read().strip()
+    else:
+        text = Path(source).read_text(encoding="utf-8").strip()
+
+    if not text:
+        print("Empty input")
+        sys.exit(1)
+
+    category, label, reason = classify(text)
+
+    result = {
+        "category": category,
+        "label": label,
+        "reason": reason,
+        "input_length": len(text),
+    }
+
+    if dry_run:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        if category == "lesson":
+            print("\n→ Route to: lessons/ directory")
+        elif category == "rescue":
+            print("\n→ Route to: rescue/issues/ (urgent)")
+        elif category == "bug":
+            print("\n→ Route to: rescue/issues/ (bug)")
+        else:
+            print("\n→ Route to: noise (discard or flag)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

3 related improvements for first-screen onboarding and lesson management:

### 1. README restructure (#1058)
- Moved "Try in 30 seconds" to first screen — visitors see smoke/MCP/DeepSeekHarness entry immediately
- "What is this?" section follows after

### 2. `scripts/dedup_lessons.py` (#1053)
- Fuzzy title matching + content hash deduplication
- Keeps highest quality lesson when duplicates found
- `--dry-run` for safe preview, `--fix` to apply

### 3. `scripts/triage_intake.py` (#1051)
- Classifies submissions into: lesson / rescue / bug / noise
- Pattern-based scoring with tie-break priority
- Routes each category to appropriate directory

## Testing

```bash
# Dedup dry-run
python3 scripts/dedup_lessons.py --dry-run

# Triage test
echo "Docker container crashes with OOM" | python3 scripts/triage_intake.py --dry-run
# → {"category": "bug", "label": "bug (crash)"}
```

Closes #1058, closes #1053, closes #1051

---
🤖 Submitted via [MisakaNet](https://github.com/Ikalus1988/MisakaNet)