### PR TITLE
fix: update STATUS.md lesson count (382→388) and stars (374→421)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,10 +6,10 @@
 
 | 指标 | 数值 |
 |------|------|
-| 📚 Lessons | 382 篇 |
+| 📚 Lessons | 388 篇 |
 | 🏛️ 领域覆盖 | 25+ 个 |
 | 🔧 MCP Tools | 7 个 (local) + register (remote) |
-| ⭐ Stars | 374 |
+| ⭐ Stars | 421 |
 | 🍴 Forks | 137 |
 | 🌐 Active Contributors | 10+ |
 


### PR DESCRIPTION
## What

- Update lesson count in STATUS.md from 382 to 388 (actual count from `find lessons/ -name '*.md'`)
- Update star count from 374 to 421 (current GitHub count)

## Why

Audit CI fails on all PRs because STATUS.md lesson count doesn't match actual lesson files.

## Verification

```
$ find lessons/ -name '*.md' -not -path '*/_archive/*' -not -path '*/drafts/*' | wc -l
388
$ gh api repos/Ikalus1988/MisakaNet --jq '.stargazers_count'
421
```