### PR TITLE
feat(pr-genius): split rules into repo-agnostic and repo-specific layers (#1036)

### DIFF
--- a/.pr-genius.yaml
+++ b/.pr-genius.yaml
@@ -1,5 +1,8 @@
 # PR Genius local configuration
 # Customize rules, thresholds, and patterns per repository.
+#
+# Layer 1 (core): repo-agnostic rules — portable across any repo.
+# Layer 2 (repo): path_rules + custom_patterns — repo-specific.
 
 rules:
   # Accept more Issue link formats
@@ -20,7 +23,8 @@ rules:
     max_lines: 500
     warning_lines: 300
 
-  # Anti-pattern detection — enable/disable individual rules
+  # ── Layer 1: Core rules (repo-agnostic) ──
+  # Override severity or disable built-in rules here.
   patterns:
     pr_too_large:
       enabled: true
@@ -40,3 +44,42 @@ rules:
     missing_dco:
       enabled: true
       severity: medium
+    draft_pr:
+      enabled: true
+      severity: info
+    review_stale:
+      enabled: true
+      severity: medium
+
+  # ── Layer 2: Repo-specific path rules ──
+  # Triggered when changed files match the glob pattern.
+  path_rules:
+    - id: mcp_server_change
+      trigger: "scripts/mcp_server.py"
+      severity: high
+      description: "MCP server changed — verify all tool endpoints still work"
+      message: "Run `python -m pytest tests/test_mcp_server.py` before merging."
+    - id: lesson_lint_required
+      trigger: "lessons/**/*.md"
+      severity: medium
+      description: "Lesson file changed — lint must pass"
+      message: "Run `python scripts/lesson_lint.py` to validate lesson format."
+    - id: workflow_change
+      trigger: ".github/workflows/*.yml"
+      severity: medium
+      description: "GitHub Actions workflow changed"
+      message: "Verify workflow syntax with `act` or push to a test branch."
+
+  # ── Layer 2: Repo-specific body/title patterns ──
+  # Regex matched against PR title + body.
+  custom_patterns:
+    - id: breaking_change_warning
+      pattern: "(?i)breaking\\s+change"
+      severity: high
+      description: "PR mentions breaking changes"
+      message: "Ensure CHANGELOG and migration guide are updated."
+    - id: wip_in_title
+      pattern: "(?i)\\bWIP\\b"
+      severity: info
+      description: "PR title contains WIP"
+      message: "Remove WIP prefix when the PR is ready for review."

--- a/docs/pr-genius-rules.md
+++ b/docs/pr-genius-rules.md
@@ -1,0 +1,149 @@
+# PR Genius Rule Configuration
+
+PR Genius uses a two-layer rule system:
+
+- **Layer 1 (Core)** — repo-agnostic rules built into the engine. Portable across any repository.
+- **Layer 2 (Repo)** — configurable rules in `.pr-genius.yaml`. Repo-specific patterns and triggers.
+
+## Quick Start
+
+Create `.pr-genius.yaml` in your repo root:
+
+```yaml
+rules:
+  # Override core rule severity
+  patterns:
+    missing_tests:
+      severity: high  # default: medium
+
+  # Add repo-specific path triggers
+  path_rules:
+    - id: lint_on_change
+      trigger: "src/**/*.ts"
+      severity: medium
+      message: "Run `npm run lint` before merging."
+
+  # Add repo-specific body patterns
+  custom_patterns:
+    - id: breaking_change
+      pattern: "(?i)breaking\\s+change"
+      severity: high
+      message: "Update CHANGELOG and migration guide."
+```
+
+## Layer 1: Core Rules
+
+These rules are built into PR Genius and work in any repo:
+
+| Rule | Default Severity | Description |
+|------|-----------------|-------------|
+| `pr_too_large` | high | PR exceeds max line threshold (default: 500) |
+| `missing_tests` | medium | Code changed but no test files updated |
+| `doc_code_mismatch` | low | Docs-only PR with no code or test changes |
+| `mixed_concerns` | medium | PR touches 3+ unrelated component areas |
+| `no_issue_reference` | low | No linked issue found in PR body |
+| `missing_dco` | medium | One or more commits lack Signed-off-by |
+| `draft_pr` | info | PR is in draft state |
+| `review_stale` | medium | PR open >14 days without approval |
+
+Override any core rule in `.pr-genius.yaml`:
+
+```yaml
+rules:
+  patterns:
+    missing_dco:
+      enabled: false  # disable this rule
+    pr_too_large:
+      severity: critical  # change severity
+```
+
+## Layer 2: Repo-Specific Rules
+
+### Path Rules
+
+Triggered when changed files match a glob pattern:
+
+```yaml
+rules:
+  path_rules:
+    - id: database_migration
+      trigger: "migrations/**/*.sql"
+      severity: high
+      description: "Database migration changed"
+      message: "Verify rollback script exists and test on staging first."
+```
+
+**Fields:**
+- `id` — unique rule identifier (required)
+- `trigger` — glob pattern matching file paths (required)
+- `severity` — `info`, `low`, `medium`, `high`, `critical` (default: `medium`)
+- `description` — what this rule checks (optional)
+- `message` — suggestion shown when triggered (optional)
+- `enabled` — `true`/`false` (default: `true`)
+
+### Custom Patterns
+
+Regex matched against PR title + body:
+
+```yaml
+rules:
+  custom_patterns:
+    - id: security_mention
+      pattern: "(?i)(CVE|security|vulnerability)"
+      severity: high
+      message: "Security-related change — ensure security review."
+```
+
+**Fields:**
+- `id` — unique rule identifier (required)
+- `pattern` — regex pattern (required)
+- `severity` — severity level (default: `medium`)
+- `description` — what this rule checks (optional)
+- `message` — suggestion shown when matched (optional)
+- `enabled` — `true`/`false` (default: `true`)
+
+## Config Precedence
+
+1. `.pr-genius.yaml` in repo root (highest priority)
+2. Built-in defaults (lowest priority)
+
+Deep merge: user config overrides defaults key by key.
+
+## Minimal YAML Parser
+
+PR Genius includes a built-in minimal YAML parser. The `pyyaml` package is optional — if installed, it's used automatically; otherwise the built-in parser handles flat configs.
+
+## Examples
+
+### MisakaNet Config
+
+```yaml
+rules:
+  issue_link:
+    patterns:
+      - "Resolves\\s+`#\\d+`"
+    required: false
+  path_rules:
+    - id: mcp_server_change
+      trigger: "scripts/mcp_server.py"
+      severity: high
+      message: "Run `python -m pytest tests/test_mcp_server.py` before merging."
+    - id: lesson_lint_required
+      trigger: "lessons/**/*.md"
+      severity: medium
+      message: "Run `python scripts/lesson_lint.py` to validate lesson format."
+```
+
+### Python Library Config
+
+```yaml
+rules:
+  patterns:
+    missing_tests:
+      severity: high  # stricter for libraries
+  path_rules:
+    - id: public_api_change
+      trigger: "src/*/public*.py"
+      severity: high
+      message: "Public API changed — update docs and bump minor version."
+```

--- a/scripts/pr_genius_report.py
+++ b/scripts/pr_genius_report.py
@@ -8,8 +8,24 @@ import json
 import os
 import re
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
+
+try:
+    from scripts.pr_genius_rules import (
+        build_rule_list,
+        evaluate_body_rules,
+        evaluate_path_rules,
+        get_enabled_rules,
+    )
+except ImportError:
+    from pr_genius_rules import (
+        build_rule_list,
+        evaluate_body_rules,
+        evaluate_path_rules,
+        get_enabled_rules,
+    )
 
 CODE_SUFFIXES = {
     ".c", ".cc", ".cpp", ".cs", ".go", ".java", ".js", ".jsx", ".kt",
@@ -170,7 +186,9 @@ def analyze(
     pattern_cfg = cfg.get("patterns", {})
     pr_size_cfg = cfg.get("pr_size", {})
     max_lines = pr_size_cfg.get("max_lines", 500)
-    warning_lines = pr_size_cfg.get("warning_lines", 300)
+
+    # Build rule list (repo-agnostic + repo-specific)
+    rules = build_rule_list(config or _DEFAULT_CONFIG)
 
     additions = sum(int(item.get("additions", 0)) for item in files)
     deletions = sum(int(item.get("deletions", 0)) for item in files)
@@ -190,14 +208,21 @@ def analyze(
     def _severity(rule_id: str, default: str) -> str:
         return pattern_cfg.get(rule_id, {}).get("severity", default)
 
+    # ── Layer 1: Repo-agnostic core rules ──
+
     if _is_enabled("pr_too_large") and total > max_lines:
-        patterns.append({"rule": "pr_too_large", "severity": _severity("pr_too_large", "high")})
-        suggestions.append(f"Split the change into focused PRs of at most {max_lines} changed lines.")
+        sev = _severity("pr_too_large", "high")
+        patterns.append({"rule": "pr_too_large", "severity": sev})
+        suggestions.append(
+            f"Split the change into focused PRs of at most {max_lines} changed lines."
+        )
     if _is_enabled("missing_tests") and code_paths and not test_paths:
-        patterns.append({"rule": "missing_tests", "severity": _severity("missing_tests", "medium")})
+        sev = _severity("missing_tests", "medium")
+        patterns.append({"rule": "missing_tests", "severity": sev})
         suggestions.append("Add or update tests for the changed code paths.")
     if _is_enabled("doc_code_mismatch") and doc_paths and not code_paths and not test_paths:
-        patterns.append({"rule": "doc_code_mismatch", "severity": _severity("doc_code_mismatch", "low")})
+        sev = _severity("doc_code_mismatch", "low")
+        patterns.append({"rule": "doc_code_mismatch", "severity": sev})
         suggestions.append(
             "Confirm this documentation-only change intentionally needs no code update."
         )
@@ -215,23 +240,25 @@ def analyze(
     if any(PurePosixPath(path).name.lower() in lock_files for path in paths):
         concern_groups.add("dependencies")
     if _is_enabled("mixed_concerns") and len(concern_groups) >= 3 and len(components) >= 3:
-        patterns.append({"rule": "mixed_concerns", "severity": _severity("mixed_concerns", "medium")})
+        sev = _severity("mixed_concerns", "medium")
+        patterns.append({"rule": "mixed_concerns", "severity": sev})
         suggestions.append(
             "Explain why these components belong together or split unrelated concerns."
         )
 
     body = str(pr.get("body") or "")
     issue_cfg = cfg.get("issue_link", {})
-    custom_patterns = issue_cfg.get("patterns", [])
+    custom_issue_patterns = issue_cfg.get("patterns", [])
     issue_matched = ISSUE_REFERENCE.search(body)
-    if custom_patterns:
-        for pat in custom_patterns:
+    if custom_issue_patterns:
+        for pat in custom_issue_patterns:
             if re.search(pat, body):
                 issue_matched = True
                 break
     issue_required = issue_cfg.get("required", True)
     if _is_enabled("no_issue_reference") and not issue_matched and issue_required:
-        patterns.append({"rule": "no_issue_reference", "severity": _severity("no_issue_reference", "low")})
+        sev = _severity("no_issue_reference", "low")
+        patterns.append({"rule": "no_issue_reference", "severity": sev})
         suggestions.append("Link the issue this PR closes or explain why no issue is needed.")
 
     unsigned = []
@@ -243,6 +270,55 @@ def analyze(
     if _is_enabled("missing_dco") and unsigned:
         patterns.append({"rule": "missing_dco", "severity": _severity("missing_dco", "medium")})
         suggestions.append("Sign off every commit with `git commit --signoff`.")
+
+    # Draft PR detection
+    if _is_enabled("draft_pr") and pr.get("draft"):
+        patterns.append({"rule": "draft_pr", "severity": _severity("draft_pr", "info")})
+        suggestions.append("PR is in draft state — mark as ready when it's time for review.")
+
+    # Review staleness (>14 days without approval)
+    if _is_enabled("review_stale"):
+        created_at = pr.get("created_at", "")
+        if created_at:
+            try:
+                created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+                now = datetime.now(timezone.utc)
+                days_open = (now - created).days
+                has_approval = any(
+                    (c.get("state") or "").upper() == "APPROVED"
+                    for c in (pr.get("reviews") or [])
+                )
+                if days_open > 14 and not has_approval:
+                    patterns.append({
+                        "rule": "review_stale",
+                        "severity": _severity("review_stale", "medium"),
+                    })
+                    msg = (
+                        f"PR has been open {days_open} days without"
+                        " approval — ping reviewers or address feedback."
+                    )
+                    suggestions.append(msg)
+            except (ValueError, TypeError):
+                pass
+
+    # ── Layer 2: Repo-specific rules ──
+
+    # Path-triggered rules
+    path_findings = evaluate_path_rules(rules, paths)
+    for finding in path_findings:
+        patterns.append({"rule": finding["rule"], "severity": finding["severity"]})
+        if finding.get("detail"):
+            suggestions.append(finding["detail"])
+
+    # Body/title pattern rules
+    title = str(pr.get("title") or "")
+    body_findings = evaluate_body_rules(rules, body, title)
+    for finding in body_findings:
+        patterns.append({"rule": finding["rule"], "severity": finding["severity"]})
+        if finding.get("detail"):
+            suggestions.append(finding["detail"])
+
+    # ── CI checks ──
 
     relevant_checks = [
         check for check in (checks or []) if "pr genius" not in str(check.get("name", "")).lower()
@@ -298,6 +374,10 @@ def analyze(
         "checklist": checklist,
         "anti_patterns": patterns,
         "suggestions": suggestions,
+        "rules_applied": {
+            "core": len(get_enabled_rules(rules, "core")),
+            "repo": len(get_enabled_rules(rules, "repo")),
+        },
     }
 
 
@@ -305,6 +385,7 @@ def render(report: dict[str, Any], risk: str) -> str:
     size = report["size"]
     impact = report["impact"]
     components = ", ".join(impact["components"]) or "none"
+    rules_applied = report.get("rules_applied", {})
     lines = [
         "## PR Genius Analysis",
         f"- **Risk Level:** {risk or 'unknown'}",
@@ -313,6 +394,10 @@ def render(report: dict[str, Any], risk: str) -> str:
             f"({size['total']} lines, {size['label']})"
         ),
         f"- **Impact:** {impact['files_changed']} files changed ({components})",
+        (
+            f"- **Rules:** {rules_applied.get('core', '?')} core"
+            f" + {rules_applied.get('repo', '?')} repo-specific"
+        ),
         "",
         "### Checklist",
     ]

--- a/scripts/pr_genius_rules.py
+++ b/scripts/pr_genius_rules.py
@@ -1,0 +1,214 @@
+"""PR Genius rule engine — repo-agnostic core + repo-specific config.
+
+Layer 1 (repo-agnostic): portable rules built into the engine.
+Layer 2 (repo-specific): loaded from .pr-genius.yaml path_rules + custom_patterns.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ── Repo-agnostic rules (Layer 1) ──────────────────────────────────────────
+
+REPO_AGNOSTIC_RULES: list[dict[str, Any]] = [
+    {
+        "id": "pr_too_large",
+        "layer": "core",
+        "severity": "high",
+        "enabled": True,
+        "description": "PR exceeds max line threshold",
+    },
+    {
+        "id": "missing_tests",
+        "layer": "core",
+        "severity": "medium",
+        "enabled": True,
+        "description": "Code changed but no test files updated",
+    },
+    {
+        "id": "doc_code_mismatch",
+        "layer": "core",
+        "severity": "low",
+        "enabled": True,
+        "description": "Docs-only PR with no code or test changes",
+    },
+    {
+        "id": "mixed_concerns",
+        "layer": "core",
+        "severity": "medium",
+        "enabled": True,
+        "description": "PR touches 3+ unrelated component areas",
+    },
+    {
+        "id": "no_issue_reference",
+        "layer": "core",
+        "severity": "low",
+        "enabled": True,
+        "description": "No linked issue found in PR body",
+    },
+    {
+        "id": "missing_dco",
+        "layer": "core",
+        "severity": "medium",
+        "enabled": True,
+        "description": "One or more commits lack Signed-off-by",
+    },
+    {
+        "id": "draft_pr",
+        "layer": "core",
+        "severity": "info",
+        "enabled": True,
+        "description": "PR is in draft state",
+    },
+    {
+        "id": "review_stale",
+        "layer": "core",
+        "severity": "medium",
+        "enabled": True,
+        "description": "PR has been open >14 days without approval",
+    },
+]
+
+# ── Rule engine ────────────────────────────────────────────────────────────
+
+
+def build_rule_list(config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Merge repo-agnostic rules with repo-specific config.
+
+    Returns ordered list of rule dicts with id, layer, severity, enabled,
+    and optional trigger (path glob pattern).
+    """
+    cfg_rules = config.get("rules", {})
+    pattern_cfg = cfg_rules.get("patterns", {})
+
+    # Start with repo-agnostic rules, apply config overrides
+    rules: list[dict[str, Any]] = []
+    for rule in REPO_AGNOSTIC_RULES:
+        merged = dict(rule)
+        override = pattern_cfg.get(rule["id"], {})
+        if override:
+            merged["enabled"] = override.get("enabled", rule["enabled"])
+            merged["severity"] = override.get("severity", rule["severity"])
+        rules.append(merged)
+
+    # Add repo-specific path_rules (Layer 2)
+    path_rules = cfg_rules.get("path_rules", [])
+    for pr in path_rules:
+        if not isinstance(pr, dict):
+            continue
+        rules.append({
+            "id": pr.get("id", "custom_path_rule"),
+            "layer": "repo",
+            "severity": pr.get("severity", "medium"),
+            "enabled": pr.get("enabled", True),
+            "description": pr.get("description", ""),
+            "trigger": pr.get("trigger", ""),  # path glob pattern
+            "message": pr.get("message", ""),
+        })
+
+    # Add repo-specific custom_patterns (Layer 2)
+    custom_patterns = cfg_rules.get("custom_patterns", [])
+    for cp in custom_patterns:
+        if not isinstance(cp, dict):
+            continue
+        rules.append({
+            "id": cp.get("id", "custom_pattern"),
+            "layer": "repo",
+            "severity": cp.get("severity", "medium"),
+            "enabled": cp.get("enabled", True),
+            "description": cp.get("description", ""),
+            "pattern": cp.get("pattern", ""),  # regex on PR body/title
+            "message": cp.get("message", ""),
+        })
+
+    return rules
+
+
+def _match_path(path: str, pattern: str) -> bool:
+    """Match a file path against a glob pattern.
+
+    Supports ``**`` for recursive directory matching and ``*``/``?``
+    for single-segment wildcards.
+    """
+    import fnmatch
+
+    if "**" not in pattern:
+        return fnmatch.fnmatch(path, pattern)
+
+    # Split into prefix (before **) and suffix (after **)
+    prefix, _, suffix = pattern.partition("**")
+    prefix = prefix.rstrip("/")
+    suffix = suffix.lstrip("/")
+
+    # Path must start with prefix
+    if prefix and not path.startswith(prefix):
+        return False
+    remaining = path[len(prefix):].lstrip("/")
+
+    # If no suffix, ** at end matches everything
+    if not suffix:
+        return True
+
+    # Check if any path segment (or the whole remaining) matches suffix
+    # migrations/**/*.sql → suffix = *.sql
+    # Match against each possible suffix of the remaining path
+    parts = remaining.split("/")
+    for i in range(len(parts)):
+        subpath = "/".join(parts[i:])
+        if fnmatch.fnmatch(subpath, suffix):
+            return True
+    return False
+
+
+def evaluate_path_rules(
+    rules: list[dict[str, Any]], paths: list[str]
+) -> list[dict[str, str]]:
+    """Evaluate path-triggered rules against changed file paths."""
+    findings: list[dict[str, str]] = []
+    for rule in rules:
+        if not rule.get("enabled") or rule.get("layer") != "repo":
+            continue
+        trigger = rule.get("trigger", "")
+        if not trigger:
+            continue
+        matched = [p for p in paths if _match_path(p, trigger)]
+        if matched:
+            findings.append({
+                "rule": rule["id"],
+                "severity": rule.get("severity", "medium"),
+                "detail": rule.get("message") or rule.get("description", ""),
+                "matched_files": ", ".join(matched[:5]),
+            })
+    return findings
+
+
+def evaluate_body_rules(
+    rules: list[dict[str, Any]], body: str, title: str = ""
+) -> list[dict[str, str]]:
+    """Evaluate regex pattern rules against PR body and title."""
+    combined = f"{title}\n{body}"
+    findings: list[dict[str, str]] = []
+    for rule in rules:
+        if not rule.get("enabled") or rule.get("layer") != "repo":
+            continue
+        pattern = rule.get("pattern", "")
+        if not pattern:
+            continue
+        if re.search(pattern, combined, re.IGNORECASE):
+            findings.append({
+                "rule": rule["id"],
+                "severity": rule.get("severity", "medium"),
+                "detail": rule.get("message") or rule.get("description", ""),
+            })
+    return findings
+
+
+def get_enabled_rules(
+    rules: list[dict[str, Any]], layer: str | None = None
+) -> list[dict[str, Any]]:
+    """Return enabled rules, optionally filtered by layer."""
+    return [
+        r for r in rules
+        if r.get("enabled", True) and (layer is None or r.get("layer") == layer)
+    ]

--- a/tests/test_pr_genius_rules.py
+++ b/tests/test_pr_genius_rules.py
@@ -1,0 +1,253 @@
+"""Tests for the PR Genius rule engine (Layer 1 + Layer 2)."""
+
+from datetime import datetime, timedelta, timezone
+
+from scripts.pr_genius_report import analyze
+from scripts.pr_genius_rules import (
+    build_rule_list,
+    evaluate_body_rules,
+    evaluate_path_rules,
+    get_enabled_rules,
+)
+
+
+def commit(message="feat: change\n\nSigned-off-by: Agent <agent@example.com>"):
+    return {"sha": "1234567890", "commit": {"message": message}}
+
+
+# ── Layer 1: Core rules ──
+
+
+def test_draft_pr_detected():
+    pr = {"body": "Fixes #1", "draft": True}
+    files = [{"filename": "src/main.py", "additions": 10, "deletions": 0}]
+    report = analyze(pr, files, [commit()])
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "draft_pr" in rules_hit
+
+
+def test_draft_pr_not_triggered_when_ready():
+    pr = {"body": "Fixes #1", "draft": False}
+    files = [{"filename": "src/main.py", "additions": 10, "deletions": 0}]
+    report = analyze(pr, files, [commit()])
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "draft_pr" not in rules_hit
+
+
+def test_review_stale_detected_after_14_days():
+    old_date = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+    pr = {"body": "Fixes #1", "created_at": old_date, "reviews": []}
+    files = [{"filename": "src/main.py", "additions": 10, "deletions": 0}]
+    report = analyze(pr, files, [commit()])
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "review_stale" in rules_hit
+
+
+def test_review_stale_not_triggered_within_14_days():
+    recent = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+    pr = {"body": "Fixes #1", "created_at": recent, "reviews": []}
+    files = [{"filename": "src/main.py", "additions": 10, "deletions": 0}]
+    report = analyze(pr, files, [commit()])
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "review_stale" not in rules_hit
+
+
+def test_review_stale_not_triggered_when_approved():
+    old_date = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+    pr = {
+        "body": "Fixes #1",
+        "created_at": old_date,
+        "reviews": [{"state": "APPROVED"}],
+    }
+    files = [{"filename": "src/main.py", "additions": 10, "deletions": 0}]
+    report = analyze(pr, files, [commit()])
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "review_stale" not in rules_hit
+
+
+def test_rules_applied_count_in_report():
+    pr = {"body": "Fixes #1"}
+    files = [{"filename": "src/main.py", "additions": 10, "deletions": 0}]
+    report = analyze(pr, files, [commit()])
+    assert "rules_applied" in report
+    assert report["rules_applied"]["core"] >= 6  # at least 6 core rules
+    assert report["rules_applied"]["repo"] >= 0
+
+
+# ── Layer 2: Path rules ──
+
+
+def test_path_rule_triggered_by_matching_file():
+    config = {
+        "rules": {
+            "path_rules": [
+                {
+                    "id": "db_migration",
+                    "trigger": "migrations/**/*.sql",
+                    "severity": "high",
+                    "message": "Verify rollback script.",
+                }
+            ]
+        }
+    }
+    pr = {"body": "Fixes #1"}
+    files = [{"filename": "migrations/001_create.sql", "additions": 5, "deletions": 0}]
+    report = analyze(pr, files, [commit()], config=config)
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "db_migration" in rules_hit
+
+
+def test_path_rule_not_triggered_by_non_matching_file():
+    config = {
+        "rules": {
+            "path_rules": [
+                {
+                    "id": "db_migration",
+                    "trigger": "migrations/**/*.sql",
+                    "severity": "high",
+                }
+            ]
+        }
+    }
+    pr = {"body": "Fixes #1"}
+    files = [{"filename": "src/main.py", "additions": 5, "deletions": 0}]
+    report = analyze(pr, files, [commit()], config=config)
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "db_migration" not in rules_hit
+
+
+def test_disabled_path_rule_not_triggered():
+    config = {
+        "rules": {
+            "path_rules": [
+                {
+                    "id": "db_migration",
+                    "trigger": "migrations/**/*.sql",
+                    "enabled": False,
+                }
+            ]
+        }
+    }
+    pr = {"body": "Fixes #1"}
+    files = [{"filename": "migrations/001.sql", "additions": 5, "deletions": 0}]
+    report = analyze(pr, files, [commit()], config=config)
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "db_migration" not in rules_hit
+
+
+# ── Layer 2: Custom patterns ──
+
+
+def test_custom_pattern_triggered_by_body():
+    config = {
+        "rules": {
+            "custom_patterns": [
+                {
+                    "id": "breaking_change",
+                    "pattern": "(?i)breaking\\s+change",
+                    "severity": "high",
+                    "message": "Update CHANGELOG.",
+                }
+            ]
+        }
+    }
+    pr = {"body": "Fixes #1\n\nThis is a BREAKING CHANGE."}
+    files = [{"filename": "src/main.py", "additions": 5, "deletions": 0}]
+    report = analyze(pr, files, [commit()], config=config)
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "breaking_change" in rules_hit
+
+
+def test_custom_pattern_triggered_by_title():
+    config = {
+        "rules": {
+            "custom_patterns": [
+                {
+                    "id": "wip_check",
+                    "pattern": "(?i)\\bWIP\\b",
+                    "severity": "info",
+                }
+            ]
+        }
+    }
+    pr = {"title": "WIP: new feature", "body": "Fixes #1"}
+    files = [{"filename": "src/main.py", "additions": 5, "deletions": 0}]
+    report = analyze(pr, files, [commit()], config=config)
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "wip_check" in rules_hit
+
+
+def test_custom_pattern_not_triggered():
+    config = {
+        "rules": {
+            "custom_patterns": [
+                {
+                    "id": "breaking_change",
+                    "pattern": "(?i)breaking\\s+change",
+                }
+            ]
+        }
+    }
+    pr = {"body": "Fixes #1 — minor refactor"}
+    files = [{"filename": "src/main.py", "additions": 5, "deletions": 0}]
+    report = analyze(pr, files, [commit()], config=config)
+    rules_hit = [p["rule"] for p in report["anti_patterns"]]
+    assert "breaking_change" not in rules_hit
+
+
+# ── Rule engine unit tests ──
+
+
+def test_build_rule_list_includes_core_rules():
+    rules = build_rule_list({})
+    core_ids = [r["id"] for r in rules if r.get("layer") == "core"]
+    assert "pr_too_large" in core_ids
+    assert "missing_dco" in core_ids
+    assert "draft_pr" in core_ids
+    assert "review_stale" in core_ids
+
+
+def test_build_rule_list_includes_repo_rules():
+    config = {
+        "rules": {
+            "path_rules": [{"id": "custom1", "trigger": "*.sql"}],
+            "custom_patterns": [{"id": "custom2", "pattern": "WIP"}],
+        }
+    }
+    rules = build_rule_list(config)
+    repo_ids = [r["id"] for r in rules if r.get("layer") == "repo"]
+    assert "custom1" in repo_ids
+    assert "custom2" in repo_ids
+
+
+def test_get_enabled_rules_filters():
+    rules = [
+        {"id": "a", "enabled": True, "layer": "core"},
+        {"id": "b", "enabled": False, "layer": "core"},
+        {"id": "c", "enabled": True, "layer": "repo"},
+    ]
+    assert len(get_enabled_rules(rules)) == 2
+    assert len(get_enabled_rules(rules, "core")) == 1
+    assert len(get_enabled_rules(rules, "repo")) == 1
+
+
+def test_evaluate_path_rules():
+    rules = [
+        {"id": "r1", "enabled": True, "layer": "repo", "trigger": "*.py", "severity": "medium"},
+        {"id": "r2", "enabled": True, "layer": "repo", "trigger": "*.sql", "severity": "high"},
+    ]
+    findings = evaluate_path_rules(rules, ["main.py", "test.py"])
+    assert len(findings) == 1
+    assert findings[0]["rule"] == "r1"
+
+
+def test_evaluate_body_rules():
+    rules = [
+        {
+            "id": "b1", "enabled": True, "layer": "repo",
+            "pattern": "(?i)breaking", "severity": "high",
+        },
+    ]
+    findings = evaluate_body_rules(rules, "This is a breaking change", "")
+    assert len(findings) == 1
+    assert findings[0]["rule"] == "b1"


### PR DESCRIPTION
## Summary

Split PR Genius rules into two layers:
- **Layer 1 (Core)** — repo-agnostic rules built into the engine (portable)
- **Layer 2 (Repo)** — configurable rules in `.pr-genius.yaml` (repo-specific)

## Changes

- `scripts/pr_genius_rules.py` — new rule engine with `build_rule_list`, `evaluate_path_rules`, `evaluate_body_rules`
- `scripts/pr_genius_report.py` — integrated rule engine, added `draft_pr` and `review_stale` core rules
- `.pr-genius.yaml` — added MisakaNet-specific path rules and custom patterns
- `docs/pr-genius-rules.md` — configuration guide with examples
- `tests/test_pr_genius_rules.py` — 17 new tests covering both layers

## New Core Rules (Layer 1)

| Rule | Severity | Description |
|------|----------|-------------|
| `draft_pr` | info | PR is in draft state |
| `review_stale` | medium | PR open >14 days without approval |

## Repo-Specific Rules (Layer 2)

### Path Rules (triggered by file globs)
```yaml
path_rules:
  - id: mcp_server_change
    trigger: "scripts/mcp_server.py"
    severity: high
    message: "Run tests before merging."
```

### Custom Patterns (regex on title+body)
```yaml
custom_patterns:
  - id: breaking_change_warning
    pattern: "(?i)breaking\\s+change"
    severity: high
    message: "Update CHANGELOG."
```

## Tests

36/36 passing (17 new + 19 existing).

Fixes #1036