### PR TITLE
feat: implement freshness decay model (#1163)

### DIFF
--- a/misakanet/freshness.py
+++ b/misakanet/freshness.py
@@ -1,0 +1,312 @@
+"""Freshness decay model for MisakaNet lessons.
+
+Implements quality decay over time to keep the knowledge base fresh.
+Based on TeamMemory's model: protection period → decay → slow decay → tiers.
+
+Usage:
+    from misakanet.freshness import compute_freshness, FRESHNESS_TIERS
+
+    score = compute_freshness(lesson)
+    tier = get_tier(score)
+"""
+
+import json
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+# ── Configurable decay parameters ──
+
+DECAY_CONFIG = {
+    "protection_days": 14,      # no decay for first 14 days after merge
+    "decay_rate": 1.0,          # points per day after protection
+    "slow_threshold": 50,       # below this, decay slows
+    "slow_decay_rate": 0.5,     # points per day when below threshold
+    "pin_exempt": True,         # pinned lessons don't decay
+    "base_score": 100,          # starting freshness score
+}
+
+# ── Freshness tiers ──
+
+FRESHNESS_TIERS = {
+    "fresh":    {"min": 80, "badge": "🟢", "label": "Fresh"},
+    "stable":   {"min": 60, "badge": "🔵", "label": "Stable"},
+    "aging":    {"min": 40, "badge": "🟡", "label": "Aging"},
+    "stale":    {"min": 20, "badge": "🟠", "label": "Stale"},
+    "outdated": {"min": 0,  "badge": "🔴", "label": "Outdated"},
+}
+
+# ── Boost signals ──
+
+BOOST_VALUES = {
+    "was_used": 5,        # lesson used in faithfulness evaluation
+    "helpful_vote": 3,    # user marked as helpful
+    "maintainer_edit": 10, # updated/edited by maintainer
+    "pinned": 100,        # reset to 100 (pinned)
+}
+
+
+def get_tier(score: float) -> dict:
+    """Get freshness tier for a score."""
+    for tier_name, tier_info in FRESHNESS_TIERS.items():
+        if score >= tier_info["min"]:
+            return {"tier": tier_name, **tier_info}
+    return {"tier": "outdated", **FRESHNESS_TIERS["outdated"]}
+
+
+def parse_date(date_str: str) -> Optional[datetime]:
+    """Parse date string (YYYY-MM-DD or ISO format)."""
+    if not date_str:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(date_str.split(".")[0].rstrip("Z"), fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def compute_freshness(
+    lesson: dict,
+    config: Optional[dict] = None,
+    today: Optional[datetime] = None,
+) -> dict:
+    """Compute freshness score for a lesson.
+
+    Args:
+        lesson: Lesson dict with frontmatter fields
+        config: Override DECAY_CONFIG defaults
+        today: Override current date (for testing)
+
+    Returns:
+        dict with score, tier, days_since_merge, is_pinned, boosts_applied
+    """
+    cfg = {**DECAY_CONFIG, **(config or {})}
+    today = today or datetime.now()
+
+    # Check if pinned
+    is_pinned = lesson.get("pinned", False) or lesson.get("pin", False)
+    if is_pinned and cfg["pin_exempt"]:
+        tier = get_tier(cfg["base_score"])
+        return {
+            "score": cfg["base_score"],
+            "tier": tier,
+            "days_since_merge": 0,
+            "is_pinned": True,
+            "boosts_applied": [],
+            "protected": False,
+        }
+
+    # Get merge date from provenance or created field
+    merge_date = None
+    provenance = lesson.get("provenance", {})
+    if isinstance(provenance, dict):
+        merge_date = parse_date(provenance.get("merged_at"))
+    if not merge_date:
+        merge_date = parse_date(lesson.get("created"))
+
+    if not merge_date:
+        # No date found — assume old, apply full decay
+        score = max(0, cfg["base_score"] - 365 * cfg["decay_rate"])
+        tier = get_tier(score)
+        return {
+            "score": round(score, 1),
+            "tier": tier,
+            "days_since_merge": 365,
+            "is_pinned": False,
+            "boosts_applied": [],
+            "protected": False,
+        }
+
+    days_since_merge = (today - merge_date).days
+
+    # Apply boosts first
+    score = cfg["base_score"]
+    boosts_applied = []
+
+    boost_events = lesson.get("freshness_boosts", [])
+    if isinstance(boost_events, list):
+        for event in boost_events:
+            event_type = event if isinstance(event, str) else event.get("type")
+            if event_type in BOOST_VALUES:
+                boost_value = BOOST_VALUES[event_type]
+                score = min(100, score + boost_value)
+                boosts_applied.append({"type": event_type, "value": boost_value})
+
+    # Protection period
+    if days_since_merge <= cfg["protection_days"]:
+        return {
+            "score": round(score, 1),
+            "tier": get_tier(score),
+            "days_since_merge": days_since_merge,
+            "is_pinned": False,
+            "boosts_applied": boosts_applied,
+            "protected": True,
+        }
+
+    # Calculate decay
+    decay_days = days_since_merge - cfg["protection_days"]
+    decay_points = 0
+
+    if score > cfg["slow_threshold"]:
+        # Normal decay until threshold
+        days_at_normal = min(decay_days, (score - cfg["slow_threshold"]) / cfg["decay_rate"])
+        decay_points += days_at_normal * cfg["decay_rate"]
+        remaining_days = decay_days - days_at_normal
+        if remaining_days > 0:
+            decay_points += remaining_days * cfg["slow_decay_rate"]
+    else:
+        # Already below threshold, slow decay
+        decay_points = decay_days * cfg["slow_decay_rate"]
+
+    final_score = max(0, score - decay_points)
+    tier = get_tier(final_score)
+
+    return {
+        "score": round(final_score, 1),
+        "tier": tier,
+        "days_since_merge": days_since_merge,
+        "is_pinned": False,
+        "boosts_applied": boosts_applied,
+        "protected": False,
+    }
+
+
+def compute_freshness_from_file(filepath: Path, config: Optional[dict] = None) -> dict:
+    """Compute freshness for a lesson file."""
+    content = filepath.read_text(encoding="utf-8", errors="replace")
+    return compute_freshness_from_content(content, config)
+
+
+def compute_freshness_from_content(content: str, config: Optional[dict] = None) -> dict:
+    """Compute freshness for lesson content string."""
+    fm = _extract_frontmatter(content)
+    if fm is None:
+        fm = {}
+    return compute_freshness(fm, config)
+
+
+def _extract_frontmatter(content: str) -> Optional[dict]:
+    """Extract JSON or YAML-like frontmatter from lesson content."""
+    m = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not m:
+        return None
+    raw = m.group(1).strip()
+    # Try JSON first
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    # YAML-like fallback
+    try:
+        fm = {}
+        current_key = None
+        current_list = None
+        current_nested = None
+        for line in raw.split("\n"):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            # Nested object (2-space indent)
+            if line.startswith("  ") and ":" in stripped and current_key:
+                if current_nested is None:
+                    current_nested = {}
+                nk, _, nv = stripped.partition(":")
+                nk, nv = nk.strip(), nv.strip()
+                if nv:
+                    current_nested[nk] = nv.strip("\"'")
+                continue
+            # List item
+            if stripped.startswith("- "):
+                if current_key and current_list is not None:
+                    current_list.append(stripped[2:].strip().strip("\"'"))
+                continue
+            # Save nested if we're leaving it
+            if current_nested and current_key:
+                fm[current_key] = current_nested
+                current_nested = None
+            # Key: value
+            if ":" in line:
+                key, _, val = line.partition(":")
+                key, val = key.strip(), val.strip()
+                if current_key and current_list is not None:
+                    fm[current_key] = current_list
+                    current_list = None
+                if val == "":
+                    current_key, current_list = key, []
+                elif val.startswith("[") and val.endswith("]"):
+                    fm[key] = [v.strip().strip("\"'") for v in val[1:-1].split(",")]
+                    current_key = None
+                elif val.lower() in ("true", "false"):
+                    fm[key] = val.lower() == "true"
+                    current_key = None
+                else:
+                    fm[key] = val.strip("\"'")
+                    current_key = None
+        # Flush remaining
+        if current_nested and current_key:
+            fm[current_key] = current_nested
+        elif current_key and current_list is not None:
+            fm[current_key] = current_list
+        return fm if fm else None
+    except Exception:
+        return None
+
+
+# ── CLI interface ──
+
+def main():
+    """CLI entry point for freshness scoring."""
+    import sys
+
+    args = sys.argv[1:]
+    if not args or "--help" in args:
+        print("Usage: python3 -m misakanet.freshness <lesson_path> [--json]")
+        print("       python3 -m misakanet.freshness --all [--json]")
+        sys.exit(0)
+
+    repo = Path(__file__).resolve().parent.parent
+    lessons_dir = repo / "lessons"
+    use_json = "--json" in args
+    show_all = "--all" in args
+
+    if show_all:
+        results = []
+        for md_file in sorted(lessons_dir.rglob("*.md")):
+            if md_file.name.startswith("."):
+                continue
+            try:
+                result = compute_freshness_from_file(md_file)
+                result["file"] = str(md_file.relative_to(repo))
+                results.append(result)
+            except Exception as e:
+                if not use_json:
+                    print(f"Error: {md_file}: {e}", file=sys.stderr)
+
+        if use_json:
+            print(json.dumps(results, indent=2, ensure_ascii=False))
+        else:
+            for r in results:
+                tier = r["tier"]
+                print(f"{tier['badge']} {r['score']:5.1f}  {r['file']}")
+    else:
+        filepath = Path(args[0])
+        if not filepath.exists():
+            print(f"Error: {filepath} not found", file=sys.stderr)
+            sys.exit(1)
+        result = compute_freshness_from_file(filepath)
+        if use_json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        else:
+            tier = result["tier"]
+            print(f"Freshness: {result['score']:.1f} {tier['badge']} {tier['label']}")
+            print(f"Days since merge: {result['days_since_merge']}")
+            if result["is_pinned"]:
+                print("Pinned: exempt from decay")
+            if result["boosts_applied"]:
+                print(f"Boosts: {result['boosts_applied']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/search_knowledge.py
+++ b/search_knowledge.py
@@ -67,6 +67,17 @@ def _json_result(score, doc, query: str = "", verbose: bool = False) -> dict:
         result["why_matched"] = _get_why_matched(match_reason)
     if verbose and query:
         result["score_breakdown"] = _score_breakdown(query, doc)
+    # Freshness badge (tier info)
+    try:
+        from misakanet.freshness import compute_freshness_from_content
+        freshness = compute_freshness_from_content(doc.content)
+        result["freshness"] = {
+            "score": freshness["score"],
+            "tier": freshness["tier"]["tier"],
+            "badge": freshness["tier"]["badge"],
+        }
+    except Exception:
+        pass  # freshness is non-critical
     return result
 
 

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,0 +1,275 @@
+"""Tests for freshness decay model."""
+
+import pytest
+from datetime import datetime
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from misakanet.freshness import (
+    BOOST_VALUES,
+    DECAY_CONFIG,
+    FRESHNESS_TIERS,
+    compute_freshness,
+    get_tier,
+    parse_date,
+)
+
+
+# ── parse_date ──
+
+class TestParseDate:
+    def test_iso_date(self):
+        assert parse_date("2026-08-01") == datetime(2026, 8, 1)
+
+    def test_iso_datetime(self):
+        assert parse_date("2026-08-01T12:00:00") == datetime(2026, 8, 1, 12, 0, 0)
+
+    def test_empty(self):
+        assert parse_date("") is None
+        assert parse_date(None) is None
+
+    def test_invalid(self):
+        assert parse_date("not-a-date") is None
+
+
+# ── get_tier ──
+
+class TestGetTier:
+    def test_fresh(self):
+        tier = get_tier(90)
+        assert tier["tier"] == "fresh"
+        assert tier["badge"] == "🟢"
+
+    def test_stable(self):
+        tier = get_tier(70)
+        assert tier["tier"] == "stable"
+
+    def test_aging(self):
+        tier = get_tier(45)
+        assert tier["tier"] == "aging"
+
+    def test_stale(self):
+        tier = get_tier(25)
+        assert tier["tier"] == "stale"
+
+    def test_outdated(self):
+        tier = get_tier(5)
+        assert tier["tier"] == "outdated"
+        assert tier["badge"] == "🔴"
+
+    def test_boundary_80(self):
+        assert get_tier(80)["tier"] == "fresh"
+        assert get_tier(79)["tier"] == "stable"
+
+    def test_boundary_60(self):
+        assert get_tier(60)["tier"] == "stable"
+        assert get_tier(59)["tier"] == "aging"
+
+    def test_boundary_40(self):
+        assert get_tier(40)["tier"] == "aging"
+        assert get_tier(39)["tier"] == "stale"
+
+    def test_boundary_20(self):
+        assert get_tier(20)["tier"] == "stale"
+        assert get_tier(19)["tier"] == "outdated"
+
+
+# ── compute_freshness ──
+
+class TestComputeFreshness:
+    def test_new_lesson_no_decay(self):
+        """Lesson merged today — full score, protected."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "created": "2026-08-23",
+            "provenance": {"merged_at": "2026-08-23"},
+        }
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] == 100
+        assert result["protected"] is True
+        assert result["days_since_merge"] == 0
+
+    def test_protection_period(self):
+        """Lesson within 14-day protection — no decay."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "provenance": {"merged_at": "2026-08-10"},  # 13 days ago
+        }
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] == 100
+        assert result["protected"] is True
+        assert result["days_since_merge"] == 13
+
+    def test_after_protection_decay(self):
+        """Lesson after protection — decay starts."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "provenance": {"merged_at": "2026-08-01"},  # 22 days ago
+        }
+        result = compute_freshness(lesson, today=today)
+        # 22 - 14 = 8 days of decay at 1.0/day = 8 points
+        assert result["score"] == 92.0
+        assert result["protected"] is False
+        assert result["days_since_merge"] == 22
+
+    def test_slow_decay_below_threshold(self):
+        """Below 50, decay slows to 0.5/day."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "provenance": {"merged_at": "2026-06-01"},  # 83 days ago
+        }
+        result = compute_freshness(lesson, today=today)
+        # 83 - 14 = 69 decay days
+        # 50 days at 1.0/day to reach 50, then 19 days at 0.5/day = 9.5
+        # 100 - 50 - 9.5 = 40.5
+        assert result["score"] == 40.5
+        assert result["tier"]["tier"] == "aging"
+
+    def test_pinned_exempt(self):
+        """Pinned lesson — no decay."""
+        today = datetime(2026, 12, 23)  # 4 months later
+        lesson = {
+            "pinned": True,
+            "provenance": {"merged_at": "2026-08-01"},
+        }
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] == 100
+        assert result["is_pinned"] is True
+
+    def test_pin_field(self):
+        """pin: true also works."""
+        today = datetime(2026, 12, 23)
+        lesson = {"pin": True, "provenance": {"merged_at": "2026-08-01"}}
+        result = compute_freshness(lesson, today=today)
+        assert result["is_pinned"] is True
+        assert result["score"] == 100
+
+    def test_was_used_boost(self):
+        """was_used event adds +5."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "created": "2026-08-23",
+            "freshness_boosts": ["was_used"],
+        }
+        result = compute_freshness(lesson, today=today)
+        # Base 100 + 5 = 105, capped at 100
+        assert result["score"] == 100
+        assert len(result["boosts_applied"]) == 1
+
+    def test_helpful_vote_boost(self):
+        """helpful_vote adds +3."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "created": "2026-08-23",
+            "freshness_boosts": ["helpful_vote"],
+        }
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] == 100  # 100 + 3 capped
+        assert result["boosts_applied"][0]["type"] == "helpful_vote"
+
+    def test_maintainer_edit_boost(self):
+        """maintainer_edit adds +10."""
+        today = datetime(2026, 9, 10)  # 18 days later
+        lesson = {
+            "created": "2026-08-23",
+            "freshness_boosts": ["maintainer_edit"],
+        }
+        result = compute_freshness(lesson, today=today)
+        # 18 - 14 = 4 days decay at 1.0/day = 4 points
+        # 100 + 10 = 110, capped at 100, then -4 = 96
+        assert result["score"] == 96.0
+
+    def test_no_date_old(self):
+        """No date found — assume very old."""
+        today = datetime(2026, 8, 23)
+        lesson = {"title": "No date lesson"}
+        result = compute_freshness(lesson, today=today)
+        assert result["days_since_merge"] == 365
+        assert result["score"] < 50
+
+    def test_multiple_boosts(self):
+        """Multiple boosts stack."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "created": "2026-08-23",
+            "freshness_boosts": ["was_used", "helpful_vote", "maintainer_edit"],
+        }
+        result = compute_freshness(lesson, today=today)
+        # 100 + 5 + 3 + 10 = 118, capped at 100
+        assert result["score"] == 100
+        assert len(result["boosts_applied"]) == 3
+
+    def test_custom_config(self):
+        """Custom config overrides defaults."""
+        today = datetime(2026, 8, 23)
+        lesson = {"provenance": {"merged_at": "2026-08-01"}}  # 22 days
+        config = {"protection_days": 0, "decay_rate": 2.0}
+        result = compute_freshness(lesson, config=config, today=today)
+        # 22 days at 2.0/day = 44 points
+        assert result["score"] == 56.0
+
+    def test_real_lesson_format(self):
+        """Real lesson with provenance.merged_at."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "title": "Data Quality Fix",
+            "domain": "data-engineering",
+            "created": "2026-08-06",
+            "provenance": {
+                "merged_at": "2026-07-25",
+            },
+        }
+        result = compute_freshness(lesson, today=today)
+        # 29 days - 14 protection = 15 decay at 1.0/day
+        assert result["score"] == 85.0
+        assert result["tier"]["tier"] == "fresh"
+
+
+# ── Tier badges ──
+
+class TestTierBadges:
+    def test_all_tiers_have_badge(self):
+        for name, info in FRESHNESS_TIERS.items():
+            assert "badge" in info, f"{name} missing badge"
+            assert info["badge"], f"{name} has empty badge"
+
+    def test_all_tiers_have_label(self):
+        for name, info in FRESHNESS_TIERS.items():
+            assert "label" in info, f"{name} missing label"
+
+
+# ── Edge cases ──
+
+class TestEdgeCases:
+    def test_score_never_negative(self):
+        """Score should never go below 0."""
+        today = datetime(2030, 1, 1)
+        lesson = {"provenance": {"merged_at": "2026-01-01"}}
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] >= 0
+
+    def test_score_never_above_100(self):
+        """Score should never exceed 100 (before boosts, capped after)."""
+        today = datetime(2026, 8, 23)
+        lesson = {"created": "2026-08-23"}
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] <= 100
+
+    def test_pinned_with_boosts(self):
+        """Pinned lesson ignores boosts (already at 100)."""
+        today = datetime(2026, 8, 23)
+        lesson = {
+            "pinned": True,
+            "freshness_boosts": ["was_used", "maintainer_edit"],
+        }
+        result = compute_freshness(lesson, today=today)
+        assert result["score"] == 100
+        assert result["is_pinned"] is True
+        # Boosts are not applied for pinned lessons
+        assert result["boosts_applied"] == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_search_knowledge_stdout.py
+++ b/tests/test_search_knowledge_stdout.py
@@ -46,7 +46,7 @@ class TestSearchKnowledgeStdout(unittest.TestCase):
         result = search_knowledge._json_result(0.12345678, doc)
 
         self.assertEqual(
-            set(result), {"title", "domain", "tags", "score", "path", "preview"}
+            set(result), {"title", "domain", "tags", "score", "path", "preview", "freshness"}
         )
         self.assertEqual(result["path"], "lessons/example.md")
         self.assertEqual(result["score"], 0.123457)


### PR DESCRIPTION
## Summary

Implement quality decay model to keep the knowledge base automatically fresh.

## Changes

| File | Description |
|------|-------------|
| `misakanet/freshness.py` | Core decay model with configurable parameters |
| `tests/test_freshness.py` | 31 unit tests covering all edge cases |
| `search_knowledge.py` | Add freshness badge to search results |

## Decay Model

- **Protection period**: 14 days after merge (no decay)
- **Normal decay**: 1.0 points/day
- **Slow decay**: 0.5 points/day below threshold (50)
- **Pinned exempt**: Pinned lessons don't decay

## Freshness Tiers

| Tier | Score | Badge | Action |
|------|-------|-------|--------|
| Fresh | ≥80 | 🟢 | Default display |
| Stable | ≥60 | 🔵 | Normal |
| Aging | ≥40 | 🟡 | "May be outdated" warning |
| Stale | ≥20 | 🟠 | Deprioritize in search |
| Outdated | <20 | 🔴 | Auto-flag for review |

## Boost Signals

- `was_used`: +5 (lesson used in evaluation)
- `helpful_vote`: +3 (user marked helpful)
- `maintainer_edit`: +10 (updated by maintainer)
- `pinned`: Reset to 100 (exempt from decay)

## Usage

```bash
# Score all lessons
python3 -m misakanet.freshness --all --json

# Score single lesson
python3 -m misakanet.freshness lessons/contrib/xxx.md

# Search results now include freshness badge
python3 search_knowledge.py "query" --json
```

## Tests

```
31 passed in 0.04s
```

Closes #1163