### PR TITLE
docs: sync STATUS.md, ROADMAP.md, README.md to v2.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > **Git-backed failure-memory for AI coding agents.**
 >
 > Zero dependencies. Zero server. Zero database.
-> Paste an error → search 290 lessons → get a fix path.
+> Paste an error → search 377 lessons → get a fix path.
 
 mcp-name: io.github.Ikalus1988/misakanet
 
@@ -77,7 +77,7 @@ Returns `node_id` + `token`. Use token for unlimited remote searches.
 
 **Git-backed failure-memory for AI coding agents.** Zero dependencies. Zero server. Zero database.
 
-Agent hits an error → search 290 lessons → get a fix path. No prompt leaking, no raw logs stored.
+Agent hits an error → search 377 lessons → get a fix path. No prompt leaking, no raw logs stored.
 
 ### Integration surfaces
 
@@ -147,7 +147,7 @@ curl -sS https://misakanet.org/mcp \
 | **Security Fix** | CodeQL #49: URL validation uses `startswith()` instead of substring check |
 | **Worker Syntax Fix** | Fixed pre-existing missing closing brace in `register-proxy-sw.js` |
 | **Issue Evaluator** | PR Genius extended with issue quality review (spam, secrets, labels) |
-| **290 Lessons** | First lesson from remote MCP intake (#1069 → `github-release-large-asset-download-cn.md`) |
+| **377 Lessons** | First lesson from remote MCP intake (#1069 → `github-release-large-asset-download-cn.md`) |
 
 → [Full release notes](https://github.com/Ikalus1988/MisakaNet/releases/tag/v2.18.0)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,13 +14,13 @@ MisakaNet should stay offline-first and Git-backed. External listings are useful
 
 ## Current baseline
 
-- Release/distribution: PyPI `misakanet 2.16.0`, GitHub release `v2.16.0`,
+- Release/distribution: PyPI `misakanet-core`, GitHub release `v2.18.0`,
   Glama indexed/scored, MCP Toplist badge live, Remote MCP endpoint.
-- **v2.16.0 done** (2026-08-11): Remote MCP, pairing code, Identity Aura, Voice Prompts, evidence levels, security hotfixes.
+- **v2.18.0 done (2026-08-21): Agent-first registration, preflight guardrails, Remote MCP intake): Remote MCP, pairing code, Identity Aura, Voice Prompts, evidence levels, security hotfixes.
 - Test suite: passing.
 - Public site is online: homepage, `/search/`, journey page, Worker APIs, and
   lesson data endpoints are healthy.
-- Corpus wording baseline: **289 indexed failure lessons**; avoid claiming
+- Corpus wording baseline: **377 indexed failure lessons**; avoid claiming
   all are verified unless also stating the verified count separately.
 - Local MCP server exposes three tools: `misakanet_search`,
   `misakanet_get_lesson`, and `misakanet_submit_usage`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,15 +1,14 @@
 # 项目状态
 
-> 更新于 2026-08-12 | v2.17.0 (dev)
+> 更新于 2026-08-21 | v2.18.0
 
 ## 概览
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 289 篇 |
-| 🏛️ 领域覆盖 | 25 个 |
-| 🎤 Network Voices | 5 条 |
-| 📡 Feed Items | 5 条 |
+| 📚 Lessons | 377 篇 |
+| 🏛️ 领域覆盖 | 25+ 个 |
+| 🔧 MCP Tools | 7 个 (local) + register (remote) |
 | ⭐ Stars | 374 |
 | 🍴 Forks | 137 |
 | 🌐 Active Contributors | 10+ |
@@ -19,7 +18,8 @@
 | 模块 | 状态 |
 |------|------|
 | BM25 关键词搜索 | ✅ 零依赖 |
-| MCP Server (stdio) | ✅ 4 tools, Glama indexed |
+| MCP Server (stdio) | ✅ 7 tools, Glama indexed |
+| MCP Remote | ✅ misakanet.org/mcp, pairing code + token |
 | POST /api/intake | ✅ 私有反馈提交，自动 redaction |
 | Demand Board | ✅ intake 聚类 + 维护者 override |
 | Contribution Credits | ✅ 用量配额 + 贡献积分 |
@@ -29,6 +29,23 @@
 | PR Genius Advisory | ✅ 质量信号，不阻塞 merge |
 | Thank-you Workflow | ✅ PR merge 后自动评论 |
 | Email Intake | ✅ bot@misakanet.org → Worker → GitHub Issue |
+| Evidence Levels | ✅ E0-E4, trust_score = quality × (0.7 + 0.3 × evidence) |
+| Identity Aura | ✅ agent 身份认证 + pairing code |
+| Voice Prompts | ✅ 语音提示系统 |
+| Preflight Guard | ✅ MCP 风险注入检查 |
+
+## MCP 工具列表
+
+| 工具 | 用途 |
+|------|------|
+| `misakanet_search` | 搜索 failure lessons |
+| `misakanet_get_lesson` | 获取单篇 lesson 全文 |
+| `misakanet_submit_usage` | 提交使用反馈 |
+| `misakanet_submit_intake` | 匿名提交 failure 报告 |
+| `misakanet_write_lesson` | 注册 agent 提交 lesson（需 token） |
+| `misakanet_preflight` | 风险注入检查 |
+| `misakanet_usage_status` | 查询用量状态 |
+| `misakanet_register` | 远程 agent 注册（remote MCP） |
 
 ## 前端状态
 
@@ -41,57 +58,36 @@
 | i18n | ✅ zh/EN toggle (home + search + voices) |
 | Data Guard | ✅ CI prevents empty lessons.json |
 
-## 领域分布 (Top 10)
-
-| 领域 | 数量 |
-|------|------|
-| contrib | 221 |
-| devops | 11 |
-| rag | 9 |
-| agent-network | 3 |
-| growth | 3 |
-| feishu | 2 |
-| mcp | 2 |
-| web3 | 2 |
-| crypto-ops | 2 |
-| 其他 (16 domains) | 各 1 |
-
 ## 集成状态
 
 | 集成 | 状态 |
 |------|------|
 | Glama | ✅ Listed, MCP indexed |
 | MCP Registry | ✅ Listed |
-| awesome-mcp-servers | ⏳ PR submitted, awaiting review |
+| MCP Toplist | ✅ Badge live |
 | Cursor | ✅ Failure-memory rule (.cursor/rules/) |
 | Claude Code | ✅ Failure playbook + SKILL.md |
-
-## 快速开始
-
-```bash
-# 搜索
-python3 search_knowledge.py "关键词"
-
-# MCP server
-python3 scripts/mcp_server.py
-
-# 捕获失败报告
-python3 scripts/misaka_capture.py --summary "error description" --context log.txt
-
-# 搜索后反馈
-python3 search_knowledge.py "query" --feedback
-
-# 质量评分
-python3 scripts/score_lessons.py
-```
+| Smithery | ⏸ Paused |
 
 ## 版本历史
 
 | 版本 | 日期 | 要点 |
 |------|------|------|
+| v2.18.0 | 2026-08-21 | Agent-first registration、preflight guardrails、Remote MCP intake |
+| v2.17.1 | 2026-08-16 | Remote MCP Intake: no-account lesson contribution path |
+| v2.17.0 | 2026-08-13 | Trust & Curation Hardening |
 | v2.16.0 | 2026-08-11 | Remote MCP、Pairing Code、Identity Aura、Voice Prompts、Security hotfixes |
 | v2.15.0 | 2026-08-03 | Hub federation、CI self-healing、Auto-Merge |
 | v2.14.0 | 2026-07-29 | 贡献积分、需求看板、Capture CLI、Runtime 入口 |
 | v2.13.0 | 2026-07-29 | Intake 端点、Secret redaction、分类器、需求看板 |
 | v2.12.0 | 2026-07-16 | PR template 简化、feedback 入口、Glama 集成 |
 | v2.11.0 | 2026-07-14 | Email intake、DCO 指南、Network Voices |
+
+## 竞品研究（2026-08-21）
+
+| 竞品 | 定位 | MisakaNet 差异化 |
+|------|------|-----------------|
+| TeamMemory | MCP 团队经验记忆 | MisakaNet 有 redaction layer + failure classifier + demand board |
+| WeKnora | 腾讯 RAG 平台 | MisakaNet 聚焦 agent failure memory，不是通用知识库 |
+
+→ 详见 [#1162-#1168](https://github.com/Ikalus1988/MisakaNet/issues/1162)


### PR DESCRIPTION
## Problem

Three documentation files were out of sync with the actual repo state:

| File | Was | Now |
|---|---|---|
| STATUS.md | v2.17.0 (dev), 289 lessons, 4 tools | v2.18.0, 377 lessons, 7+1 tools |
| ROADMAP.md baseline | v2.16.0, 289 lessons, 3 tools | v2.18.0, 377 lessons, 7+1 tools |
| README.md | 290 lessons | 377 lessons |

## Changes

### STATUS.md
- Version: v2.17.0 (dev) → v2.18.0
- Lessons: 289 → 377
- MCP tools: 4 → 7 local + register (remote)
- Added: MCP tool list table (8 tools)
- Added: Evidence levels, Identity Aura, Voice Prompts, Preflight Guard
- Added: v2.17.1 and v2.18.0 to version history
- Added: competitive research summary
- Fixed: Smithery status (was missing, now paused)

### ROADMAP.md baseline
- Version: v2.16.0 → v2.18.0
- Lessons: 289 → 377
- MCP tools: 3 → 7 local + register (remote)

### README.md
- All references: 290 → 377 lessons

## Verification

```bash
# Lesson count
find lessons/ -name "*.md" | grep -v README | grep -v LESSON_QUALITY | wc -l
# → 377

# MCP tools
grep '"name": "misakanet_' scripts/mcp_server.py
# → 7 tools

# Version
gh release view v2.18.0 --json tagName
# → v2.18.0
```