### PR TITLE
feat: configurable BM25/vector hybrid search weights (#1220)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ data/contribution_queue.jsonl
 
 # local search quality feedback (issue #604)
 data/search-feedback.jsonl
+
+# Zero-result search gap logging (issue #1175)
+data/search_gaps.jsonl
 .private/
 
 # Benchmark results (local only)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,10 @@
+# MisakaNet Configuration Example
+# Copy to config.yaml and customize as needed.
+
+# Search scoring weights (Issue #1220)
+# Weights must sum to 1.0
+search:
+  bm25_weight: 0.65      # BM25 keyword relevance
+  metadata_weight: 0.20  # Domain/tag/title match
+  baseline_weight: 0.15  # Document baseline score
+  rrf_k: 60              # Reciprocal Rank Fusion constant (future vector hybrid)

--- a/misakanet/search/engine.py
+++ b/misakanet/search/engine.py
@@ -438,11 +438,14 @@ def _rank_docs_impl(
     expanded_query = _expand_query(query)
     bm25_raw = _compute_bm25_scores(expanded_query, docs)
     bm25_norm = _normalize(bm25_raw)
+    # Load configurable weights (Issue #1220)
+    from scripts.search_config import get_cached_config
+    cfg = get_cached_config()
     scored = [
         (
-            0.65 * bm25_norm[i]
-            + 0.20 * _metadata_bonus(query, d)
-            + 0.15 * d.score_baseline
+            cfg.bm25_weight * bm25_norm[i]
+            + cfg.metadata_weight * _metadata_bonus(query, d)
+            + cfg.baseline_weight * d.score_baseline
             + _compute_boost(d),
             d,
         )
@@ -809,6 +812,8 @@ def _vector_similarity(query: str, doc: CachedDoc) -> float | None:
 
 def _score_breakdown(query: str, doc: CachedDoc, docs: list[CachedDoc] | None = None) -> dict:
     """Return field-level ranking evidence for CLI/API explain modes."""
+    from scripts.search_config import get_cached_config
+    cfg = get_cached_config()
     bm25 = _compute_bm25_scores(query, [doc])[0]
     meta_parts = _metadata_bonus_breakdown(query, doc)
     boost_parts = _compute_boost_breakdown(doc)
@@ -821,9 +826,9 @@ def _score_breakdown(query: str, doc: CachedDoc, docs: list[CachedDoc] | None = 
         "vector_similarity": vector,
         "entity_matches": _entity_matches(query, doc),
         "hybrid": {
-            "bm25_component": round(0.65 * float(bm25), 6),
-            "metadata_component": round(0.20 * metadata_total, 6),
-            "baseline_component": round(0.15 * float(doc.score_baseline), 6),
+            "bm25_component": round(cfg.bm25_weight * float(bm25), 6),
+            "metadata_component": round(cfg.metadata_weight * metadata_total, 6),
+            "baseline_component": round(cfg.baseline_weight * float(doc.score_baseline), 6),
             "boost_component": round(boost_total, 6),
             "vector_component": vector,
         },

--- a/scripts/search_config.py
+++ b/scripts/search_config.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Search configuration — configurable weights for BM25/vector hybrid scoring.
+
+Reads from config.yaml (if present) or uses defaults.
+
+Usage:
+    from scripts.search_config import get_search_config
+    config = get_search_config()
+    print(config.bm25_weight)  # 0.65
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_FILE = REPO_ROOT / "config.yaml"
+
+
+@dataclass
+class SearchConfig:
+    """Search scoring weights and parameters."""
+    bm25_weight: float = 0.65
+    metadata_weight: float = 0.20
+    baseline_weight: float = 0.15
+    rrf_k: int = 60  # Reciprocal Rank Fusion constant (for future vector hybrid)
+
+    def validate(self) -> list[str]:
+        """Validate weights. Returns list of errors (empty = valid)."""
+        errors = []
+        total = self.bm25_weight + self.metadata_weight + self.baseline_weight
+        if abs(total - 1.0) > 0.01:
+            errors.append(f"Weights must sum to 1.0, got {total:.3f}")
+        for name, val in [
+            ("bm25_weight", self.bm25_weight),
+            ("metadata_weight", self.metadata_weight),
+            ("baseline_weight", self.baseline_weight),
+        ]:
+            if val < 0 or val > 1:
+                errors.append(f"{name} must be 0-1, got {val}")
+        if self.rrf_k < 1:
+            errors.append(f"rrf_k must be >= 1, got {self.rrf_k}")
+        return errors
+
+
+def _load_config_from_yaml() -> Optional[dict]:
+    """Try to load search config from config.yaml."""
+    if not CONFIG_FILE.exists():
+        return None
+    try:
+        # Simple YAML-like parser for search section (avoid pyyaml dependency)
+        text = CONFIG_FILE.read_text(encoding="utf-8")
+        in_search = False
+        config = {}
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped == "search:":
+                in_search = True
+                continue
+            if in_search:
+                if stripped and not stripped.startswith("#") and ":" in stripped:
+                    key, val = stripped.split(":", 1)
+                    key = key.strip()
+                    val = val.strip().split("#")[0].strip()  # strip inline comments
+                    config[key] = val
+                elif stripped and not stripped.startswith(" ") and not stripped.startswith("\t"):
+                    break  # exited search section
+        return config if config else None
+    except Exception:
+        return None
+
+
+def _load_config_from_env() -> dict:
+    """Load search config from environment variables."""
+    config = {}
+    for key, env_key in [
+        ("bm25_weight", "MISAKA_SEARCH_BM25_WEIGHT"),
+        ("metadata_weight", "MISAKA_SEARCH_METADATA_WEIGHT"),
+        ("baseline_weight", "MISAKA_SEARCH_BASELINE_WEIGHT"),
+        ("rrf_k", "MISAKA_SEARCH_RRF_K"),
+    ]:
+        val = os.environ.get(env_key)
+        if val is not None:
+            config[key] = val
+    return config
+
+
+def get_search_config() -> SearchConfig:
+    """Load and return search configuration.
+
+    Priority: env vars > config.yaml > defaults.
+    """
+    config = SearchConfig()
+
+    # Layer 1: config.yaml
+    yaml_config = _load_config_from_yaml()
+    if yaml_config:
+        for key in ("bm25_weight", "metadata_weight", "baseline_weight", "rrf_k"):
+            if key in yaml_config:
+                try:
+                    val = float(yaml_config[key]) if key != "rrf_k" else int(yaml_config[key])
+                    setattr(config, key, val)
+                except (ValueError, TypeError):
+                    pass
+
+    # Layer 2: env vars (override yaml)
+    env_config = _load_config_from_env()
+    for key, val in env_config.items():
+        try:
+            setattr(config, key, float(val) if key != "rrf_k" else int(val))
+        except (ValueError, TypeError):
+            pass
+
+    return config
+
+
+# Module-level cached config
+_cached_config: Optional[SearchConfig] = None
+
+
+def get_cached_config() -> SearchConfig:
+    """Get cached search config (loaded once per process)."""
+    global _cached_config
+    if _cached_config is None:
+        _cached_config = get_search_config()
+    return _cached_config
+
+
+if __name__ == "__main__":
+    config = get_search_config()
+    errors = config.validate()
+    print(f"Search Config:")
+    print(f"  BM25 weight:     {config.bm25_weight}")
+    print(f"  Metadata weight: {config.metadata_weight}")
+    print(f"  Baseline weight: {config.baseline_weight}")
+    print(f"  RRF k:           {config.rrf_k}")
+    if errors:
+        print(f"\n  ERRORS: {errors}")
+    else:
+        print(f"\n  Valid ✓")

--- a/tests/test_search_config.py
+++ b/tests/test_search_config.py
@@ -1,0 +1,103 @@
+"""Tests for search_config module (Issue #1220)."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from scripts.search_config import SearchConfig, get_search_config, _load_config_from_yaml
+
+
+def test_default_config():
+    """Default weights should be 0.65/0.20/0.15."""
+    cfg = SearchConfig()
+    assert cfg.bm25_weight == 0.65
+    assert cfg.metadata_weight == 0.20
+    assert cfg.baseline_weight == 0.15
+    assert cfg.rrf_k == 60
+
+
+def test_validate_valid():
+    """Valid config should have no errors."""
+    cfg = SearchConfig()
+    assert cfg.validate() == []
+
+
+def test_validate_invalid_sum():
+    """Weights not summing to 1.0 should fail."""
+    cfg = SearchConfig(bm25_weight=0.8, metadata_weight=0.2, baseline_weight=0.2)
+    errors = cfg.validate()
+    assert len(errors) == 1
+    assert "sum to 1.0" in errors[0]
+
+
+def test_validate_negative_weight():
+    """Negative weight should fail."""
+    cfg = SearchConfig(bm25_weight=-0.1, metadata_weight=0.6, baseline_weight=0.5)
+    errors = cfg.validate()
+    assert len(errors) == 1
+    assert "0-1" in errors[0]
+
+
+def test_validate_rrf_k():
+    """rrf_k < 1 should fail."""
+    cfg = SearchConfig(rrf_k=0)
+    errors = cfg.validate()
+    assert len(errors) == 1
+    assert "rrf_k" in errors[0]
+
+
+def test_load_from_yaml(tmp_path):
+    """Load weights from config.yaml."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "search:\n"
+        "  bm25_weight: 0.70\n"
+        "  metadata_weight: 0.15\n"
+        "  baseline_weight: 0.15\n"
+        "  rrf_k: 100\n"
+    )
+    # Monkey-patch CONFIG_FILE
+    import scripts.search_config as mod
+    old_file = mod.CONFIG_FILE
+    mod.CONFIG_FILE = config_file
+    try:
+        cfg = _load_config_from_yaml()
+        assert cfg["bm25_weight"] == "0.70"
+        assert cfg["rrf_k"] == "100"
+    finally:
+        mod.CONFIG_FILE = old_file
+
+
+def test_load_from_env(monkeypatch):
+    """Env vars should override yaml."""
+    monkeypatch.setenv("MISAKA_SEARCH_BM25_WEIGHT", "0.55")
+    monkeypatch.setenv("MISAKA_SEARCH_RRF_K", "30")
+    cfg = get_search_config()
+    # Env overrides should be applied (but we can't test full integration
+    # without mocking _cached_config)
+    from scripts.search_config import _load_config_from_env
+    env_cfg = _load_config_from_env()
+    assert env_cfg["bm25_weight"] == "0.55"
+    assert env_cfg["rrf_k"] == "30"
+
+
+def test_config_no_yaml(tmp_path):
+    """Missing config.yaml should use defaults."""
+    import scripts.search_config as mod
+    old_file = mod.CONFIG_FILE
+    mod.CONFIG_FILE = tmp_path / "nonexistent.yaml"
+    try:
+        result = _load_config_from_yaml()
+        assert result is None
+    finally:
+        mod.CONFIG_FILE = old_file
+
+
+if __name__ == "__main__":
+    test_default_config()
+    test_validate_valid()
+    test_validate_invalid_sum()
+    test_validate_negative_weight()
+    test_validate_rrf_k()
+    test_config_no_yaml(Path(tempfile.mkdtemp()))
+    print("All tests passed ✓")


### PR DESCRIPTION
## Summary
- New `search_config` module makes BM25/vector scoring weights configurable
- Replaces hardcoded 0.65/0.20/0.15 weights with config.yaml or env vars
- Priority: env vars > config.yaml > defaults

## Changes
- `scripts/search_config.py`: config loading with validation
- `misakanet/search/engine.py`: use configurable weights
- `config.example.yaml`: example configuration
- `tests/test_search_config.py`: 8 unit tests
- `.gitignore`: exclude runtime data files

## Testing
- All 32 tests pass (24 existing + 8 new)
- Backward compatible: defaults match original hardcoded values

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)