### PR TITLE
feat(mcp): add misakanet_register tool to local MCP servers

### DIFF
--- a/scripts/mcp_http_server.py
+++ b/scripts/mcp_http_server.py
@@ -310,6 +310,47 @@ def misakanet_usage_status(user: str = "anon:mcp-default") -> dict:
         return {"error": str(e), "user": "unknown", "free_reads_remaining": -1}
 
 
+@mcp.tool()
+def misakanet_register(agent_type: str = "unknown") -> dict:
+    """Register an agent and receive a node_id and token for unlimited remote MCP access.
+
+    Local stdio MCP is unlimited and does not need registration. For remote HTTP MCP,
+    call this tool first to get a token, then pass it as the user parameter in subsequent
+    calls (e.g. user='token:<your-token>').
+    """
+    import secrets
+    from datetime import datetime, timezone
+
+    # Generate deterministic node_id from agent_type + random suffix
+    suffix = secrets.token_hex(3).upper()
+    node_id = f"Misaka{int(suffix, 16) % 100000:05d}"
+
+    # Generate token
+    token = f"mcp_{secrets.token_urlsafe(24)}"
+
+    registered_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    # Persist registration to usage_meter so token:user can be tracked
+    try:
+        from scripts.usage_meter import _save_record
+        _save_record({
+            "user": f"token:{token}",
+            "action": "register",
+            "node_id": node_id,
+            "agent_type": agent_type,
+            "ts": registered_at,
+        })
+    except Exception:
+        pass  # Non-fatal: registration still returns token
+
+    return {
+        "node_id": node_id,
+        "token": token,
+        "registered_at": registered_at,
+        "agent_type": agent_type,
+    }
+
+
 # ── Resources ──
 @mcp.resource("misaka://lessons/index")
 def lessons_index() -> str:

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -469,6 +469,44 @@ def handle_usage_status(args: dict) -> dict:
         return {"error": str(e), "user": "unknown", "free_reads_remaining": -1}
 
 
+def handle_register(args: dict) -> dict:
+    """Register an agent and return a node_id + token for unlimited access."""
+    import hashlib
+    import secrets
+    from datetime import datetime, timezone
+
+    agent_type = args.get("agent_type", "unknown")
+
+    # Generate deterministic node_id from agent_type + random suffix
+    suffix = secrets.token_hex(3).upper()
+    node_id = f"Misaka{int(suffix, 16) % 100000:05d}"
+
+    # Generate token
+    token = f"mcp_{secrets.token_urlsafe(24)}"
+
+    registered_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    # Persist registration to usage_meter so token:user can be tracked
+    try:
+        from scripts.usage_meter import _save_record
+        _save_record({
+            "user": f"token:{token}",
+            "action": "register",
+            "node_id": node_id,
+            "agent_type": agent_type,
+            "ts": registered_at,
+        })
+    except Exception:
+        pass  # Non-fatal: registration still returns token
+
+    return {
+        "node_id": node_id,
+        "token": token,
+        "registered_at": registered_at,
+        "agent_type": agent_type,
+    }
+
+
 # ── MCP Resources ──
 RESOURCES = [
     {
@@ -916,6 +954,24 @@ TOOLS = [
             },
         },
     },
+    {
+        "name": "misakanet_register",
+        "description": (
+            "Register an agent and receive a node_id and token for unlimited remote MCP access. "
+            "Local stdio MCP is unlimited and does not need registration. For remote HTTP MCP, "
+            "call this tool first to get a token, then pass it as the user parameter in subsequent "
+            "calls (e.g. user='token:<your-token>'). Input semantics: agent_type is optional "
+            "(defaults to 'unknown'). Output schema: JSON with node_id, token, registered_at, "
+            "and agent_type. Error cases: none. Side effects: persists registration record. "
+            "Auth: none. Rate limits: one registration per session."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_type": {"type": "string", "description": "Optional agent type identifier (e.g. 'claude-code', 'cursor', 'aider'). Defaults to 'unknown'."},
+            },
+        },
+    },
 ]
 
 
@@ -962,6 +1018,7 @@ def handle_request(request: dict) -> dict:
             "misakanet_write_lesson": handle_write_lesson,
             "misakanet_preflight": handle_preflight,
             "misakanet_usage_status": handle_usage_status,
+            "misakanet_register": handle_register,
         }
 
         handler = handlers.get(tool_name)


### PR DESCRIPTION
## What
Both `mcp_server.py` (stdio) and `mcp_http_server.py` (HTTP) were missing the `misakanet_register` tool documented in README v2.18.

## Changes
- **mcp_server.py**: add `handle_register()` + tool definition + handler mapping
- **mcp_http_server.py**: add `@mcp.tool()` decorated `misakanet_register()`

Registration generates `node_id` (MisakaNNNNN) and `token` (mcp_...), persists to `usage_meter` for rate-limit tracking.

## Testing
Local stdio: register returns node_id + token. Token user shows `is_registered: true`, `free_reads_limit: 20` (vs 5 anonymous). All 6 tools listed.

## Note
Remote server (`misakanet.org`) token verification is broken — registration succeeds but token cannot be used for subsequent calls. Remote server code is not in this repo; needs separate fix.

Signed-off-by: zsxh1990 <445655361@qq.com>
