### PR TITLE
docs: add pip install example + Try it now table (#1194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,30 @@ misakanet "database is locked"
 # Or: python3 -m search_knowledge "your error here"
 ```
 
-**Option 4 — DeepSeek Harness:**
+**Option 4 — Python library (for scripts/notebooks):**
+```bash
+pip install misakanet-core
+```
+```python
+from misakanet.search import search_lessons
+results = search_lessons("pip install timeout")
+for r in results:
+    print(r["title"], r["score"])
+```
+
+**Option 5 — DeepSeek Harness:**
 ```bash
 python3 scripts/mcp_deepseek_adapter.py
 ```
+
+### Try it now
+
+| Method | Command | Time |
+|---|---|---|
+| Remote MCP | `curl -sS https://misakanet.org/mcp ...` | 10s |
+| Local MCP | `git clone ... && python3 scripts/mcp_server.py` | 30s |
+| Python lib | `pip install misakanet-core` | 15s |
+| CLI smoke | `python3 scripts/misakanet_cli.py smoke` | 5s |
 
 → [Full quickstart (Remote MCP, CLI, Docker)](docs/quickstart.md) · [Troubleshooting](docs/troubleshooting.md)
 


### PR DESCRIPTION
## Summary

Closes #1194

- Add **Option 4 — Python library** with `pip install misakanet-core`
- Add 3-line Python usage example (`search_lessons()`)
- Add **"Try it now"** summary table (Remote MCP / Local MCP / Python lib / CLI)
- Renumber DeepSeek Harness to Option 5

## Changes

```markdown
**Option 4 — Python library (for scripts/notebooks):**
pip install misakanet-core

from misakanet.search import search_lessons
results = search_lessons("pip install timeout")

### Try it now
| Method | Command | Time |
|---|---|---|
| Remote MCP | curl ... | 10s |
| Local MCP | git clone ... | 30s |
| Python lib | pip install misakanet-core | 15s |
| CLI smoke | python3 scripts/misakanet_cli.py smoke | 5s |
```

## Acceptance Criteria

- [x] `pip install misakanet-core` example in Quick Start
- [x] 3-line Python usage example
- [x] "Try it now" summary table
- [x] No duplicate curl examples

🤖 Generated with [Claude Code](https://claude.ai/code)