### PR TITLE
feat: add misakanet_memory_context tool (#1165)

### DIFF
--- a/misakanet/server/handlers/__init__.py
+++ b/misakanet/server/handlers/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from .get_lesson import handle_get_lesson
+from .memory_context import handle_memory_context
 from .preflight import handle_preflight
 from .search import handle_search
 from .status import handle_register, handle_usage_status
@@ -17,4 +18,5 @@ __all__ = [
     "handle_preflight",
     "handle_usage_status",
     "handle_register",
+    "handle_memory_context",
 ]

--- a/misakanet/server/handlers/memory_context.py
+++ b/misakanet/server/handlers/memory_context.py
@@ -1,0 +1,83 @@
+"""Memory context handler — proactive lesson injection at task start."""
+from __future__ import annotations
+
+from .search import _fallback_search, _get_search_state
+
+
+def handle_memory_context(args: dict) -> dict:
+    """Pull relevant lessons as context for a task description.
+
+    Intended to be called at the start of a task, so the agent has
+    failure-memory injected into its context before it begins work.
+    """
+    task = args.get("task", "")
+    domain = args.get("domain")
+    top_n = min(args.get("top_n", 5), 10)
+
+    if not task:
+        return {
+            "error": "task is required",
+            "hint": (
+                "Describe the task you are about to perform"
+                " (e.g. 'set up ChromaDB RAG pipeline')."
+            ),
+            "voice": "failure-warning",
+        }
+
+    HAS_SAG, SAG_DB, HAS_BM25, sag_search = _get_search_state()
+
+    # Reuse the existing search infrastructure
+    if HAS_SAG:
+        results = sag_search(SAG_DB, task, domain=domain, top=top_n)
+    elif HAS_BM25:
+        from .._config import _load_docs_cached, _search_cached, LESSONS
+        from misakanet.search.engine import _score_breakdown
+
+        docs = _load_docs_cached(LESSONS, is_lesson=True)
+        scored = _search_cached(task, docs)
+        results = []
+        for score, doc in scored[:top_n]:
+            results.append({
+                "title": doc.title,
+                "path": str(doc.filepath),
+                "score": round(score, 3),
+                "domain": doc.domain,
+                "status": doc.status,
+            })
+    else:
+        results = _fallback_search(task, domain=domain, top=top_n)
+        if results is None:
+            results = []
+
+    # Build condensed context block for agent injection
+    context_lines = []
+    for i, r in enumerate(results, 1):
+        title = r.get("title", "Untitled")
+        lesson_id = r.get("id") or r.get("path", "")
+        problem = r.get("problem", "")
+        fix = r.get("fix", "")
+        entry = f"{i}. [{title}] ({lesson_id})"
+        if problem:
+            entry += f"\n   Problem: {problem[:200]}"
+        if fix:
+            entry += f"\n   Fix: {fix[:200]}"
+        context_lines.append(entry)
+
+    context_block = (
+        "\n".join(context_lines)
+        if context_lines
+        else "(No matching lessons found)"
+    )
+
+    return {
+        "task": task,
+        "lesson_count": len(results),
+        "lessons": results,
+        "context_block": (
+            f"## Relevant MisakaNet Lessons ({len(results)} found)\n"
+            f"Task: {task}\n\n{context_block}\n\n"
+            "Use these lessons to avoid known pitfalls. "
+            "Search MisakaNet for more details if needed."
+        ),
+        "voice": "lesson-found" if results else "failure-warning",
+    }

--- a/misakanet/server/protocol.py
+++ b/misakanet/server/protocol.py
@@ -7,6 +7,7 @@ import sys
 from ._config import get_server_version
 from .handlers import (
     handle_get_lesson,
+    handle_memory_context,
     handle_preflight,
     handle_register,
     handle_search,
@@ -29,6 +30,7 @@ _HANDLERS = {
     "misakanet_preflight": handle_preflight,
     "misakanet_usage_status": handle_usage_status,
     "misakanet_register": handle_register,
+    "misakanet_memory_context": handle_memory_context,
 }
 
 

--- a/misakanet/server/tools.py
+++ b/misakanet/server/tools.py
@@ -420,6 +420,52 @@ TOOLS = [
             },
         },
     },
+    {
+        "name": "misakanet_memory_context",
+        "description": (
+            "Pull relevant failure-memory lessons as context"
+            " before starting a task. Call this at the beginning"
+            " of a coding session or before attempting a"
+            " non-trivial operation. Returns a condensed context"
+            " block with matching lessons (problem + fix"
+            " summaries) that can be injected into the agent's"
+            " system prompt. Input semantics: task (required),"
+            " domain (optional filter), top_n (optional,"
+            " default 5, max 10). Output schema: JSON with task,"
+            " lesson_count, lessons array, and context_block"
+            " (ready-to-inject markdown). Error cases: missing"
+            " task. Side effects: none. Auth: none."
+            " Rate limits: none."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": (
+                        "Task description (e.g. 'set up ChromaDB"
+                        " RAG pipeline', 'deploy FastAPI to"
+                        " production')."
+                    ),
+                },
+                "domain": {
+                    "type": "string",
+                    "description": (
+                        "Optional domain filter (e.g."
+                        " 'search-and-retrieval', 'ci-cd')."
+                    ),
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": (
+                        "Number of lessons to retrieve"
+                        " (default 5, max 10)."
+                    ),
+                },
+            },
+            "required": ["task"],
+        },
+    },
 ]
 
 

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -36,6 +36,7 @@ from misakanet.server._config import (  # noqa: E402
 )
 from misakanet.server.handlers import (  # noqa: E402
     handle_get_lesson,
+    handle_memory_context,
     handle_preflight,
     handle_register,
     handle_search,
@@ -81,6 +82,7 @@ __all__ = [
     "handle_preflight",
     "handle_usage_status",
     "handle_register",
+    "handle_memory_context",
     "handle_resources_list",
     "handle_resources_read",
     "handle_prompts_get",


### PR DESCRIPTION
## Add memory_context tool for proactive lesson injection

**Use case:** At the start of a coding task, call `misakanet_memory_context` with a task description to get relevant failure-memory injected as context — before you start working and potentially hitting known pitfalls.

**Tool signature:**
```
misakanet_memory_context(task: str, domain?: str, top_n?: int) → {
  task, lesson_count, lessons[], context_block
}
```

**Implementation:**
- Reuses existing SAG/BM25/fallback search infrastructure
- Supports optional `domain` filter (e.g. "rag", "docker", "python")
- `top_n` defaults to 5, max 10
- Returns ready-to-inject markdown `context_block` with problem+fix summaries

**Example:**
```json
{"task": "set up ChromaDB RAG pipeline", "domain": "rag", "top_n": 3}
```

Closes #1165