### PR TITLE
feat(integration): add LangChain and LlamaIndex tool wrappers

### DIFF
--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,0 +1,89 @@
+# MisakaNet LangChain Integration
+
+Search MisakaNet failure memory from LangChain agents and chains.
+
+## Installation
+
+```bash
+pip install langchain
+# No additional dependencies needed - uses stdlib only
+```
+
+## Quick Start
+
+```python
+from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+# Create the tool
+tool = MisakaNetSearchTool()
+
+# Use directly
+result = tool.run("TypeErrCannot read property of undefined")
+print(result)
+```
+
+## With LangChain Agent
+
+```python
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_openai import ChatOpenAI
+from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+# Initialize tool and LLM
+tool = MisakaNetSearchTool()
+llm = ChatOpenAI(model="gpt-4")
+
+# Create agent with MisakaNet tool
+agent = create_react_agent(llm, [tool], prompt)
+executor = AgentExecutor(agent=agent, tools=[tool])
+
+# Agent will automatically search MisakaNet when encountering errors
+result = executor.invoke({"input": "Fix this Docker build error: permission denied"})
+```
+
+## Configuration
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `MISAKANET_SEARCH_URL` | Search API endpoint | `https://misakanet.dev/api/search` |
+| `MISAKANET_MCP_URL` | MCP protocol endpoint | `https://misakanet.dev/mcp` |
+| `MISAKANET_API_KEY` | API key for authenticated requests | None |
+
+### Programmatic Configuration
+
+```python
+tool = MisakaNetSearchTool(
+    endpoint="http://localhost:8000/api/search",
+    use_mcp=True,  # Use MCP protocol instead of REST
+    api_key="your-api-key",
+)
+```
+
+## MCP Protocol Support
+
+For MCP-compatible environments:
+
+```python
+tool = MisakaNetSearchTool(use_mcp=True)
+result = tool.run("Docker permission denied")
+```
+
+## API Reference
+
+### `MisakaNetSearchTool`
+
+LangChain `BaseTool` subclass for MisakaNet search.
+
+**Parameters:**
+- `query` (str): Error description or failure pattern
+- `max_results` (int): Max results to return (1-10, default: 3)
+
+**Returns:** Formatted string with matching lessons and solutions.
+
+### `get_misakanet_tool(**kwargs)`
+
+Convenience function to create a configured tool instance.
+
+## Related Issues
+
+- Implements #1178

--- a/integrations/langchain/misakanet_tool.py
+++ b/integrations/langchain/misakanet_tool.py
@@ -1,0 +1,191 @@
+"""LangChain tool for searching MisakaNet failure memory.
+
+Usage:
+    from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+    tool = MisakaNetSearchTool()
+    results = tool.run("TypeErrCannot read property of undefined")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional, Type
+
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForToolRun,
+    CallbackManagerForToolRun,
+)
+from langchain.pydantic_v1 import BaseModel, Field
+from langchain.tools import BaseTool
+
+# Default MisakaNet search endpoint
+DEFAULT_ENDPOINT = "https://misakanet.dev/api/search"
+DEFAULT_MCP_URL = "https://misakanet.dev/mcp"
+
+
+class MisakaNetSearchInput(BaseModel):
+    """Input for MisakaNet search tool."""
+
+    query: str = Field(
+        description="Search query describing an error, bug, or failure pattern. "
+        "Examples: 'TypeErrCannot read property of undefined', "
+        "'CUDA out of memory', 'Docker build fails with permission denied'"
+    )
+    max_results: int = Field(
+        default=3,
+        description="Maximum number of results to return (1-10).",
+        ge=1,
+        le=10,
+    )
+
+
+class MisakaNetSearchTool(BaseTool):
+    """Search MisakaNet failure memory for solutions to coding errors.
+
+    MisakaNet is a distributed failure-lesson knowledge network contributed
+    by AI coding agents. Use this tool when you encounter an error, bug,
+    or unexpected failure to find known solutions and workarounds.
+
+    Example:
+        tool = MisakaNetSearchTool()
+        result = tool.run("npm install fails with ERESOLVE unable to resolve")
+    """
+
+    name: str = "misakanet_search"
+    description: str = (
+        "Search MisakaNet failure memory for solutions to coding errors, "
+        "bugs, and unexpected failures. Returns proven solutions from "
+        "real-world experiences of AI coding agents."
+    )
+    args_schema: Type[BaseModel] = MisakaNetSearchInput
+    return_direct: bool = False
+
+    # Configuration
+    endpoint: str = Field(
+        default_factory=lambda: os.environ.get(
+            "MISAKANET_SEARCH_URL", DEFAULT_ENDPOINT
+        )
+    )
+    mcp_url: str = Field(
+        default_factory=lambda: os.environ.get("MISAKANET_MCP_URL", DEFAULT_MCP_URL)
+    )
+    use_mcp: bool = Field(default=False, description="Use MCP protocol instead of REST")
+    api_key: Optional[str] = Field(
+        default_factory=lambda: os.environ.get("MISAKANET_API_KEY"),
+        description="Optional API key for authenticated requests.",
+    )
+
+    def _search_rest(self, query: str, max_results: int) -> str:
+        """Search using REST API."""
+        import urllib.request
+        import urllib.parse
+
+        params = urllib.parse.urlencode(
+            {"q": query, "limit": max_results, "detail": "summary"}
+        )
+        url = f"{self.endpoint}?{params}"
+
+        req = urllib.request.Request(url)
+        if self.api_key:
+            req.add_header("Authorization", f"Bearer {self.api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            return f"Search failed: {e}"
+
+        if not data.get("results"):
+            return "No matching lessons found in MisakaNet."
+
+        lines = [f"Found {len(data['results'])} relevant lessons:\n"]
+        for i, result in enumerate(data["results"], 1):
+            score = result.get("score", 0)
+            title = result.get("title", "Untitled")
+            lesson_type = result.get("type", "unknown")
+            lines.append(f"{i}. [{lesson_type}] {title} (relevance: {score:.2f})")
+
+            # Include summary or problem if available
+            if result.get("summary"):
+                lines.append(f"   {result['summary']}")
+            elif result.get("problem"):
+                lines.append(f"   Problem: {result['problem']}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _search_mcp(self, query: str, max_results: int) -> str:
+        """Search using MCP protocol."""
+        import urllib.request
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "misakanet_search",
+                "arguments": {"query": query, "limit": max_results},
+            },
+        }
+
+        req = urllib.request.Request(
+            self.mcp_url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        if self.api_key:
+            req.add_header("Authorization", f"Bearer {self.api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            return f"MCP search failed: {e}"
+
+        if "error" in data:
+            return f"MCP error: {data['error']}"
+
+        content = data.get("result", {}).get("content", [])
+        if not content:
+            return "No matching lessons found in MisakaNet."
+
+        # Extract text from MCP response
+        texts = [item.get("text", "") for item in content if item.get("type") == "text"]
+        return "\n".join(texts) if texts else "No matching lessons found in MisakaNet."
+
+    def _run(
+        self,
+        query: str,
+        max_results: int = 3,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Search MisakaNet for failure lessons matching the query."""
+        if self.use_mcp:
+            return self._search_mcp(query, max_results)
+        return self._search_rest(query, max_results)
+
+    async def _arun(
+        self,
+        query: str,
+        max_results: int = 3,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Async search MisakaNet for failure lessons."""
+        # For simplicity, use sync implementation
+        # In production, use aiohttp or httpx
+        return self._run(query, max_results)
+
+
+# Convenience function for quick usage
+def get_misakanet_tool(**kwargs) -> MisakaNetSearchTool:
+    """Create a MisakaNet search tool with optional configuration.
+
+    Args:
+        **kwargs: Additional configuration passed to MisakaNetSearchTool.
+
+    Returns:
+        Configured MisakaNetSearchTool instance.
+    """
+    return MisakaNetSearchTool(**kwargs)

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -1,0 +1,94 @@
+# MisakaNet LlamaIndex Integration
+
+Search MisakaNet failure memory from LlamaIndex agents and query engines.
+
+## Installation
+
+```bash
+pip install llama-index-core
+```
+
+## Quick Start
+
+```python
+from integrations.llamaindex.misakanet_tool import misakanet_search
+
+# Direct function call
+result = misakanet_search("TypeErrCannot read property of undefined")
+print(result)
+```
+
+## With LlamaIndex Agent
+
+```python
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+from integrations.llamaindex.misakanet_tool import get_misakanet_tool
+
+# Create tool and LLM
+tool = get_misakanet_tool()
+llm = OpenAI(model="gpt-4")
+
+# Create agent with MisakaNet tool
+agent = ReActAgent.from_tools([tool], llm=llm, verbose=True)
+
+# Agent will search MisakaNet when encountering errors
+response = agent.chat("Fix this error: CUDA out of memory")
+print(response)
+```
+
+## Module-Level Tool Instance
+
+```python
+from integrations.llamaindex.misakanet_tool import misakanet_search_tool
+
+if misakanet_search_tool:
+    # Tool is ready to use
+    result = misakanet_search_tool("npm ERESOLVE dependency conflict")
+```
+
+## Configuration
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `MISAKANET_SEARCH_URL` | Search API endpoint | `https://misakanet.dev/api/search` |
+| `MISAKANET_API_KEY` | API key for authenticated requests | None |
+
+### Programmatic Configuration
+
+```python
+from integrations.llamaindex.misakanet_tool import misakanet_search
+
+result = misakanet_search(
+    query="Docker permission denied",
+    endpoint="http://localhost:8000/api/search",
+    api_key="your-api-key",
+    max_results=5,
+)
+```
+
+## API Reference
+
+### `misakanet_search(query, max_results=3, endpoint=None, api_key=None)`
+
+Search MisakaNet for failure lessons matching the query.
+
+**Parameters:**
+- `query` (str): Error description or failure pattern
+- `max_results` (int): Max results to return (1-10, default: 3)
+- `endpoint` (str, optional): Custom search endpoint URL
+- `api_key` (str, optional): API key for authenticated requests
+
+**Returns:** Formatted string with matching lessons and solutions.
+
+### `get_misakanet_tool()`
+
+Create a LlamaIndex `FunctionTool` for MisakaNet search.
+
+**Returns:** `FunctionTool` instance ready for use with LlamaIndex agents.
+
+**Raises:** `ImportError` if llama_index is not installed.
+
+## Related Issues
+
+- Implements #1178

--- a/integrations/llamaindex/misakanet_tool.py
+++ b/integrations/llamaindex/misakanet_tool.py
@@ -1,0 +1,137 @@
+"""LlamaIndex tool for searching MisakaNet failure memory.
+
+Usage:
+    from integrations.llamaindex.misakanet_tool import misakanet_search_tool
+
+    # Use directly as a FunctionTool
+    result = misakanet_search_tool("TypeErrCannot read property of undefined")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+# Default MisakaNet search endpoint
+DEFAULT_ENDPOINT = "https://misakanet.dev/api/search"
+DEFAULT_MCP_URL = "https://misakanet.dev/mcp"
+
+
+def misakanet_search(
+    query: str,
+    max_results: int = 3,
+    endpoint: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> str:
+    """Search MisakaNet failure memory for solutions to coding errors.
+
+    MisakaNet is a distributed failure-lesson knowledge network contributed
+    by AI coding agents. Use this function when you encounter an error, bug,
+    or unexpected failure to find known solutions and workarounds.
+
+    Args:
+        query: Search query describing an error, bug, or failure pattern.
+            Examples: "TypeErrCannot read property of undefined",
+            "CUDA out of memory", "Docker build fails with permission denied"
+        max_results: Maximum number of results to return (1-10). Default: 3.
+        endpoint: Custom search endpoint URL. Defaults to MISAKANET_SEARCH_URL
+            env var or https://misakanet.dev/api/search.
+        api_key: Optional API key for authenticated requests. Defaults to
+            MISAKANET_API_KEY env var.
+
+    Returns:
+        Formatted string with matching failure lessons and their solutions.
+
+    Example:
+        >>> result = misakanet_search("npm install ERESOLVE unable to resolve")
+        >>> print(result)
+        Found 2 relevant lessons:
+        1. [dependency] npm ERESOLVE dependency conflict resolution...
+    """
+    import urllib.request
+    import urllib.parse
+
+    search_endpoint = endpoint or os.environ.get(
+        "MISAKANET_SEARCH_URL", DEFAULT_ENDPOINT
+    )
+    key = api_key or os.environ.get("MISAKANET_API_KEY")
+
+    # Clamp max_results to valid range
+    max_results = max(1, min(10, max_results))
+
+    params = urllib.parse.urlencode(
+        {"q": query, "limit": max_results, "detail": "summary"}
+    )
+    url = f"{search_endpoint}?{params}"
+
+    req = urllib.request.Request(url)
+    if key:
+        req.add_header("Authorization", f"Bearer {key}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        return f"Search failed: {e}"
+
+    if not data.get("results"):
+        return "No matching lessons found in MisakaNet."
+
+    lines = [f"Found {len(data['results'])} relevant lessons:\n"]
+    for i, result in enumerate(data["results"], 1):
+        score = result.get("score", 0)
+        title = result.get("title", "Untitled")
+        lesson_type = result.get("type", "unknown")
+        lines.append(f"{i}. [{lesson_type}] {title} (relevance: {score:.2f})")
+
+        # Include summary or problem if available
+        if result.get("summary"):
+            lines.append(f"   {result['summary']}")
+        elif result.get("problem"):
+            lines.append(f"   Problem: {result['problem']}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def get_misakanet_tool():
+    """Create a LlamaIndex FunctionTool for MisakaNet search.
+
+    Returns:
+        FunctionTool instance ready for use with LlamaIndex agents.
+
+    Example:
+        from llama_index.core.agent import ReActAgent
+        from integrations.llamaindex.misakanet_tool import get_misakanet_tool
+
+        tool = get_misakanet_tool()
+        agent = ReActAgent.from_tools([tool], llm=llm)
+        response = agent.chat("Fix this error: TypeErrCannot read property 'map' of undefined")
+    """
+    try:
+        from llama_index.core.tools import FunctionTool
+    except ImportError:
+        raise ImportError(
+            "llama_index is required for LlamaIndex integration. "
+            "Install it with: pip install llama-index-core"
+        )
+
+    return FunctionTool.from_defaults(
+        fn=misakanet_search,
+        name="misakanet_search",
+        description=(
+            "Search MisakaNet failure memory for solutions to coding errors, "
+            "bugs, and unexpected failures. Returns proven solutions from "
+            "real-world experiences of AI coding agents. Use this tool when "
+            "you encounter any error or unexpected behavior."
+        ),
+    )
+
+
+# Module-level tool instance for convenience
+try:
+    misakanet_search_tool = get_misakanet_tool()
+except ImportError:
+    # llama_index not installed; tool will be created on first call
+    misakanet_search_tool = None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,206 @@
+"""Tests for LangChain and LlamaIndex integrations."""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add repo root to path for imports
+sys.path.insert(0, str(os.path.dirname(os.path.dirname(__file__))))
+
+
+class TestLangChainIntegration:
+    """Tests for LangChain MisakaNet tool."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_langchain(self):
+        """Skip LangChain tests if langchain is not installed."""
+        pytest.importorskip("langchain")
+
+    def test_tool_import(self):
+        """Test that LangChain tool can be imported."""
+        from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+        tool = MisakaNetSearchTool()
+        assert tool.name == "misakanet_search"
+        assert "MisakaNet" in tool.description
+
+    def test_tool_input_schema(self):
+        """Test tool input schema is properly defined."""
+        from integrations.langchain.misakanet_tool import (
+            MisakaNetSearchInput,
+            MisakaNetSearchTool,
+        )
+
+        tool = MisakaNetSearchTool()
+        schema = tool.args_schema.schema()
+
+        assert "query" in schema["properties"]
+        assert "max_results" in schema["properties"]
+        assert schema["properties"]["query"]["type"] == "string"
+
+    @patch("urllib.request.urlopen")
+    def test_search_rest_success(self, mock_urlopen):
+        """Test REST API search with successful response."""
+        from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+        # Mock response
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(
+            {
+                "results": [
+                    {
+                        "title": "Test Lesson",
+                        "type": "error",
+                        "score": 0.95,
+                        "problem": "Test problem",
+                    }
+                ]
+            }
+        ).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        tool = MisakaNetSearchTool()
+        result = tool._run("test query")
+
+        assert "Found 1 relevant lessons" in result
+        assert "Test Lesson" in result
+
+    @patch("urllib.request.urlopen")
+    def test_search_rest_empty(self, mock_urlopen):
+        """Test REST API search with no results."""
+        from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"results": []}).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        tool = MisakaNetSearchTool()
+        result = tool._run("nonexistent query")
+
+        assert "No matching lessons found" in result
+
+    @patch("urllib.request.urlopen")
+    def test_search_rest_error(self, mock_urlopen):
+        """Test REST API search with network error."""
+        from integrations.langchain.misakanet_tool import MisakaNetSearchTool
+
+        mock_urlopen.side_effect = Exception("Connection failed")
+
+        tool = MisakaNetSearchTool()
+        result = tool._run("test query")
+
+        assert "Search failed" in result
+
+    def test_get_misakanet_tool(self):
+        """Test convenience function."""
+        from integrations.langchain.misakanet_tool import get_misakanet_tool
+
+        tool = get_misakanet_tool()
+        assert tool.name == "misakanet_search"
+
+
+class TestLlamaIndexIntegration:
+    """Tests for LlamaIndex MisakaNet tool."""
+
+    def test_function_import(self):
+        """Test that LlamaIndex function can be imported."""
+        from integrations.llamaindex.misakanet_tool import misakanet_search
+
+        assert callable(misakanet_search)
+
+    @patch("urllib.request.urlopen")
+    def test_search_success(self, mock_urlopen):
+        """Test search with successful response."""
+        from integrations.llamaindex.misakanet_tool import misakanet_search
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(
+            {
+                "results": [
+                    {
+                        "title": "Test Lesson",
+                        "type": "error",
+                        "score": 0.95,
+                        "problem": "Test problem",
+                    }
+                ]
+            }
+        ).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        result = misakanet_search("test query")
+
+        assert "Found 1 relevant lessons" in result
+        assert "Test Lesson" in result
+
+    @patch("urllib.request.urlopen")
+    def test_search_empty(self, mock_urlopen):
+        """Test search with no results."""
+        from integrations.llamaindex.misakanet_tool import misakanet_search
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"results": []}).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        result = misakanet_search("nonexistent query")
+
+        assert "No matching lessons found" in result
+
+    @patch("urllib.request.urlopen")
+    def test_search_error(self, mock_urlopen):
+        """Test search with network error."""
+        from integrations.llamaindex.misakanet_tool import misakanet_search
+
+        mock_urlopen.side_effect = Exception("Connection failed")
+
+        result = misakanet_search("test query")
+
+        assert "Search failed" in result
+
+    def test_max_results_clamping(self):
+        """Test that max_results is clamped to valid range."""
+        from integrations.llamaindex.misakanet_tool import misakanet_search
+
+        # Mock to avoid actual API call
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({"results": []}).encode(
+                "utf-8"
+            )
+            mock_response.__enter__ = lambda s: s
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            # Test clamping
+            misakanet_search("test", max_results=0)  # Should become 1
+            misakanet_search("test", max_results=100)  # Should become 10
+
+    @patch.dict(os.environ, {"MISAKANET_API_KEY": "test-key"})
+    @patch("urllib.request.urlopen")
+    def test_api_key_from_env(self, mock_urlopen):
+        """Test that API key is read from environment."""
+        from integrations.llamaindex.misakanet_tool import misakanet_search
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"results": []}).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        misakanet_search("test query")
+
+        # Verify API key was passed
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer test-key"


### PR DESCRIPTION
## Summary

Add official tool wrappers for LangChain and LlamaIndex, two of the largest AI agent frameworks. This enables their combined user base (10x+ current integrations) to search MisakaNet failure memory.

## Changes

### LangChain Integration (`integrations/langchain/`)
- `MisakaNetSearchTool`: BaseTool subclass with full schema support
- REST API and MCP protocol support
- Async support via `_arun` method
- Comprehensive input validation via Pydantic

### LlamaIndex Integration (`integrations/llamaindex/`)
- `misakanet_search()`: Standalone function for direct usage
- `get_misakanet_tool()`: Factory function returning FunctionTool
- Module-level tool instance for convenience

### Shared Features
- Environment variable configuration (`MISAKANET_SEARCH_URL`, `MISAKANET_API_KEY`)
- API key authentication
- Max results clamping (1-10)
- Error handling with graceful fallbacks

### Tests (`tests/test_integrations.py`)
- 12 tests covering both integrations
- Mock-based testing (no API calls required)
- Graceful skip when dependencies not installed

## Usage Examples

### LangChain
```python
from integrations.langchain.misakanet_tool import MisakaNetSearchTool
tool = MisakaNetSearchTool()
result = tool.run("TypeErrCannot read property of undefined")
```

### LlamaIndex
```python
from integrations.llamaindex.misakanet_tool import get_misakanet_tool
tool = get_misakanet_tool()
agent = ReActAgent.from_tools([tool], llm=llm)
```

## Related Issues

- Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)