### PR TITLE
fix(mcp): restore search backend compatibility

### DIFF
--- a/misakanet/server/handlers/search.py
+++ b/misakanet/server/handlers/search.py
@@ -187,9 +187,11 @@ def _apply_detail_level(results: list[dict], detail: str) -> list[dict]:
     return compact
 
 
-def handle_search(args: dict) -> dict:
+def handle_search(args: dict, search_state=None) -> dict:
     """Search MisakaNet lessons."""
-    HAS_SAG, SAG_DB, HAS_BM25, sag_search = _get_search_state()  # noqa: N806
+    if search_state is None:
+        search_state = _get_search_state()
+    HAS_SAG, SAG_DB, HAS_BM25, sag_search = search_state  # noqa: N806
 
     query = args.get("query", "")
     domain = args.get("domain")

--- a/scripts/mcp_deepseek_adapter.py
+++ b/scripts/mcp_deepseek_adapter.py
@@ -177,7 +177,7 @@ TOOLS = [
 def handle_deepseek_search(args: dict) -> dict:
     """Delegate to misakanet.search with DeepSeekHarness naming."""
     try:
-        result = handle_search(args)
+        result = handle_search({**args, "detail": "full"})
     except Exception as e:
         # SAG-Lite FTS may fail on SQLite keywords (e.g. "off", "and")
         # Fall back to empty result with error info

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -39,7 +39,7 @@ from misakanet.server.handlers import (  # noqa: E402
     handle_memory_context,
     handle_preflight,
     handle_register,
-    handle_search,
+    handle_search as _handle_search,
     handle_submit_intake,
     handle_submit_usage,
     handle_usage_status,
@@ -66,6 +66,11 @@ from misakanet.server.tools import _filtered_tools  # noqa: E402
 
 # Expose search state for tests that monkeypatch
 HAS_SAG, SAG_DB, HAS_BM25, sag_search = _init_search()
+
+
+def handle_search(args: dict) -> dict:
+    """Search through the package handler using compatibility search state."""
+    return _handle_search(args, (HAS_SAG, SAG_DB, HAS_BM25, sag_search))
 
 __all__ = [
     "TOOLS",

--- a/tests/test_mcp_fallback.py
+++ b/tests/test_mcp_fallback.py
@@ -41,8 +41,8 @@ def test_fallback_source_is_distinct():
 
 
 def test_fallback_results_have_lesson_shape():
-    """Fallback results carry the documented shape (title/path/domain)."""
-    resp = mcp.handle_search({"query": "sandbox", "top": 3})
+    """Full fallback results carry the documented title/path/domain shape."""
+    resp = mcp.handle_search({"query": "sandbox", "top": 3, "detail": "full"})
     for r in resp["results"]:
         assert isinstance(r, dict)
         assert "title" in r
@@ -71,7 +71,9 @@ def test_fallback_empty_query_is_rejected():
 
 def test_fallback_domain_filter():
     """A domain filter narrows the fallback results."""
-    resp = mcp.handle_search({"query": "MCP", "top": 20, "domain": "core"})
+    resp = mcp.handle_search({
+        "query": "MCP", "top": 20, "domain": "core", "detail": "full",
+    })
     for r in resp["results"]:
         assert r.get("domain") == "core"
 


### PR DESCRIPTION
## Summary

- reconnect the backward-compatible `scripts.mcp_server` search state to the package handler after the server split
- make the DeepSeek adapter request `detail=full`, preserving the path needed by its search -> get_lesson smoke flow
- update fallback tests that assert path/domain to explicitly request the documented full detail level

## Root cause

The MCP server split in 68faa3a moved search execution behind a private package-level cache while leaving `HAS_SAG`, `HAS_BM25`, and `sag_search` exposed by the compatibility wrapper. Callers and tests could still patch those exported values, but the handler no longer observed them. The same split enabled compact progressive disclosure, while the DeepSeek adapter still assumed every default search result contained a lesson path.

This caused the full audit on #1293 to fail in `test_mcp_fallback.py` and `test_mcp_deepseek_adapter.py` even though that PR does not touch Python search code.

## Validation

- red baseline: 3/9 targeted tests failed locally; GitHub audit reported 7 failures under Python 3.10/BM25
- `PYTHONPATH=. pytest -q tests/test_mcp_deepseek_adapter.py tests/test_mcp_fallback.py` — 9 passed
- `PYTHONPATH=. pytest -q tests/test_mcp_server.py tests/test_mcp_auth_contract.py` — 27 passed
- full local audit selection — 756 passed, 8 skipped; one macOS-only proxy assertion remains because urllib reads the host system proxy outside environment variables (the Ubuntu audit environment does not have that proxy)
- `git diff --check`

Unblocks #1293.

Node ID: hjqcan/goodmemory-maintainer