### PR TITLE
feat(mcp): guide no-match searches into intake

### DIFF
--- a/misakanet/server/handlers/search.py
+++ b/misakanet/server/handlers/search.py
@@ -25,6 +25,28 @@ def _log_search_gap(query: str, source: str) -> None:
     except Exception:
         pass  # Non-critical, don't break search
 
+
+def _no_match_feedback(query: str) -> dict:
+    """Return an actionable continuation for a query with no lesson match."""
+    return {
+        "no_match": True,
+        "query": query,
+        "suggestion": (
+            "No MisakaNet lesson matched this query. Call "
+            "misakanet_submit_intake with kind=\"missing_lesson\" to report "
+            "the knowledge gap."
+        ),
+        "intake": {
+            "tool": "misakanet_submit_intake",
+            "args": {
+                "kind": "missing_lesson",
+                "problem": "<short description of the failure>",
+                "error": query,
+                "source": "mcp",
+            },
+        },
+    }
+
 # Lazy init on first call
 _SEARCH_STATE = None
 
@@ -306,9 +328,12 @@ def handle_search(args: dict, search_state=None) -> dict:
         _log_search_gap(query, source)
 
     voice = "lesson-found" if results else "failure-warning"
-    return {
+    response = {
         "results": results,
         "source": source,
         "detail": detail,
         "voice": voice,
     }
+    if not results:
+        response.update(_no_match_feedback(query))
+    return response

--- a/scripts/mcp_http_server.py
+++ b/scripts/mcp_http_server.py
@@ -59,6 +59,28 @@ INTAKE_IP_WINDOW: dict[str, list[float]] = {}
 INTAKE_IP_LIMIT = 3          # per IP per hour
 
 
+def _no_match_feedback(query: str) -> dict:
+    """Return an actionable continuation for a query with no lesson match."""
+    return {
+        "no_match": True,
+        "query": query,
+        "suggestion": (
+            "No MisakaNet lesson matched this query. Call "
+            "misakanet_submit_intake with kind=\"missing_lesson\" to report "
+            "the knowledge gap."
+        ),
+        "intake": {
+            "tool": "misakanet_submit_intake",
+            "args": {
+                "kind": "missing_lesson",
+                "problem": "<short description of the failure>",
+                "error": query,
+                "source": "mcp",
+            },
+        },
+    }
+
+
 @mcp.tool()
 def misakanet_search(query: str, domain: str = "", top: int = 5) -> dict:
     """Search MisakaNet's public failure-lesson index by error text, keyword, or topic."""
@@ -70,12 +92,18 @@ def misakanet_search(query: str, domain: str = "", top: int = 5) -> dict:
     if HAS_SAG:
         results = sag_search(SAG_DB, query, domain=domain_val, top=top)
         voice = "lesson-found" if results else "failure-warning"
-        return {"results": results, "source": "sag-lite", "voice": voice}
+        response = {"results": results, "source": "sag-lite", "voice": voice}
+        if not results:
+            response.update(_no_match_feedback(query))
+        return response
     elif HAS_BM25:
         engine = MisakaNetSearchEngine()
         results = engine.search(query, top=top)
         voice = "lesson-found" if results else "failure-warning"
-        return {"results": results, "source": "bm25", "voice": voice}
+        response = {"results": results, "source": "bm25", "voice": voice}
+        if not results:
+            response.update(_no_match_feedback(query))
+        return response
     else:
         return {"error": "No search engine available. Run: python3 scripts/build_sag_index.py", "voice": "failure-warning"}
 

--- a/tests/test_issue_1360_no_match_feedback.py
+++ b/tests/test_issue_1360_no_match_feedback.py
@@ -1,0 +1,39 @@
+"""Regression tests for the no-match search -> intake continuation contract."""
+import json
+
+from scripts.mcp_server import handle_request
+
+
+def test_no_match_returns_actionable_intake_template(monkeypatch, tmp_path):
+    import misakanet.server.handlers.search as search
+
+    monkeypatch.setattr(search, "_SEARCH_STATE", (False, None, False, None))
+    monkeypatch.setattr(search, "REPO_ROOT", tmp_path)
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "lessons.json").write_text("[{}]", encoding="utf-8")
+
+    result = search.handle_search({"query": "quantum computing error correction"})
+
+    assert result["results"] == []
+    assert result["no_match"] is True
+    assert result["query"] == "quantum computing error correction"
+    assert "misakanet_submit_intake" in result["suggestion"]
+    assert result["intake"] == {
+        "tool": "misakanet_submit_intake",
+        "args": {
+            "kind": "missing_lesson",
+            "problem": "<short description of the failure>",
+            "error": "quantum computing error correction",
+            "source": "mcp",
+        },
+    }
+
+
+def test_match_does_not_include_no_match_feedback(monkeypatch):
+    import misakanet.server.handlers.search as search
+
+    monkeypatch.setattr(search, "_SEARCH_STATE", (False, None, False, None))
+    monkeypatch.setattr(search, "_fallback_search", lambda *args, **kwargs: [{"title": "match"}])
+    result = search.handle_search({"query": "known topic"})
+    assert result["results"][0]["title"] == "match"
+    assert "no_match" not in result


### PR DESCRIPTION
Closes #1360

Adds the complete no-match feedback contract to both MCP search handlers: `no_match`, original `query`, actionable `suggestion`, and a valid `misakanet_submit_intake` argument template. Includes regression coverage for the no-match and matched-result cases.

Verification: `python -m pytest -q tests/test_issue_1360_no_match_feedback.py tests/test_mcp_server.py` (21 passed).

/claim #1360