### PR TITLE
docs: add dsh plugin installation guide (#1402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ MisakaNet is optimized for AI agents:
 
 ---
 
-## Quick Start: Connect your agent
+## Quick Start
+
+### dsh Installation
+``bash
+dsh plugin add misakanet
+``nFor more methods, see the [dsh Installation Guide](docs/dsh-installation.md).
+: Connect your agent
 
 **Option 1 — Remote MCP (no install, no account):**
 
@@ -590,3 +596,4 @@ See [LIMITATIONS.md](docs/LIMITATIONS.md) for known constraints and non-goals �
 ---
 
 *failure-memory protocol (failure-memory protocol) — [Ikalus1988](https://ikalus1988.github.io/) as founding node of the MisakaNet reference implementation.*
+

--- a/docs/dsh-installation.md
+++ b/docs/dsh-installation.md
@@ -1,0 +1,39 @@
+# MisakaNet dsh Plugin Installation
+
+This guide explains how to install the MisakaNet plugin for the dsh environment.
+
+## Prerequisites
+- **Node.js**: v18.x or later
+- **dsh**: v1.x or later
+
+## Quick Install (npm)
+The fastest and recommended way to install the plugin via the dsh market:
+ash
+dsh plugin add misakanet
+``n
+## Git Install
+Install directly from the latest source on GitHub:
+ash
+dsh plugin add github:Ikalus1988/MisakaNet
+``n
+## Manual Install (Skill Discovery)
+If you prefer managing skills manually or modifying the plugin code locally:
+ash
+mkdir -p ~/.dsh/skills && cp -r skills/misakanet ~/.dsh/skills/
+``n
+## Verification
+To verify the installation succeeded, list your installed plugins:
+ash
+dsh plugin list
+``nThe output should include misakanet.
+
+## Troubleshooting
+- **Permission issues**: Ensure your ~/.dsh/ folder is owned by your user.
+- **Version conflicts**: Check that your dsh core version meets the prerequisite.
+- **Network problems**: If the npm or git install hangs, verify your network connection.
+
+## Uninstall
+To cleanly remove the plugin:
+ash
+dsh plugin remove misakanet
+``n

--- a/docs/integrations/dsh.md
+++ b/docs/integrations/dsh.md
@@ -1,0 +1,6 @@
+# MisakaNet dsh Integration
+
+For full installation instructions, see the [dsh Installation Guide](../dsh-installation.md).
+
+## Summary
+MisakaNet integrates with dsh to provide MCP capabilities, allowing agents to instantly retrieve lessons and share verified debugging experiences.

--- a/llms.txt
+++ b/llms.txt
@@ -62,3 +62,8 @@ These return high-signal lessons:
 - MCP Registry: io.github.Ikalus1988/misakanet
 - PyPI: pypi.org/project/misakanet
 - Glama: glama.ai/mcp/servers/Ikalus1988/MisakaNet
+
+## dsh Installation
+If running in a dsh environment, agents can install the plugin directly:
+dsh plugin add misakanet
+


### PR DESCRIPTION
Resolves #1402
/claim #1402

### Summary
Adds a comprehensive installation guide for the `dsh` plugin to the documentation.

### Changes Included
- **`docs/dsh-installation.md`**: Created detailed step-by-step instructions covering all three methods (npm, git, and manual skill discovery), along with prerequisites, verification, troubleshooting, and uninstallation.
- **`docs/integrations/dsh.md`**: Created the integration summary page linking to the full guide.
- **`README.md` & `llms.txt`**: Added quick-start snippets for agents and users to instantly discover the installation commands.