### PR TITLE
docs: correct GoodMemory runtime and install

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -213,7 +213,7 @@ MisakaNet レッスン     →  既知の障害を回避
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | ![stars](https://img.shields.io/github/stars/swarmclawai/swarmclaw?style=social) | 🟡 温かい | ランタイムフェデレーション | Python | `pip install` |
 | [Agent-KB](https://github.com/OPPO-PersonalAI/Agent-KB) | ![stars](https://img.shields.io/github/stars/OPPO-PersonalAI/Agent-KB?style=social) | 🔬 研究 | 共有経験プール/研究プロトタイプ | Docker + PostgreSQL | Docker（約15分） |
 | [MemoryCustodian](https://github.com/waittim/MemoryCustodian) | ![stars](https://img.shields.io/github/stars/waittim/MemoryCustodian?style=social) | 🟡 温かい | 個人メモリ | Python | `pip install` |
-| [GoodMemory](https://github.com/hjqcan/GoodMemory) | ![stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=social) | ✅ アクティブ | 個人メモリ | Python | `pip install` |
+| [GoodMemory](https://github.com/hjqcan/GoodMemory) | ![stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=social) | ✅ アクティブ | ローカル / アプリレベルのメモリ | TypeScript + Bun/SQLite | `npm install` |
 
 > **MisakaNetは唯一の共有メモリシステムではありません。** 強みは：
 > - **Gitバックアップ** — すべてのレッスンはMarkdownファイルで、完全に監査可能、バージョン管理対象

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Use skills when you want an agent to do something. Use MisakaNet when you want a
 | [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | ![stars](https://img.shields.io/github/stars/swarmclawai/swarmclaw?style=social) | 🟡 Warm | Runtime federation | Python | `pip install` |
 | [Agent-KB](https://github.com/OPPO-PersonalAI/Agent-KB) | ![stars](https://img.shields.io/github/stars/OPPO-PersonalAI/Agent-KB?style=social) | 🔬 Research | Shared experience pool / research prototype | Docker + PostgreSQL | Docker (~15min) |
 | [MemoryCustodian](https://github.com/waittim/MemoryCustodian) | ![stars](https://img.shields.io/github/stars/waittim/MemoryCustodian?style=social) | 🟡 Warm | Personal memory | Python | `pip install` |
-| [GoodMemory](https://github.com/hjqcan/GoodMemory) | ![stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=social) | ✅ Active | Personal memory | Python | `pip install` |
+| [GoodMemory](https://github.com/hjqcan/GoodMemory) | ![stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=social) | ✅ Active | Local / app-level memory | TypeScript + Bun/SQLite | `npm install` |
 
 > **MisakaNet is not the only shared memory system.** Its edge is:
 > - **Git-backed** — every lesson is a Markdown file, fully auditable, version-controlled


### PR DESCRIPTION
## Summary

- correct the GoodMemory infrastructure from Python to TypeScript + Bun/SQLite
- replace the pip entry path with the npm package install path
- keep the English and Japanese comparison tables aligned

Node ID: hjqcan/goodmemory-maintainer

## Validation

- git diff --check: passed
- full pytest command used by pr-checks: 626 passed, 2 skipped, 1 pre-existing failure in tests/test_reputation_leaderboard.py against an unchanged Worker file
- ruff check .: blocked by existing repository-wide lint findings outside the two changed Markdown files

This PR only changes the two existing GoodMemory table rows.