### PR TITLE
test: add dsh plugin integration test suite

### DIFF
--- a/.github/workflows/dsh-integration.yml
+++ b/.github/workflows/dsh-integration.yml
@@ -30,11 +30,18 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Validate npm installation artifact
         run: npm pack --dry-run
       - name: Install Python dependencies
         shell: bash
+        env:
+          PYTHON: python
         run: python -m pip install -r requirements.txt
       - name: Run dsh integration suite
         shell: bash
+        env:
+          PYTHON: python
         run: node --test tests/dsh/*.test.mjs

--- a/.github/workflows/dsh-integration.yml
+++ b/.github/workflows/dsh-integration.yml
@@ -1,0 +1,40 @@
+name: dsh Plugin Integration Tests
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'cordis.patch.yml'
+      - 'index.js'
+      - 'index.d.ts'
+      - 'skills/**'
+      - 'tests/dsh/**'
+      - '.github/workflows/dsh-integration.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: ${{ matrix.os }} / Node ${{ matrix.node }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: ['18', '20', '22']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - name: Validate npm installation artifact
+        run: npm pack --dry-run
+      - name: Install Python dependencies
+        shell: bash
+        run: python -m pip install -r requirements.txt
+      - name: Run dsh integration suite
+        shell: bash
+        run: node --test tests/dsh/*.test.mjs

--- a/tests/dsh/compatibility.test.mjs
+++ b/tests/dsh/compatibility.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {request} from './dsh-test-helpers.mjs';
+
+test('MCP compatibility contract exposes standard discovery methods', async () => {
+  const init = await request('initialize');
+  assert.equal(init.jsonrpc, '2.0');
+  assert.ok(init.result.protocolVersion);
+  const resources = await request('resources/list');
+  assert.ok(resources.result.resources.some(item => item.uri === 'misaka://lessons/index'));
+});
+
+test('unknown methods use JSON-RPC method-not-found errors', async () => {
+  const response = await request('method/does-not-exist');
+  assert.equal(response.error.code, -32601);
+});

--- a/tests/dsh/dsh-test-helpers.mjs
+++ b/tests/dsh/dsh-test-helpers.mjs
@@ -28,9 +28,6 @@ function scheduleStop() {
 function startServer() {
   if (child) return;
   child = spawn(python, ['-u', 'scripts/mcp_server.py'], {cwd: root});
-  child.unref();
-  child.stdin.unref();
-  child.stdout.unref();
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', chunk => {
     buffered += chunk;

--- a/tests/dsh/dsh-test-helpers.mjs
+++ b/tests/dsh/dsh-test-helpers.mjs
@@ -1,0 +1,28 @@
+import {spawn} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import path from 'node:path';
+
+export const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+export function request(method, params = {}, id = 1) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.env.PYTHON || 'python3', ['scripts/mcp_server.py'], {cwd: root});
+    let output = '';
+    const timer = setTimeout(() => { child.kill(); reject(new Error(`timeout waiting for ${method}`)); }, 15000);
+    child.stdout.on('data', chunk => { output += chunk; });
+    child.stderr.on('data', () => {});
+    child.on('error', reject);
+    child.on('close', () => {
+      clearTimeout(timer);
+      const line = output.trim().split('\n').find(candidate => candidate.trimStart().startsWith('{"jsonrpc"'));
+      if (!line) return reject(new Error(`no JSON-RPC response for ${method}: ${output}`));
+      try { resolve(JSON.parse(line)); } catch (error) { reject(new Error(`${error.message}: ${output}`)); }
+    });
+    child.stdin.end(JSON.stringify({jsonrpc: '2.0', id, method, params}) + '\n');
+  });
+}
+
+export function toolResult(response) {
+  const text = response?.result?.content?.find(item => item.type === 'text')?.text;
+  return text ? JSON.parse(text) : response;
+}

--- a/tests/dsh/dsh-test-helpers.mjs
+++ b/tests/dsh/dsh-test-helpers.mjs
@@ -4,9 +4,11 @@ import path from 'node:path';
 
 export const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
+const python = process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
+
 export function request(method, params = {}, id = 1) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.env.PYTHON || 'python3', ['scripts/mcp_server.py'], {cwd: root});
+    const child = spawn(python, ['scripts/mcp_server.py'], {cwd: root});
     let output = '';
     const timer = setTimeout(() => { child.kill(); reject(new Error(`timeout waiting for ${method}`)); }, 15000);
     child.stdout.on('data', chunk => { output += chunk; });

--- a/tests/dsh/dsh-test-helpers.mjs
+++ b/tests/dsh/dsh-test-helpers.mjs
@@ -5,24 +5,79 @@ import path from 'node:path';
 export const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 const python = process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
+const pending = new Map();
+let child;
+let nextId = 1;
+let buffered = '';
+let idleTimer;
 
-export function request(method, params = {}, id = 1) {
+function stopServer() {
+  if (!child) return;
+  child.kill();
+  child = undefined;
+  buffered = '';
+}
+
+function scheduleStop() {
+  clearTimeout(idleTimer);
+  if (pending.size !== 0) return;
+  idleTimer = setTimeout(stopServer, 1000);
+  idleTimer.unref();
+}
+
+function startServer() {
+  if (child) return;
+  child = spawn(python, ['-u', 'scripts/mcp_server.py'], {cwd: root});
+  child.unref();
+  child.stdin.unref();
+  child.stdout.unref();
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', chunk => {
+    buffered += chunk;
+    const lines = buffered.split(/\r?\n/);
+    buffered = lines.pop();
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const response = JSON.parse(line);
+        const entry = pending.get(response.id);
+        if (entry) {
+          pending.delete(response.id);
+          clearTimeout(entry.timer);
+          entry.resolve(response);
+          scheduleStop();
+        }
+      } catch {
+        // Ignore non-JSON diagnostic output; protocol responses are JSON lines.
+      }
+    }
+  });
+  const fail = error => {
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    pending.clear();
+    child = undefined;
+    buffered = '';
+  };
+  child.on('error', fail);
+  child.on('close', code => fail(new Error(`MCP server exited with code ${code}`)));
+}
+
+export function request(method, params = {}, id = nextId++) {
+  startServer();
   return new Promise((resolve, reject) => {
-    const child = spawn(python, ['scripts/mcp_server.py'], {cwd: root});
-    let output = '';
-    const timer = setTimeout(() => { child.kill(); reject(new Error(`timeout waiting for ${method}`)); }, 15000);
-    child.stdout.on('data', chunk => { output += chunk; });
-    child.stderr.on('data', () => {});
-    child.on('error', reject);
-    child.on('close', () => {
-      clearTimeout(timer);
-      const line = output.trim().split('\n').find(candidate => candidate.trimStart().startsWith('{"jsonrpc"'));
-      if (!line) return reject(new Error(`no JSON-RPC response for ${method}: ${output}`));
-      try { resolve(JSON.parse(line)); } catch (error) { reject(new Error(`${error.message}: ${output}`)); }
-    });
-    child.stdin.end(JSON.stringify({jsonrpc: '2.0', id, method, params}) + '\n');
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`timeout waiting for ${method}`));
+    }, 15000);
+    pending.set(id, {resolve, reject, timer});
+    child.stdin.write(JSON.stringify({jsonrpc: '2.0', id, method, params}) + '\n');
   });
 }
+
+process.on('exit', () => child?.kill());
 
 export function toolResult(response) {
   const text = response?.result?.content?.find(item => item.type === 'text')?.text;

--- a/tests/dsh/fixtures/sample-lesson.json
+++ b/tests/dsh/fixtures/sample-lesson.json
@@ -1,0 +1,1 @@
+{"query":"CI pipeline","top":1}

--- a/tests/dsh/functionality.test.mjs
+++ b/tests/dsh/functionality.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {request, toolResult} from './dsh-test-helpers.mjs';
+
+test('MCP initializes and advertises the dsh tools', async () => {
+  const response = await request('initialize');
+  assert.equal(response.result.serverInfo.name, 'misakanet');
+  assert.ok(response.result.capabilities.tools);
+  const listed = await request('tools/list');
+  const names = listed.result.tools.map(tool => tool.name);
+  assert.ok(names.includes('misakanet_search'));
+  assert.ok(names.includes('misakanet_get_lesson'));
+});
+
+test('search discovers and fetches a lesson', async () => {
+  const search = toolResult(await request('tools/call', {name: 'misakanet_search', arguments: {query: 'CI pipeline', top: 3}}));
+  assert.ok(Array.isArray(search.results));
+  const lesson = toolResult(await request('tools/call', {name: 'misakanet_get_lesson', arguments: {path: 'lessons/ru/shell-script-debugging.md'}}));
+  assert.ok(lesson.content?.length > 10);
+});
+
+test('lesson index resource is readable', async () => {
+  const response = await request('resources/read', {uri: 'misaka://lessons/index'});
+  const text = response.result.contents?.[0]?.text;
+  assert.ok(text);
+  const index = JSON.parse(text);
+  assert.ok(index.count >= 0 && Array.isArray(index.lessons));
+});
+
+test('invalid tool input returns a structured error', async () => {
+  const result = toolResult(await request('tools/call', {name: 'misakanet_search', arguments: {}}));
+  assert.equal(result.error, 'query is required');
+});

--- a/tests/dsh/install.test.mjs
+++ b/tests/dsh/install.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {root} from './dsh-test-helpers.mjs';
+
+test('npm package declares a valid dsh bundle', async () => {
+  const pkg = JSON.parse(await readFile(`${root}/package.json`));
+  assert.equal(pkg.name, 'misakanet');
+  assert.match(pkg.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(pkg.dsh.bundle.patch, './cordis.patch.yml');
+  assert.equal(pkg.dsh.client.platform, 'web');
+});
+
+test('all supported installation entry points are documented', async () => {
+  const readme = await readFile(`${root}/README.md`, 'utf8');
+  for (const command of ['dsh plugin add misakanet', 'git+https://github.com/Ikalus1988/MisakaNet.git']) assert.match(readme, new RegExp(command.replace(/[.+]/g, '\\$&')));
+});

--- a/tests/dsh/install.test.mjs
+++ b/tests/dsh/install.test.mjs
@@ -13,5 +13,8 @@ test('npm package declares a valid dsh bundle', async () => {
 
 test('all supported installation entry points are documented', async () => {
   const readme = await readFile(`${root}/README.md`, 'utf8');
-  for (const command of ['dsh plugin add misakanet', 'git+https://github.com/Ikalus1988/MisakaNet.git']) assert.match(readme, new RegExp(command.replace(/[.+]/g, '\\$&')));
+  for (const command of ['dsh plugin add misakanet', 'git+https://github.com/Ikalus1988/MisakaNet.git']) {
+    const escaped = command.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+    assert.match(readme, new RegExp(escaped));
+  }
 });

--- a/tests/dsh/performance.test.mjs
+++ b/tests/dsh/performance.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {performance} from 'node:perf_hooks';
+import {request, toolResult} from './dsh-test-helpers.mjs';
+
+test('server startup and discovery complete within 10 seconds', async () => {
+  const start = performance.now();
+  const response = await request('tools/list');
+  assert.ok(response.result.tools.length > 0);
+  assert.ok(performance.now() - start < 10000);
+});
+
+test('concurrent searches return independent valid responses', async () => {
+  const responses = await Promise.all(['node', 'python', 'timeout', 'MCP'].map(query => request('tools/call', {name: 'misakanet_search', arguments: {query, top: 2}})));
+  for (const response of responses) {
+    const result = toolResult(response);
+    assert.ok(Array.isArray(result.results) || result.error);
+  }
+});


### PR DESCRIPTION
## Summary
- add installation, MCP functionality, compatibility, and performance integration tests
- exercise the real stdio JSON-RPC server, tool discovery, search/get lesson, resources, and error handling
- add cross-platform Node 18/20/22 CI matrix for Linux, macOS, and Windows

## Validation
- `node --test tests/dsh/*.test.mjs` (10 passed)
- `npm pack --dry-run` (package artifact validated)

Closes #1403

/claim #1403