### PR TITLE
feat: add D1 lesson usage analytics

### DIFF
--- a/migrations/0001_lesson_usage.sql
+++ b/migrations/0001_lesson_usage.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS lesson_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event TEXT NOT NULL,
+  query TEXT,
+  lesson_id TEXT,
+  domain TEXT,
+  ip TEXT,
+  user_agent TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_usage_event ON lesson_usage(event);
+CREATE INDEX IF NOT EXISTS idx_usage_created ON lesson_usage(created_at);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,14 @@
   "assets": {
     "directory": "docs"
   },
+  "d1_databases": [
+    {
+      "binding": "MISAKANET_DB",
+      "database_name": "misakanet-analytics",
+      "database_id": "REPLACE_WITH_CLOUDFLARE_D1_DATABASE_ID",
+      "migrations_dir": "migrations"
+    }
+  ],
   "compatibility_flags": [
     "nodejs_compat"
   ],


### PR DESCRIPTION
## Summary
- add D1 `lesson_usage` migration and anonymized IP/user-agent tracking
- track lesson searches, no-match knowledge gaps, and lesson views
- add `GET /api/analytics` with seven-day top queries, lessons, gaps, and daily counts

## Verification
- `node --check workers/register-proxy-sw.js`
- `git diff --check`

/claim #1357