### PR TITLE
feat: add FTS5 search to D1 lesson API

### DIFF
--- a/scripts/sync_lessons_to_d1.py
+++ b/scripts/sync_lessons_to_d1.py
@@ -180,6 +180,9 @@ def upsert_sql(lessons: list[dict]) -> str:
             + ", ".join(f"{c}=excluded.{c}" for c in cols if c != "id")
             + ";"
         )
+    # Rebuild the external-content FTS index after every sync. REBUILD reads
+    # the current lessons table, so it also removes rows deleted with --prune.
+    stmts.append("INSERT INTO lessons_fts(lessons_fts) VALUES('rebuild');")
     stmts.append(f"INSERT INTO lesson_sync_log (run_at, source_commit, total, upserted) "
                  f"VALUES ({now}, '{git_head()}', {len(lessons)}, {len(lessons)});")
     return "\n".join(stmts) + "\n"

--- a/workers/d1-lesson-service.test.mjs
+++ b/workers/d1-lesson-service.test.mjs
@@ -268,3 +268,13 @@ test('/api/lessons?limit= caps result count', async () => {
   const data = await resp.json();
   assert.equal(data.length, 1);
 });
+
+test('/api/lessons?q= uses FTS ranking and composes with domain filter', async () => {
+  const env = { MISAKANET_D1: createD1(D1_ROWS) };
+  const resp = await apiLessons('?q=pip+timeout&domain=python&limit=5', env);
+  assert.equal(resp.status, 200);
+  const data = await resp.json();
+  assert.equal(data.length, 1);
+  assert.equal(data[0].id, 'd1-pip-mirror');
+  assert.ok(Object.hasOwn(data[0], 'rank'));
+});

--- a/workers/d1/schema.sql
+++ b/workers/d1/schema.sql
@@ -27,6 +27,14 @@ CREATE INDEX IF NOT EXISTS idx_lessons_status ON lessons(status);
 CREATE INDEX IF NOT EXISTS idx_lessons_updated ON lessons(updated);
 CREATE INDEX IF NOT EXISTS idx_lessons_created ON lessons(created);
 
+-- FTS5 search index for ranked lesson discovery. The sync job rebuilds this
+-- external-content index after upserting lessons.
+CREATE VIRTUAL TABLE IF NOT EXISTS lessons_fts USING fts5(
+  id, title, problem, root_cause, solution, content_md,
+  content='lessons',
+  content_rowid='rowid'
+);
+
 -- Sync ledger: one row per successful sync run (audit + reconciliation)
 CREATE TABLE IF NOT EXISTS lesson_sync_log (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -1155,12 +1155,21 @@ async function fetchLessonsFromD1(env, filters = {}) {
     where.push("id = ?" + (bind.length + 1));
     bind.push(filters.id);
   }
+  if (filters.q) {
+    where.push("lessons_fts MATCH ?" + (bind.length + 1));
+    bind.push(filters.q);
+  }
   const limit = Math.min(Math.max(parseInt(filters.limit, 10) || 100, 1), 5000);
+  const search = filters.q
+    ? " FROM lessons JOIN lessons_fts ON lessons_fts.rowid = lessons.rowid"
+    : " FROM lessons";
+  const select = filters.q
+    ? "SELECT lessons.id, lessons.title, lessons.domain, lessons.status, lessons.tags, lessons.path, lessons.summary, lessons.problem, lessons.updated, lessons.created, bm25(lessons_fts) AS rank"
+    : "SELECT id, title, domain, status, tags, path, summary, problem, updated, created";
   const sql =
-    `SELECT id, title, domain, status, tags, path, summary, problem, updated, created
-     FROM lessons` +
+    select + search +
     (where.length ? " WHERE " + where.join(" AND ") : "") +
-    ` ORDER BY updated DESC LIMIT ${limit}`;
+    (filters.q ? " ORDER BY rank ASC" : " ORDER BY updated DESC") + ` LIMIT ${limit}`;
   let stmt = d1.prepare(sql);
   if (bind.length) stmt = stmt.bind(...bind);
   const { results } = await stmt.all();
@@ -1175,6 +1184,7 @@ async function fetchLessonsFromD1(env, filters = {}) {
     description: (r.summary || r.problem || "").slice(0, 400),
     updated: r.updated,
     created: r.created,
+    ...(filters.q ? { rank: Number(r.rank) } : {}),
   }));
 }
 
@@ -1752,11 +1762,13 @@ export default {
         const qTag = url.searchParams.get("tag");
         const qId = url.searchParams.get("id");
         const qLimit = url.searchParams.get("limit");
+        const q = url.searchParams.get("q");
         if (qDomain) filters.domain = qDomain.slice(0, 50);
         if (qStatus) filters.status = qStatus.slice(0, 20);
         if (qTag) filters.tag = qTag.slice(0, 50);
         if (qId) filters.id = qId.slice(0, 120);
         if (qLimit) filters.limit = qLimit;
+        if (q) filters.q = q.slice(0, 200);
         const hasFilters = Object.keys(filters).length > 0;
         if (hasFilters && !d1Binding(env)) {
           // Filtered queries require D1 — don't silently return the full list.


### PR DESCRIPTION
## Summary
- add the external-content SQLite FTS5 index to the D1 schema
- support ranked `q` searches and existing structured filters on `/api/lessons`
- rebuild the FTS index after lesson sync

## Verification
- `node --test workers/d1-lesson-service.test.mjs`
- `python3 scripts/sync_lessons_to_d1.py --dry-run` (314 lessons)
- `git diff --check`

/claim #1356