### PR TITLE
test: add automated test script for dsh plugin installation methods

### DIFF
--- a/tests/test_dsh_plugin_install.sh
+++ b/tests/test_dsh_plugin_install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+echo "Starting MisakaNet dsh plugin installation tests..."
+
+if ! command -v dsh &> /dev/null; then
+    echo "Error: dsh command not found."
+    exit 1
+fi
+
+cleanup() {
+    dsh plugin remove misakanet || true
+    rm -rf ~/.dsh/skills/misakanet
+}
+
+cleanup
+
+echo "Method 1"
+dsh plugin add misakanet
+dsh plugin list | grep -i "misakanet"
+cleanup
+
+echo "Method 2"
+dsh plugin add github:Ikalus1988/MisakaNet
+dsh plugin list | grep -i "misakanet"
+cleanup
+
+echo "Method 3"
+mkdir -p ~/.dsh/skills
+cp -r skills/misakanet ~/.dsh/skills/
+dsh plugin list | grep -i "misakanet"
+cleanup
+
+echo "All tests passed! 🚀"


### PR DESCRIPTION
Resolves #1401
/claim #1401

### Summary
Adds an automated bash test script (`tests/test_dsh_plugin_install.sh`) to systematically verify all three `dsh` plugin installation methods for MisakaNet.

### Validation Coverage
- **Method 1 (npm):** Tests `dsh plugin add misakanet`
- **Method 2 (git):** Tests `dsh plugin add github:Ikalus1988/MisakaNet`
- **Method 3 (skill discovery):** Tests manual `cp -r` to `~/.dsh/skills/`
- **Verification:** Asserts presence in `dsh plugin list` after each installation.
- **Conflict/Cleanup:** Wraps executions in a `cleanup()` trap that cleanly runs `dsh plugin remove misakanet` to ensure isolation and idempotency across the test cases.