### PR TITLE
fix: align MCP fallback tests with lazy search state

### DIFF
--- a/scripts/mcp_deepseek_adapter.py
+++ b/scripts/mcp_deepseek_adapter.py
@@ -29,7 +29,6 @@ Tool mapping:
 from __future__ import annotations
 
 import json
-import subprocess
 import sys
 import time
 from pathlib import Path
@@ -39,12 +38,12 @@ ADAPTER_VERSION = "1.0.0"
 
 # ── Import existing MCP handlers ──────────────────────────────────
 sys.path.insert(0, str(REPO_ROOT))
-from scripts.mcp_server import (
-    handle_search,
+from scripts.mcp_server import (  # noqa: E402, I001
+    get_server_version,
     handle_get_lesson,
+    handle_search,
     handle_submit_usage,
     handle_usage_status,
-    get_server_version,
 )
 
 
@@ -221,7 +220,7 @@ def handle_deepseek_status(args: dict) -> dict:
     # Check search engine
     engines = []
     try:
-        from scripts.build_sag_index import search as sag_search
+        from scripts.build_sag_index import search as _sag_search  # noqa: F401
         sag_db = REPO_ROOT / "data" / "sag.db"
         if sag_db.exists():
             engines.append("sag-lite")
@@ -229,7 +228,7 @@ def handle_deepseek_status(args: dict) -> dict:
         pass
 
     try:
-        from misakanet.search.engine import LESSONS
+        from misakanet.search.engine import LESSONS as _LESSONS  # noqa: F401
         engines.append("bm25")
     except ImportError:
         pass
@@ -281,13 +280,13 @@ def handle_deepseek_doctor(args: dict) -> dict:
     # Check search engine
     engine_status = "none"
     try:
-        from scripts.build_sag_index import search as sag_search
+        from scripts.build_sag_index import search as _sag_search  # noqa: F401
         if sag_db.exists():
             engine_status = "sag-lite"
     except ImportError:
         pass
     try:
-        from misakanet.search.engine import LESSONS
+        from misakanet.search.engine import LESSONS as _LESSONS  # noqa: F401
         engine_status = "bm25"
     except ImportError:
         pass
@@ -317,7 +316,11 @@ def handle_deepseek_smoke(args: dict) -> dict:
 
     # Test 1: Search
     try:
-        search_result = handle_deepseek_search({"query": smoke_query, "top": 1})
+        search_result = handle_deepseek_search({
+            "query": smoke_query,
+            "top": 1,
+            "detail": "full",
+        })
         result_count = len(search_result.get("results", []))
         results["search"] = {
             "status": "ok" if result_count > 0 else "fail",

--- a/tests/test_mcp_fallback.py
+++ b/tests/test_mcp_fallback.py
@@ -7,28 +7,36 @@ mcp_server._fallback_search) and reports source "fallback" so callers
 can distinguish the three modes. These tests pin the behaviour and
 prevent regressions in the sandbox fallback path.
 """
-import json
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-import pytest
+import pytest  # noqa: E402
 
-import scripts.mcp_server as mcp
+import misakanet.server.handlers.search as search_handler  # noqa: E402
+import scripts.mcp_server as mcp  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
 def no_engines(monkeypatch):
     """Force both SAG-Lite and BM25 to be unavailable."""
-    monkeypatch.setattr(mcp, "HAS_SAG", False)
-    monkeypatch.setattr(mcp, "HAS_BM25", False)
-    yield
+    monkeypatch.setattr(search_handler, "_SEARCH_STATE", (False, None, False, None))
+
+
+def fallback_search(query: str, top: int = 5, domain: str | None = None):
+    """Request the full fallback result contract used by these tests."""
+    return mcp.handle_search({
+        "query": query,
+        "top": top,
+        "domain": domain,
+        "detail": "full",
+    })
 
 
 def test_fallback_returns_results_instead_of_error():
-    resp = mcp.handle_search({"query": "MCP", "top": 5})
+    resp = fallback_search("MCP", top=5)
     assert "error" not in resp
     assert "results" in resp
     assert resp["source"] == "fallback"
@@ -36,13 +44,13 @@ def test_fallback_returns_results_instead_of_error():
 
 def test_fallback_source_is_distinct():
     """The source field must be exactly 'fallback' (not sag-lite/bm25)."""
-    resp = mcp.handle_search({"query": "MCP", "top": 3})
+    resp = fallback_search("MCP", top=3)
     assert resp["source"] == "fallback"
 
 
 def test_fallback_results_have_lesson_shape():
     """Fallback results carry the documented shape (title/path/domain)."""
-    resp = mcp.handle_search({"query": "sandbox", "top": 3})
+    resp = fallback_search("sandbox", top=3)
     for r in resp["results"]:
         assert isinstance(r, dict)
         assert "title" in r
@@ -52,7 +60,7 @@ def test_fallback_results_have_lesson_shape():
 
 def test_fallback_matches_real_content():
     """A query for a real lesson topic must return a relevant hit."""
-    resp = mcp.handle_search({"query": "release notes", "top": 5})
+    resp = fallback_search("release notes", top=5)
     assert resp["results"], "expected at least one hit for 'release notes'"
     top = resp["results"][0]
     blob = " ".join(str(v).lower() for v in top.values())
@@ -60,7 +68,7 @@ def test_fallback_matches_real_content():
 
 
 def test_fallback_respects_top_limit():
-    resp = mcp.handle_search({"query": "MCP", "top": 2})
+    resp = fallback_search("MCP", top=2)
     assert len(resp["results"]) <= 2
 
 
@@ -71,19 +79,20 @@ def test_fallback_empty_query_is_rejected():
 
 def test_fallback_domain_filter():
     """A domain filter narrows the fallback results."""
-    resp = mcp.handle_search({"query": "MCP", "top": 20, "domain": "core"})
+    resp = fallback_search("MCP", top=20, domain="core")
     for r in resp["results"]:
         assert r.get("domain") == "core"
 
 
 def test_sag_still_preferred_when_available(monkeypatch):
     """With SAG available, the source must be sag-lite (no fallback)."""
-    monkeypatch.setattr(mcp, "HAS_SAG", True)
-    monkeypatch.setattr(mcp, "SAG_DB", Path("/nonexistent/sag.db"))
-
     def fake_sag(db, query, domain=None, top=5):
         return [{"id": "x", "title": query}]
 
-    monkeypatch.setattr(mcp, "sag_search", fake_sag)
-    resp = mcp.handle_search({"query": "MCP", "top": 5})
+    monkeypatch.setattr(
+        search_handler,
+        "_SEARCH_STATE",
+        (True, Path("/nonexistent/sag.db"), False, fake_sag),
+    )
+    resp = fallback_search("MCP", top=5)
     assert resp["source"] == "sag-lite"


### PR DESCRIPTION
## Summary

- patch the actual lazy `_SEARCH_STATE` used by `handle_search` instead of stale compatibility-layer globals
- request `detail: full` when fallback tests assert `path` and `domain`
- make the DeepSeek smoke request the full search result before following its lesson path
- keep the touched files clean under Ruff

Closes #1290.

Node ID: `hjqcan/goodmemory-maintainer`

## Validation

- minimal dependency path: `9 passed`
- audit-equivalent core + nested optional requirements: `9 passed`
- `uvx ruff check scripts/mcp_deepseek_adapter.py tests/test_mcp_fallback.py tests/test_mcp_deepseek_adapter.py`: passed
- `git diff --check`: passed
- full audit-equivalent suite on macOS: `756 passed, 8 skipped, 1 platform-specific pre-existing failure` in `test_get_proxy_opener_no_proxy`; macOS `urllib.request.build_opener()` installs a `ProxyHandler` from system proxy settings even after the two uppercase variables removed by that test. The seven MCP failures seen in PR #1229 are all resolved.

## Why this is separate from #1229

PR #1229 changes only the GoodMemory rows in two README files. This focused PR fixes the audit regression at its source so unrelated documentation PRs do not need to carry MCP code/test changes.