### PR TITLE
feat(search): log zero-result queries for demand board gap analysis

### DIFF
--- a/misakanet/server/handlers/search.py
+++ b/misakanet/server/handlers/search.py
@@ -6,6 +6,25 @@ from datetime import datetime, timezone
 
 from .._config import REPO_ROOT, _init_search
 
+# Gap analysis: log zero-result queries (Issue #1164)
+_GAPS_FILE = REPO_ROOT / "data" / "search_gaps.jsonl"
+
+
+def _log_search_gap(query: str, source: str) -> None:
+    """Log a zero-result search query for gap analysis."""
+    try:
+        entry = {
+            "query": query,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "result_count": 0,
+            "source": source,
+        }
+        _GAPS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(_GAPS_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass  # Non-critical, don't break search
+
 # Lazy init on first call
 _SEARCH_STATE = None
 
@@ -281,6 +300,10 @@ def handle_search(args: dict, search_state=None) -> dict:
 
     if results and detail in ("compact", "summary"):
         results = _apply_detail_level(results, detail)
+
+    # ── Gap analysis: log zero-result queries (Issue #1164) ──
+    if not results:
+        _log_search_gap(query, source)
 
     voice = "lesson-found" if results else "failure-warning"
     return {

--- a/scripts/demand_board.py
+++ b/scripts/demand_board.py
@@ -158,6 +158,68 @@ def list_items(state: str = "", family: str = "", limit: int = 50) -> list[dict]
     return items[-limit:]
 
 
+# ── Gap analysis: zero-result search queries (Issue #1164) ──
+
+GAPS_FILE = REPO_ROOT / "data" / "search_gaps.jsonl"
+
+
+def load_gaps() -> list[dict]:
+    """Load zero-result search queries."""
+    if not GAPS_FILE.exists():
+        return []
+    gaps = []
+    with open(GAPS_FILE, encoding="utf-8") as f:
+        for line in f:
+            try:
+                gaps.append(json.loads(line.strip()))
+            except json.JSONDecodeError:
+                continue
+    return gaps
+
+
+def get_gap_summary(top: int = 20) -> dict:
+    """Aggregate gap data: cluster similar queries, rank by frequency."""
+    gaps = load_gaps()
+    if not gaps:
+        return {"total": 0, "clusters": []}
+
+    # Count query frequencies
+    from collections import Counter
+    query_counts = Counter(g["query"].lower().strip() for g in gaps)
+
+    # Simple clustering: merge queries with >50% word overlap
+    clusters = []
+    used = set()
+    for query, count in query_counts.most_common():
+        if query in used:
+            continue
+        words = set(query.split())
+        cluster = {"queries": [query], "count": count}
+        used.add(query)
+
+        for other_query, other_count in query_counts.items():
+            if other_query in used:
+                continue
+            other_words = set(other_query.split())
+            if not words or not other_words:
+                continue
+            overlap = len(words & other_words) / max(len(words), len(other_words))
+            if overlap >= 0.5:
+                cluster["queries"].append(other_query)
+                cluster["count"] += other_count
+                used.add(other_query)
+
+        cluster["representative"] = cluster["queries"][0]
+        clusters.append(cluster)
+
+    clusters.sort(key=lambda c: c["count"], reverse=True)
+    return {
+        "total": len(gaps),
+        "unique_queries": len(query_counts),
+        "clusters": clusters[:top],
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Demand board — intake cluster tracking")
     sub = parser.add_subparsers(dest="cmd")
@@ -182,6 +244,11 @@ def main():
     p_ovr.add_argument("--state", default="", help="New state")
     p_ovr.add_argument("--category", default="", help="New category")
     p_ovr.add_argument("--note", default="", help="Override note")
+
+    # gaps
+    p_gaps = sub.add_parser("gaps", help="Show zero-result search gap clusters")
+    p_gaps.add_argument("--top", type=int, default=10, help="Top N clusters")
+    p_gaps.add_argument("--json", action="store_true")
 
     # summary
     p_sum = sub.add_parser("summary", help="Show summary")
@@ -215,6 +282,23 @@ def main():
             print(f"  Not found: {args.id}", file=sys.stderr)
             sys.exit(1)
 
+    elif args.cmd == "gaps":
+        gap_summary = get_gap_summary(args.top)
+        if getattr(args, "json", False):
+            print(json.dumps(gap_summary, ensure_ascii=False, indent=2))
+        else:
+            print(f"\n  Search Gaps — {gap_summary['total']} zero-result queries")
+            if gap_summary.get("unique_queries"):
+                print(f"  Unique queries: {gap_summary['unique_queries']}")
+            if not gap_summary["clusters"]:
+                print("  No gap data yet. Search queries with zero results are logged to data/search_gaps.jsonl")
+            else:
+                print(f"\n  {'#':<4} {'Count':<8} Representative")
+                print(f"  {'-'*4} {'-'*8} {'-'*50}")
+                for idx, c in enumerate(gap_summary["clusters"], 1):
+                    print(f"  {idx:<4} {c['count']:<8} {c['representative']}")
+        print()
+
     elif args.cmd == "summary":
         summary = get_summary()
         if getattr(args, "json", False):
@@ -230,6 +314,13 @@ def main():
             print(f"\n  By category:")
             for cat, c in summary["by_category"].items():
                 print(f"    {cat:<12} {c}")
+
+        # Gap integration in summary
+        gap_summary = get_gap_summary(5)
+        if gap_summary["total"] > 0:
+            print(f"\n  Top Content Gaps ({gap_summary['total']} zero-result queries):")
+            for idx, c in enumerate(gap_summary["clusters"][:5], 1):
+                print(f"    {idx}. {c['representative']} ({c['count']}x)")
         print()
 
     else:

--- a/tests/test_demand_board_gaps.py
+++ b/tests/test_demand_board_gaps.py
@@ -1,0 +1,174 @@
+"""Tests for demand board gap analysis (Issue #1164)."""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.demand_board import get_gap_summary, load_gaps, GAPS_FILE
+
+
+class TestGapLoading:
+    """Test gap data loading."""
+
+    def test_load_empty_gaps(self, tmp_path):
+        """No gap file returns empty list."""
+        with patch("scripts.demand_board.GAPS_FILE", tmp_path / "nonexistent.jsonl"):
+            assert load_gaps() == []
+
+    def test_load_valid_gaps(self, tmp_path):
+        """Load valid JSONL gap entries."""
+        gap_file = tmp_path / "test_gaps.jsonl"
+        entries = [
+            {"query": "robot welding error", "timestamp": "2026-08-23T00:00:00Z", "result_count": 0},
+            {"query": "servo motor fault", "timestamp": "2026-08-23T00:01:00Z", "result_count": 0},
+        ]
+        with open(gap_file, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+
+        with patch("scripts.demand_board.GAPS_FILE", gap_file):
+            gaps = load_gaps()
+        assert len(gaps) == 2
+        assert gaps[0]["query"] == "robot welding error"
+        assert gaps[1]["query"] == "servo motor fault"
+
+    def test_load_skips_invalid_json(self, tmp_path):
+        """Invalid JSON lines are skipped."""
+        gap_file = tmp_path / "test_gaps.jsonl"
+        with open(gap_file, "w") as f:
+            f.write("not json\n")
+            f.write(json.dumps({"query": "valid"}) + "\n")
+            f.write("{broken json\n")
+
+        with patch("scripts.demand_board.GAPS_FILE", gap_file):
+            gaps = load_gaps()
+        assert len(gaps) == 1
+
+
+class TestGapSummary:
+    """Test gap clustering and summary."""
+
+    def test_empty_summary(self, tmp_path):
+        """No data returns zero-count summary."""
+        with patch("scripts.demand_board.GAPS_FILE", tmp_path / "empty.jsonl"):
+            summary = get_gap_summary()
+        assert summary["total"] == 0
+        assert summary["clusters"] == []
+
+    def test_single_query_cluster(self, tmp_path):
+        """Single query forms one cluster."""
+        gap_file = tmp_path / "gaps.jsonl"
+        entries = [
+            {"query": "robot welding error", "timestamp": "2026-08-23T00:00:00Z", "result_count": 0},
+            {"query": "robot welding error", "timestamp": "2026-08-23T00:01:00Z", "result_count": 0},
+            {"query": "robot welding error", "timestamp": "2026-08-23T00:02:00Z", "result_count": 0},
+        ]
+        with open(gap_file, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+
+        with patch("scripts.demand_board.GAPS_FILE", gap_file):
+            summary = get_gap_summary()
+        assert summary["total"] == 3
+        assert summary["unique_queries"] == 1
+        assert len(summary["clusters"]) == 1
+        assert summary["clusters"][0]["count"] == 3
+
+    def test_similar_queries_clustered(self, tmp_path):
+        """Queries with >50% word overlap are clustered."""
+        gap_file = tmp_path / "gaps.jsonl"
+        entries = [
+            {"query": "robot welding error", "timestamp": "2026-08-23T00:00:00Z", "result_count": 0},
+            {"query": "robot welding fault", "timestamp": "2026-08-23T00:01:00Z", "result_count": 0},
+            {"query": "servo motor error", "timestamp": "2026-08-23T00:02:00Z", "result_count": 0},
+            {"query": "servo motor problem", "timestamp": "2026-08-23T00:03:00Z", "result_count": 0},
+        ]
+        with open(gap_file, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+
+        with patch("scripts.demand_board.GAPS_FILE", gap_file):
+            summary = get_gap_summary()
+        assert summary["total"] == 4
+        # robot welding error/fault should cluster (2/3 overlap = 0.67)
+        # servo motor error/problem should cluster (2/3 overlap = 0.67)
+        assert len(summary["clusters"]) == 2
+
+    def test_top_n_limit(self, tmp_path):
+        """top parameter limits clusters returned."""
+        gap_file = tmp_path / "gaps.jsonl"
+        # Use completely distinct queries so they don't cluster
+        topics = ["welding", "painting", "assembly", "inspection", "logistics",
+                   "conveyor", "robot arm", "sensor", "PLC", "vision system",
+                   "hydraulic", "pneumatic", "servo motor", "encoder", "actuator"]
+        entries = [
+            {"query": t, "timestamp": "2026-08-23T00:00:00Z", "result_count": 0}
+            for t in topics
+        ]
+        with open(gap_file, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+
+        with patch("scripts.demand_board.GAPS_FILE", gap_file):
+            summary = get_gap_summary(top=5)
+        assert len(summary["clusters"]) == 5
+
+
+class TestSearchGapLogging:
+    """Test the search handler's gap logging function."""
+
+    def test_log_creates_file(self, tmp_path):
+        """Gap log creates the file if it doesn't exist."""
+        gap_file = tmp_path / "data" / "search_gaps.jsonl"
+        with patch("misakanet.server.handlers.search._GAPS_FILE", gap_file):
+            from misakanet.server.handlers.search import _log_search_gap
+            _log_search_gap("test query", "test_source")
+
+        assert gap_file.exists()
+        with open(gap_file) as f:
+            entry = json.loads(f.readline())
+        assert entry["query"] == "test query"
+        assert entry["source"] == "test_source"
+        assert entry["result_count"] == 0
+
+    def test_log_appends(self, tmp_path):
+        """Gap log appends to existing file."""
+        gap_file = tmp_path / "data" / "search_gaps.jsonl"
+        gap_file.parent.mkdir(parents=True, exist_ok=True)
+
+        with patch("misakanet.server.handlers.search._GAPS_FILE", gap_file):
+            from misakanet.server.handlers.search import _log_search_gap
+            _log_search_gap("query 1", "src1")
+            _log_search_gap("query 2", "src2")
+
+        with open(gap_file) as f:
+            lines = f.readlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["query"] == "query 1"
+        assert json.loads(lines[1])["query"] == "query 2"
+
+    def test_log_silences_errors(self, tmp_path):
+        """Gap logging silences I/O errors gracefully."""
+        with patch("misakanet.server.handlers.search._GAPS_FILE", Path("/nonexistent/dir/file.jsonl")):
+            from misakanet.server.handlers.search import _log_search_gap
+            # Should not raise
+            _log_search_gap("test", "test")
+
+    def test_log_includes_timestamp(self, tmp_path):
+        """Gap entry includes ISO timestamp."""
+        gap_file = tmp_path / "data" / "search_gaps.jsonl"
+        with patch("misakanet.server.handlers.search._GAPS_FILE", gap_file):
+            from misakanet.server.handlers.search import _log_search_gap
+            _log_search_gap("test query", "test")
+
+        with open(gap_file) as f:
+            entry = json.loads(f.readline())
+        assert "timestamp" in entry
+        assert "T" in entry["timestamp"]  # ISO format

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -482,6 +482,22 @@ async function handleMcpToolCall(env, toolName, args, authToken, clientIp) {
     };
   }
 
+  // Gap analysis: log zero-result search queries to KV (Issue #1164)
+  async function logSearchGap(env, query, source) {
+    try {
+      if (!env.MISAKANET_KV) return;
+      const key = `gap:${query.toLowerCase().trim()}`;
+      const existing = await env.MISAKANET_KV.get(key, { type: "json" });
+      const entry = {
+        query,
+        count: (existing?.count || 0) + 1,
+        source,
+        lastSeen: new Date().toISOString(),
+      };
+      await env.MISAKANET_KV.put(key, JSON.stringify(entry), { expirationTtl: 86400 * 90 });
+    } catch (_) {}
+  }
+
   if (toolName === "misakanet_search") {
     if (!args.query) return { error: "query is required" };
 
@@ -520,6 +536,11 @@ async function handleMcpToolCall(env, toolName, args, authToken, clientIp) {
     } else {
       results = searchLessons(lessons, args.query, args.domain, args.top || 5);
       debugLog(env, 2, "Fallback search", { query: args.query, results: results.length });
+    }
+
+    // Gap analysis: log zero-result queries (Issue #1164)
+    if ((!results || results.length === 0) && args.query) {
+      logSearchGap(env, args.query, source).catch(() => {});
     }
 
     // Progressive disclosure: transform by detail level


### PR DESCRIPTION
## Summary

Implements Issue #1164: Log zero-result search queries for content gap detection.

## Changes

### Zero-Result Logging
- **Python handler** (`search.py`): Logs zero-result queries to `data/search_gaps.jsonl` with query, timestamp, source
- **Worker proxy** (`register-proxy-sw.js`): Logs zero-result queries to Cloudflare KV with 90-day TTL

### Demand Board Integration
- New `gaps` subcommand: shows clustered zero-result queries ranked by frequency
- `summary` command now includes top content gaps section
- Simple n-gram similarity clustering (>50% word overlap) groups related queries

### Tests
- 11 unit tests covering:
  - Gap file loading (empty, valid, invalid JSON)
  - Clustering (single query, similar queries, top-N limit)
  - Search handler logging (creates file, appends, silences errors, includes timestamp)

## Testing

```bash
# Run tests
python -m pytest tests/test_demand_board_gaps.py -v

# Test CLI
python scripts/demand_board.py gaps
python scripts/demand_board.py summary
```

Closes #1164