### PR TITLE
docs: add agent compatibility grid (#1147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ Agent hits an error → search 290 lessons → get a fix path. No prompt leaking
 | Remote MCP | HTTP endpoint | https://misakanet.org/mcp |
 | DSH Adapter | Harness integration | `python3 scripts/mcp_deepseek_adapter.py` |
 
+### Agent compatibility
+
+| Agent | Integration | Status |
+|---|---|---|
+| Claude Code | MCP + SKILL.md | ✅ Supported |
+| Codex | MCP + AGENTS.md | ✅ Supported |
+| Cursor | MCP + rules | ✅ Supported |
+| DeepSeek Harness | MCP adapter | ✅ Supported |
+| Gemini CLI | MCP | ✅ Supported |
+| Windsurf | MCP | ✅ Supported |
+| OpenCode | MCP | ✅ Supported |
+| Copilot | MCP | ✅ Supported |
+
 **🔥 New: No-account MCP intake.** If your agent finds no good lesson, submit a failure case directly:
 
 ```bash


### PR DESCRIPTION
## What\n\nAdd agent compatibility grid after "What is this?" section.\n\n| Agent | Integration | Status |\n|---|---|---|\n| Claude Code | MCP + SKILL.md | ✅ Supported |\n| Codex | MCP + AGENTS.md | ✅ Supported |\n| Cursor | MCP + rules | ✅ Supported |\n| DeepSeek Harness | MCP adapter | ✅ Supported |\n| Gemini CLI | MCP | ✅ Supported |\n| Windsurf | MCP | ✅ Supported |\n| OpenCode | MCP | ✅ Supported |\n| Copilot | MCP | ✅ Supported |\n\nCloses #1147\n\n---\n🤖 Submitted via [MisakaNet](https://github.com/Ikalus1988/MisakaNet)