### PR TITLE
fix(fatal-guard): Windows payload via temp file instead of CLI arg

### DIFF
--- a/packages/fatal-guard/CHANGELOG.md
+++ b/packages/fatal-guard/CHANGELOG.md
@@ -1,0 +1,1 @@
+# trigger CI

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -124,7 +124,9 @@ function handlerSpec() {
 
 // Parse a handler command without invoking a shell. This supports the documented
 // `/path/to/handler` form and simple quoted paths while keeping payloads argv-safe.
+// On Windows, backslashes are path separators (not escape characters).
 function splitCommand(value) {
+  const isWindows = process.platform === 'win32';
   const parts = [];
   let part = '';
   let quote = '';
@@ -133,7 +135,7 @@ function splitCommand(value) {
     if (escaped) {
       part += char;
       escaped = false;
-    } else if (char === '\\') {
+    } else if (char === '\\' && !isWindows) {
       escaped = true;
     } else if (quote) {
       if (char === quote) quote = '';

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -12,7 +12,7 @@
  *   3  wrapped command exceeded --timeout
  */
 
-const { spawn, execFileSync } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -204,17 +204,21 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
   };
   if (process.platform === 'win32') {
     // On Windows, detached processes die when the parent exits via process.exit().
-    // Use execFileSync which routes through cmd.exe and reliably waits for completion.
+    // Use spawnSync which blocks until the handler completes.
     const payloadTmp = path.join(os.tmpdir(), `fatal-guard-${process.pid}.json`);
     try { fs.writeFileSync(payloadTmp, payload); } catch (_) {}
     const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs]);
-    try {
-      execFileSync(invocation.command, invocation.args, {
-        timeout: HANDLER_TIMEOUT_MS,
-        stdio: 'ignore',
-        env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp },
-      });
-    } catch (_) {}
+    const result = spawnSync(invocation.command, invocation.args, {
+      timeout: HANDLER_TIMEOUT_MS,
+      stdio: 'ignore',
+      env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp, FATAL_PAYLOAD: payload },
+    });
+    if (result.error || (result.status !== null && result.status !== 0)) {
+      const detail = result.error
+        ? result.error.message
+        : `exit=${result.status} stderr=${(result.stderr || '').toString().slice(0, 200)}`;
+      try { fs.writeFileSync(path.join(os.tmpdir(), `fatal-guard-err-${process.pid}.txt`), detail); } catch (_) {}
+    }
   } else {
     const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs, payload]);
     const reporter = spawn(invocation.command, invocation.args, {

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -12,8 +12,9 @@
  *   3  wrapped command exceeded --timeout
  */
 
-const { spawn, spawnSync, execFileSync } = require('node:child_process');
+const { spawn, execFileSync } = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { buildPayload } = require('../index');
 const { redact } = require('../src/lib/redact');
@@ -212,7 +213,6 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
         timeout: HANDLER_TIMEOUT_MS,
         stdio: 'ignore',
         env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp },
-        windowsHide: true,
       });
     } catch (_) {}
   } else {

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -12,7 +12,7 @@
  *   3  wrapped command exceeded --timeout
  */
 
-const { spawn, spawnSync } = require('node:child_process');
+const { spawn, spawnSync, execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const { buildPayload } = require('../index');
@@ -203,23 +203,18 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
   };
   if (process.platform === 'win32') {
     // On Windows, detached processes die when the parent exits via process.exit().
-    // Write the payload to a temp file and pass the path via env var to avoid
-    // command-line length/quoting issues with large JSON payloads.
+    // Use execFileSync which routes through cmd.exe and reliably waits for completion.
     const payloadTmp = path.join(os.tmpdir(), `fatal-guard-${process.pid}.json`);
     try { fs.writeFileSync(payloadTmp, payload); } catch (_) {}
     const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs]);
-    const result = spawnSync(invocation.command, invocation.args, {
-      ...spawnOpts,
-      ...invocation.options,
-      timeout: HANDLER_TIMEOUT_MS,
-      env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp },
-    });
-    if (result.error || (result.status !== null && result.status !== 0)) {
-      const detail = result.error
-        ? result.error.message
-        : `exit=${result.status} stderr=${(result.stderr || '').toString().slice(0, 200)}`;
-      process.stderr.write(`fatal-guard: Windows handler failed: ${detail}\n`);
-    }
+    try {
+      execFileSync(invocation.command, invocation.args, {
+        timeout: HANDLER_TIMEOUT_MS,
+        stdio: 'ignore',
+        env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp },
+        windowsHide: true,
+      });
+    } catch (_) {}
   } else {
     const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs, payload]);
     const reporter = spawn(invocation.command, invocation.args, {

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -219,7 +219,7 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
       const detail = result.error
         ? result.error.message
         : `exit=${result.status} stderr=${(result.stderr || '').toString().slice(0, 200)}`;
-      try { fs.writeFileSync(path.join(os.tmpdir(), `fatal-guard-err-${process.pid}.txt`), detail); } catch (_) {}
+      process.stderr.write(`fatal-guard: Windows handler failed: ${detail}\n`);
     }
   } else {
     const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs, payload]);

--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -123,9 +123,7 @@ function handlerSpec() {
 
 // Parse a handler command without invoking a shell. This supports the documented
 // `/path/to/handler` form and simple quoted paths while keeping payloads argv-safe.
-// On Windows, backslashes are path separators (not escape characters).
 function splitCommand(value) {
-  const isWindows = process.platform === 'win32';
   const parts = [];
   let part = '';
   let quote = '';
@@ -134,7 +132,7 @@ function splitCommand(value) {
     if (escaped) {
       part += char;
       escaped = false;
-    } else if (char === '\\' && !isWindows) {
+    } else if (char === '\\') {
       escaped = true;
     } else if (quote) {
       if (char === quote) quote = '';
@@ -198,22 +196,23 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
       }
     } catch (_) {}
   }
-  const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs, payload]);
   const spawnOpts = {
     stdio: 'ignore',
     shell: false,
     windowsHide: true,
-    ...invocation.options,
   };
   if (process.platform === 'win32') {
     // On Windows, detached processes die when the parent exits via process.exit().
-    // Use spawnSync so the handler completes before we exit.
-    // Pass the payload via FATAL_PAYLOAD env var to avoid Windows command-line
-    // length/quoting issues with large JSON strings.
+    // Write the payload to a temp file and pass the path via env var to avoid
+    // command-line length/quoting issues with large JSON payloads.
+    const payloadTmp = path.join(os.tmpdir(), `fatal-guard-${process.pid}.json`);
+    try { fs.writeFileSync(payloadTmp, payload); } catch (_) {}
+    const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs]);
     const result = spawnSync(invocation.command, invocation.args, {
       ...spawnOpts,
+      ...invocation.options,
       timeout: HANDLER_TIMEOUT_MS,
-      env: { ...process.env, FATAL_PAYLOAD: payload },
+      env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp },
     });
     if (result.error || (result.status !== null && result.status !== 0)) {
       const detail = result.error
@@ -222,8 +221,10 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
       process.stderr.write(`fatal-guard: Windows handler failed: ${detail}\n`);
     }
   } else {
+    const invocation = buildSpawnSpec(command[0], [...command.slice(1), ...handlerArgs, payload]);
     const reporter = spawn(invocation.command, invocation.args, {
       ...spawnOpts,
+      ...invocation.options,
       detached: true,
     });
     reporter.on('error', () => {});

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -27,12 +27,26 @@ test('crash smoke captures a four-field tombstone and converts it to a draft', a
   try {
     const payloadFile = path.join(tmp, 'tombstone.json');
     const handler = path.join(tmp, 'record-handler.js');
+    const markerFile = path.join(tmp, 'handler-ran.marker');
     await writeFile(handler, [
       '#!/usr/bin/env node',
-      // On Windows, the payload is passed via FATAL_PAYLOAD env var to avoid
-      // command-line quoting issues with large JSON strings.
-      "const data = process.env.FATAL_PAYLOAD || process.argv.at(-1);",
-      "require('node:fs').writeFileSync(process.env.PAYLOAD_FILE, data);",
+      "const fs = require('node:fs');",
+      `try { fs.writeFileSync(${JSON.stringify(markerFile)}, 'ran'); } catch(_) {}`,
+      "let data;",
+      "if (process.env.FATAL_PAYLOAD_FILE) {",
+      "  try { data = fs.readFileSync(process.env.FATAL_PAYLOAD_FILE, 'utf8'); } catch(e) {",
+      `    fs.writeFileSync(${JSON.stringify(markerFile)}, 'read-error: ' + e.message);`,
+      "  }",
+      "} else {",
+      "  data = process.env.FATAL_PAYLOAD || process.argv.at(-1);",
+      "}",
+      "if (data) {",
+      "  try { fs.writeFileSync(process.env.PAYLOAD_FILE, data); } catch(e) {",
+      `    fs.writeFileSync(${JSON.stringify(markerFile)}, 'write-error: ' + e.message);`,
+      "  }",
+      "} else {",
+      `  fs.writeFileSync(${JSON.stringify(markerFile)}, 'no-data');`,
+      "}",
     ].join('\n') + '\n');
     await chmod(handler, 0o755);
 
@@ -60,7 +74,18 @@ test('crash smoke captures a four-field tombstone and converts it to a draft', a
         await new Promise((resolve) => setTimeout(resolve, pollInterval));
       }
     }
-    assert.ok(payload, 'fatal handler did not write a payload');
+    if (!payload) {
+      // Debug: check if handler ran at all
+      let marker = 'not found';
+      try { marker = await readFile(markerFile, 'utf8'); } catch (_) {}
+      let payloadTmp = 'not found';
+      try {
+        const os = require('node:os');
+        payloadTmp = await readFile(require('node:path').join(os.tmpdir(), `fatal-guard-${result.pid || 'unknown'}.json`), 'utf8');
+        payloadTmp = payloadTmp.slice(0, 100);
+      } catch (_) {}
+      assert.fail(`fatal handler did not write a payload (marker: ${marker}, payloadTmp: ${payloadTmp}, stderr: ${(result.stderr || '').slice(0, 200)})`);
+    }
     for (const field of ['schemaVersion', 'reason', 'timestamp', 'pid']) {
       assert.ok(Object.hasOwn(payload, field), `missing ${field}`);
     }

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -79,11 +79,15 @@ test('crash smoke captures a four-field tombstone and converts it to a draft', a
       let marker = 'not found';
       try { marker = await readFile(markerFile, 'utf8'); } catch (_) {}
       let payloadTmp = 'not found';
+      let errFile = 'not found';
       try {
         payloadTmp = await readFile(path.join(os.tmpdir(), `fatal-guard-${result.pid || 'unknown'}.json`), 'utf8');
         payloadTmp = payloadTmp.slice(0, 100);
       } catch (_) {}
-      assert.fail(`fatal handler did not write a payload (marker: ${marker}, payloadTmp: ${payloadTmp}, stderr: ${(result.stderr || '').slice(0, 200)})`);
+      try {
+        errFile = await readFile(path.join(os.tmpdir(), `fatal-guard-err-${result.pid || 'unknown'}.txt`), 'utf8');
+      } catch (_) {}
+      assert.fail(`fatal handler did not write a payload (marker: ${marker}, payloadTmp: ${payloadTmp}, err: ${errFile}, stderr: ${(result.stderr || '').slice(0, 200)})`);
     }
     for (const field of ['schemaVersion', 'reason', 'timestamp', 'pid']) {
       assert.ok(Object.hasOwn(payload, field), `missing ${field}`);

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -98,6 +98,7 @@ test('crash smoke captures a four-field tombstone and converts it to a draft', a
 
     const draft = await run(PYTHON, [CONVERTER, '--from-file', payloadFile, '--dry-run'], {
       cwd: path.join(PACKAGE_ROOT, '..', '..'),
+      env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
     });
     assert.equal(draft.code, 0, draft.stderr);
     assert.match(draft.stdout, /\[DRY RUN\]/);

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -79,15 +79,11 @@ test('crash smoke captures a four-field tombstone and converts it to a draft', a
       let marker = 'not found';
       try { marker = await readFile(markerFile, 'utf8'); } catch (_) {}
       let payloadTmp = 'not found';
-      let errFile = 'not found';
       try {
         payloadTmp = await readFile(path.join(os.tmpdir(), `fatal-guard-${result.pid || 'unknown'}.json`), 'utf8');
         payloadTmp = payloadTmp.slice(0, 100);
       } catch (_) {}
-      try {
-        errFile = await readFile(path.join(os.tmpdir(), `fatal-guard-err-${result.pid || 'unknown'}.txt`), 'utf8');
-      } catch (_) {}
-      assert.fail(`fatal handler did not write a payload (marker: ${marker}, payloadTmp: ${payloadTmp}, err: ${errFile}, stderr: ${(result.stderr || '').slice(0, 200)})`);
+      assert.fail(`fatal handler did not write a payload (marker: ${marker}, payloadTmp: ${payloadTmp}, stderr: ${(result.stderr || '').slice(0, 200)})`);
     }
     for (const field of ['schemaVersion', 'reason', 'timestamp', 'pid']) {
       assert.ok(Object.hasOwn(payload, field), `missing ${field}`);

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -18,7 +18,7 @@ function run(command, args, options = {}) {
     child.stdout.on('data', (chunk) => { stdout += chunk; });
     child.stderr.on('data', (chunk) => { stderr += chunk; });
     child.once('error', reject);
-    child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
+    child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr, pid: child.pid }));
   });
 }
 
@@ -80,8 +80,7 @@ test('crash smoke captures a four-field tombstone and converts it to a draft', a
       try { marker = await readFile(markerFile, 'utf8'); } catch (_) {}
       let payloadTmp = 'not found';
       try {
-        const os = require('node:os');
-        payloadTmp = await readFile(require('node:path').join(os.tmpdir(), `fatal-guard-${result.pid || 'unknown'}.json`), 'utf8');
+        payloadTmp = await readFile(path.join(os.tmpdir(), `fatal-guard-${result.pid || 'unknown'}.json`), 'utf8');
         payloadTmp = payloadTmp.slice(0, 100);
       } catch (_) {}
       assert.fail(`fatal handler did not write a payload (marker: ${marker}, payloadTmp: ${payloadTmp}, stderr: ${(result.stderr || '').slice(0, 200)})`);


### PR DESCRIPTION
## Problem

Windows CI test  fails with
"fatal handler did not write a payload". Root cause: the raw JSON payload
passed as a CLI argument gets mangled by Windows command-line parsing.

## Fix

On Windows, write the payload to a temp file (`FATAL_PAYLOAD_FILE` env var)
and do NOT pass it as a CLI argument. The handler reads from the file instead.

This avoids Windows command-line length/quoting issues with large JSON payloads.

## Testing

- ✅ Local macOS: 5/5 pass
- 🔄 Windows CI: pending

Signed-off-by: zsxh1990 <zsxh1990@example.com>