### PR TITLE
fix: [Intake] Windows CI: three bugs in one session. (1) splitCom

### DIFF
--- a/packages/fatal-guard/bin/fatal-guard.js
+++ b/packages/fatal-guard/bin/fatal-guard.js
@@ -221,7 +221,12 @@ function reportCrash(reason, error, stderrBuffer, exitCode) {
     const result = spawnSync(invocation.command, invocation.args, {
       timeout: HANDLER_TIMEOUT_MS,
       stdio: 'ignore',
-      env: { ...process.env, FATAL_PAYLOAD_FILE: payloadTmp, FATAL_PAYLOAD: payload },
+      env: {
+        ...process.env,
+        PYTHONIOENCODING: 'utf-8',
+        FATAL_PAYLOAD_FILE: payloadTmp,
+        FATAL_PAYLOAD: payload,
+      },
     });
     if (result.error || (result.status !== null && result.status !== 0)) {
       const detail = result.error

--- a/packages/fatal-guard/register.js
+++ b/packages/fatal-guard/register.js
@@ -22,65 +22,7 @@
  *   - Fire-and-forget: detached child, no wait
  */
 
-const { spawn } = require('node:child_process');
-const { redact } = require('./src/lib/redact');
-const { buildSpawnSpec } = require('./src/lib/spawn-command');
-
-/** Payload builder with diagnostic fields */
-function buildPayload(reason, error) {
-  const payload = {
-    schemaVersion: 1,
-    reason,
-    timestamp: new Date().toISOString(),
-    pid: process.pid,
-  };
-  if (error) {
-    const err = typeof error === 'string' ? { message: error } : error;
-    payload.errorName = err.name || 'Error';
-    payload.message = redact(String(err.message || '')).slice(0, 500);
-    if (err.stack) {
-      payload.stackSnippet = redact(String(err.stack)).slice(0, 1000);
-    }
-  }
-  return JSON.stringify(payload);
-}
-
-/** Fire-and-forget external handler invocation (supports env var fallback chain) */
-function runHandler(reason, error) {
-  const handler = (
-    process.env.FATAL_HANDLER ||
-    process.env.MISAKANET_ERROR_HANDLER ||
-    process.env.VITE_ERROR_HANDLER ||
-    process.env.E2B_ERROR_HANDLER ||
-    process.env.OPENCLAW_ERROR_HANDLER ||
-    ''
-  ).trim();
-  if (!handler) return;
-
-  try {
-    const payload = buildPayload(reason, error);
-    let handlerArgs = [];
-    if (process.env.FATAL_HANDLER_ARGS) {
-      try {
-        const parsed = JSON.parse(process.env.FATAL_HANDLER_ARGS);
-        if (Array.isArray(parsed) && parsed.every((arg) => typeof arg === 'string')) {
-          handlerArgs = parsed;
-        }
-      } catch (_) {}
-    }
-    const invocation = buildSpawnSpec(handler, [...handlerArgs, payload]);
-    const child = spawn(invocation.command, invocation.args, {
-      stdio: 'ignore',
-      detached: true,
-      shell: false,
-      ...invocation.options,
-    });
-    child.on('error', () => { /* swallow — handler failure must not block */ });
-    child.unref();
-  } catch (_) {
-    /* swallow all */
-  }
-}
+const { runHandler } = require('./index.js');
 
 // ── Register hooks ──────────────────────────────────────────────
 

--- a/packages/fatal-guard/tests/smoke.test.js
+++ b/packages/fatal-guard/tests/smoke.test.js
@@ -10,6 +10,44 @@ const WRAPPER = path.join(PACKAGE_ROOT, 'bin', 'fatal-guard.js');
 const CONVERTER = path.join(PACKAGE_ROOT, '..', '..', 'scripts', 'tombstone_to_draft.py');
 const PYTHON = process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
 
+test('register crash handler receives UTF-8 environment before shutdown', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'fatal-guard-register-'));
+  try {
+    const marker = path.join(tmp, 'encoding.txt');
+    const handler = path.join(tmp, 'handler.js');
+    await writeFile(handler, `
+      const payload = JSON.parse(process.argv.at(-1));
+      if (payload.reason === 'uncaught_exception') {
+        require('node:fs').writeFileSync(${JSON.stringify(marker)}, process.env.PYTHONIOENCODING);
+      }
+    `);
+    const result = await run(process.execPath, [
+      '-r', path.join(PACKAGE_ROOT, 'register.js'), '-e', "throw new Error('register crash');",
+    ], {
+      env: {
+        ...process.env,
+        FATAL_HANDLER: process.execPath,
+        FATAL_HANDLER_ARGS: JSON.stringify([handler]),
+        PYTHONIOENCODING: 'ascii',
+      },
+    });
+    assert.equal(result.code, 1, result.stderr);
+    let encoding;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      try {
+        encoding = await readFile(marker, 'utf8');
+        break;
+      } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    assert.equal(encoding, 'utf-8');
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 function run(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { ...options, stdio: ['ignore', 'pipe', 'pipe'] });


### PR DESCRIPTION
Fixes #1223

Routed `register.js` through the fixed `runHandler` in `index.js` (Windows `spawnSync` + UTF-8 env) and added `PYTHONIOENCODING=utf-8` to the CLI’s Windows handler spawn; `splitCommand` backslash handling was already correct.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.