### PR TITLE
fix: verify agent token against federation secrets (#1240)

### DIFF
--- a/hub/federation/secrets.py
+++ b/hub/federation/secrets.py
@@ -111,6 +111,40 @@ def revoke_secret(node_id: str) -> bool:
     return False
 
 
+def verify_token(token: str) -> Optional[str]:
+    """Verify a token against all registered nodes.
+
+    Accepts raw hex tokens or 'token:<hex>' prefixed format.
+    Returns the node_id if valid, None otherwise.
+    """
+    if not token:
+        return None
+
+    # Strip 'token:' prefix if present
+    raw = token
+    if raw.startswith("token:"):
+        raw = raw[6:]
+
+    secrets_dir = _secrets_dir()
+    if not secrets_dir.exists():
+        return None
+
+    for node_dir in secrets_dir.iterdir():
+        if not node_dir.is_dir():
+            continue
+        key_path = node_dir / _KEY_FILE
+        if not key_path.exists():
+            continue
+        try:
+            data = json.loads(key_path.read_text())
+            if data.get("secret") == raw:
+                return data.get("node_id", node_dir.name)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    return None
+
+
 def _safe_filename(node_id: str) -> str:
     """Sanitize node_id for use as a directory name."""
     # Allow alphanumeric, hyphens, underscores, dots

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -373,8 +373,10 @@ def handle_write_lesson(args: dict) -> dict:
             "hint": "write_lesson requires title, domain, problem, root_cause, and fix.",
         }
 
-    # Require registered agent token
-    if not token or token.startswith("anon:"):
+    # Require registered agent token — verify against federation secrets
+    from hub.federation.secrets import verify_token
+    node_id = verify_token(token)
+    if not node_id:
         return {
             "submitted": False,
             "error": "Registered agent token required",
@@ -402,7 +404,7 @@ def handle_write_lesson(args: dict) -> dict:
 
     result = submit_contribution(
         contrib_type="lesson",
-        user=token,
+        user=node_id,
         title=title,
         message=message,
         problem=problem,
@@ -450,6 +452,73 @@ def handle_preflight(args: dict) -> dict:
         return {"error": "intent is required", "voice": "failure-warning"}
     result = preflight_check(intent, context)
     return result
+
+
+def handle_memory_context(args: dict) -> dict:
+    """Pull relevant lessons as context for a task description.
+
+    Intended to be called at the start of a task, so the agent has
+    failure-memory injected into its context before it begins work.
+    """
+    task = args.get("task", "")
+    domain = args.get("domain")
+    top_n = min(args.get("top_n", 5), 10)
+
+    if not task:
+        return {
+            "error": "task is required",
+            "hint": "Describe the task you are about to perform (e.g. 'set up ChromaDB RAG pipeline').",
+            "voice": "failure-warning",
+        }
+
+    # Reuse the existing search infrastructure
+    if HAS_SAG:
+        results = sag_search(SAG_DB, task, domain=domain, top=top_n)
+    elif HAS_BM25:
+        docs = _load_docs_cached(LESSONS, is_lesson=True)
+        scored = _search_cached(task, docs)
+        results = []
+        for score, doc in scored[:top_n]:
+            results.append({
+                "title": doc.title,
+                "path": str(doc.filepath),
+                "score": round(score, 3),
+                "domain": doc.domain,
+                "status": doc.status,
+            })
+    else:
+        results = _fallback_search(task, domain=domain, top=top_n)
+        if results is None:
+            results = []
+
+    # Build condensed context block for agent injection
+    context_lines = []
+    for i, r in enumerate(results, 1):
+        title = r.get("title", "Untitled")
+        lesson_id = r.get("id") or r.get("path", "")
+        problem = r.get("problem", "")
+        fix = r.get("fix", "")
+        entry = f"{i}. [{title}] ({lesson_id})"
+        if problem:
+            entry += f"\n   Problem: {problem[:200]}"
+        if fix:
+            entry += f"\n   Fix: {fix[:200]}"
+        context_lines.append(entry)
+
+    context_block = "\n".join(context_lines) if context_lines else "(No matching lessons found)"
+
+    return {
+        "task": task,
+        "lesson_count": len(results),
+        "lessons": results,
+        "context_block": (
+            f"## Relevant MisakaNet Lessons ({len(results)} found)\n"
+            f"Task: {task}\n\n{context_block}\n\n"
+            "Use these lessons to avoid known pitfalls. "
+            "Search MisakaNet for more details if needed."
+        ),
+        "voice": "lesson-found" if results else "failure-warning",
+    }
 
 
 def handle_usage_status(args: dict) -> dict:
@@ -941,6 +1010,37 @@ TOOLS = [
         },
     },
     {
+        "name": "misakanet_memory_context",
+        "description": (
+            "Pull relevant failure-memory lessons as context before starting a task. "
+            "Call this at the beginning of a coding session or before attempting a "
+            "non-trivial operation. Returns a condensed context block with matching "
+            "lessons (problem + fix summaries) that can be injected into the agent's "
+            "system prompt. Input semantics: task (required), domain (optional filter), "
+            "top_n (optional, default 5, max 10). Output schema: JSON with task, "
+            "lesson_count, lessons array, and context_block (ready-to-inject markdown). "
+            "Error cases: missing task. Side effects: none. Auth: none. Rate limits: none."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Task description (e.g. 'set up ChromaDB RAG pipeline', 'deploy FastAPI to production').",
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Optional domain filter (e.g. 'rag', 'docker', 'python').",
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "Number of lessons to return (default 5, max 10).",
+                },
+            },
+            "required": ["task"],
+        },
+    },
+    {
         "name": "misakanet_usage_status",
         "description": (
             "Check current usage status and remaining quota. Use to see how many free lesson reads "
@@ -1056,6 +1156,7 @@ def handle_request(request: dict) -> dict:
             "misakanet_submit_intake": handle_submit_intake,
             "misakanet_write_lesson": handle_write_lesson,
             "misakanet_preflight": handle_preflight,
+            "misakanet_memory_context": handle_memory_context,
             "misakanet_usage_status": handle_usage_status,
             "misakanet_register": handle_register,
         }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,12 +7,23 @@ Usage:
     python3 tests/test_mcp_server.py
 """
 import json
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
+
+# ── Test token setup ──
+# Create a temporary secrets directory with a test token so verify_token works
+_TEST_SECRETS_DIR = tempfile.mkdtemp(prefix="misaka_test_secrets_")
+os.environ["MISAKA_SECRETS_DIR"] = _TEST_SECRETS_DIR
+
+from hub.federation.secrets import generate_shared_secret
+_TEST_NODE_ID = "test-agent"
+_TEST_TOKEN = generate_shared_secret(_TEST_NODE_ID)
 
 from scripts.mcp_server import TOOLS, handle_request
 
@@ -320,7 +331,7 @@ def test_write_lesson_low_quality():
             "problem": "nope",
             "root_cause": "nope",
             "fix": "nope",
-            "token": "token:test-agent",
+            "token": _TEST_TOKEN,
         },
     })
     result_text = resp.get("result", {}).get("content", [{}])[0].get("text", "{}")
@@ -344,7 +355,7 @@ def test_write_lesson_success():
             "root_cause": "pip does not automatically use HTTP_PROXY_AUTH environment variables. The proxy returns 407 Proxy Authentication Required but pip treats this as a timeout.",
             "fix": "Set HTTP_PROXY and HTTPS_PROXY with embedded credentials: export HTTP_PROXY=http://user:pass@proxy:8080. Or use pip --proxy flag.",
             "verification": "Run pip install requests behind proxy and verify it completes within 30 seconds.",
-            "token": "token:test-agent",
+            "token": _TEST_TOKEN,
             "source": "smoke-test",
         },
     })
@@ -375,6 +386,41 @@ def test_preflight_missing_intent():
     check("returns error for missing intent", "error" in result)
 
 
+def test_memory_context_no_task():
+    print("\n-- tools/call: misakanet_memory_context no task --")
+    resp = rpc("tools/call", {
+        "name": "misakanet_memory_context",
+        "arguments": {},
+    })
+    result_text = resp.get("result", {}).get("content", [{}])[0].get("text", "{}")
+    result = json.loads(result_text)
+    check("returns error for missing task", "error" in result)
+    check("error mentions task required", "task" in result.get("error", "").lower())
+
+
+def test_memory_context_basic():
+    print("\n-- tools/call: misakanet_memory_context basic --")
+    resp = rpc("tools/call", {
+        "name": "misakanet_memory_context",
+        "arguments": {"task": "set up pip install behind corporate proxy"},
+    })
+    result_text = resp.get("result", {}).get("content", [{}])[0].get("text", "{}")
+    result = json.loads(result_text)
+    check("has task field", result.get("task") == "set up pip install behind corporate proxy")
+    check("has lesson_count", "lesson_count" in result)
+    check("has context_block", "context_block" in result)
+    check("context_block contains MisakaNet", "MisakaNet" in result.get("context_block", ""))
+
+
+def _cleanup_test_secrets():
+    """Remove temporary test secrets directory."""
+    import shutil
+    try:
+        shutil.rmtree(_TEST_SECRETS_DIR, ignore_errors=True)
+    except Exception:
+        pass
+
+
 if __name__ == "__main__":
     print("MisakaNet MCP Server smoke test")
     test_initialize()
@@ -392,7 +438,10 @@ if __name__ == "__main__":
     test_write_lesson_low_quality()
     test_write_lesson_success()
     test_preflight_missing_intent()
+    test_memory_context_no_task()
+    test_memory_context_basic()
 
     print(f"\n{'=' * 40}")
     print(f"Results: {PASS} passed, {FAIL} failed")
+    _cleanup_test_secrets()
     sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## Fix KV token verification for write_lesson

**Problem:** `handle_write_lesson` only checked `token.startswith("anon:")` — any non-anon string passed without actual verification against the registered agents store.

**Changes:**
- `hub/federation/secrets.py`: Add `verify_token(token)` — iterates registered node secrets to validate tokens
- `scripts/mcp_server.py`: Replace prefix check with `verify_token()` call
- Pass `node_id` (not raw token) as `user` to `submit_contribution`
- Tests: Use real token fixtures from temp secrets directory

**Also includes:** `misakanet_memory_context` tool for proactive lesson injection (#1165)

Closes #1240