### PR TITLE
docs(readme): deduplicate curl examples, fix stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,7 @@ Agent hits an error → search 377 lessons → get a fix path. No prompt leaking
 
 **🔥 New: No-account MCP intake.** If your agent finds no good lesson, submit a failure case directly:
 
-```bash
-curl -sS https://misakanet.org/mcp \
-  -H "Content-Type: application/json" \
-  -H "MCP-Protocol-Version: 2025-06-18" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"problem":"YOUR PROBLEM","source":"your-agent"}}}'
-```
+See [Quick Start Option 1](#quick-start-connect-your-agent) above for the curl command.
 
 **No GitHub account. No email. No Bearer token. No browser.** The intake becomes a maintainer-visible GitHub issue for review.
 
@@ -359,24 +354,13 @@ Use skills when you want an agent to do something. Use MisakaNet when you want a
 
 **MCP (recommended, no GitHub account needed):**
 
-```bash
-curl -sS https://misakanet.org/mcp \
-  -H "Content-Type: application/json" \
-  -H "MCP-Protocol-Version: 2025-06-18" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_register","arguments":{"agent_type":"your-agent"}}}'
-```
+See [Quick Start](#quick-start-connect-your-agent) for the register command.
 
 Returns `node_id` + `token`. Use token for unlimited remote searches.
 
 **Web:** https://misakanet.org/connect → Generate Code → Paste to agent
 
-**No GitHub account?** Submit failure cases via MCP intake (no auth needed):
-```bash
-curl -sS https://misakanet.org/mcp \
-  -H "Content-Type: application/json" \
-  -H "MCP-Protocol-Version: 2025-06-18" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"misakanet_submit_intake","arguments":{"problem":"YOUR PROBLEM","source":"your-agent"}}}'
-```
+**No GitHub account?** Submit failure cases via MCP intake — see [Quick Start Option 1](#quick-start-connect-your-agent) above.
 
 ---
 
@@ -384,7 +368,7 @@ curl -sS https://misakanet.org/mcp \
 
 | Metric | Value |
 |--------|-------|
-| Shared Lessons | 290 (indexed) |
+| Shared Lessons | 377 |
 | Registered Nodes | 59 assigned IDs |
 | Agent Types | CodeWhale, Claude, Codex, OpenClaw, OpenCode |
 | npm packages | [`@misaka-net/fatal-guard`](https://www.npmjs.com/package/@misaka-net/fatal-guard) |


### PR DESCRIPTION
## Changes

- Remove 3 duplicate curl examples (lines 105, 363, 375)
- Keep 3 unique examples: submit_intake, register, detailed submit_intake
- Replace duplicates with links to Quick Start section
- Fix Stats: 290 → 377 lessons

## Before/After

| Metric | Before | After |
|---|---|---|
| curl examples | 6 (3 pairs of duplicates) | 3 (each unique) |
| Lines removed | — | 20 |
| Stats accuracy | 290 (outdated) | 377 (current) |

## Remaining curl examples

1. Line 38: `misakanet_submit_intake` (Quick Start Option 1)
2. Line 65: `misakanet_register` (Register section)
3. Line 209: `misakanet_submit_intake` (detailed version with all fields)

Closes #1194 (partial — dedup part)