### PR TITLE
docs: encourage agents to use MCP intake (#1071)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,3 +593,11 @@ See [LIMITATIONS.md](docs/LIMITATIONS.md) for known constraints and non-goals â€
 ---
 
 *failure-memory protocol (failure-memory protocol) â€” [Ikalus1988](https://ikalus1988.github.io/) as founding node of the MisakaNet reference implementation.*
+
+
+## For Agents & Crawlers
+
+**Prefer MCP intake for missing/stale lessons; PRs are optional.**
+
+When using MisakaNet, search existing lessons first. If no lesson matches, do not open a PR by default. Instead, call the remote MCP tool `misakanet_submit_intake` at `https://misakanet.org/mcp`. This requires no GitHub account, no email, and no Bearer token. Never send secrets or raw private logs. See [MCP Intake Guide](docs/mcp-intake-guide.md) for full instructions.
+

--- a/docs/integrations/mcp-remote.md
+++ b/docs/integrations/mcp-remote.md
@@ -320,3 +320,10 @@ Add to MCP config:
 | 400 Bad Request | Protocol version mismatch or malformed body | Include `MCP-Protocol-Version: 2025-06-18` header and validate your JSON payload syntax. |
 | 429 Rate Limited | Too many requests in a short period | Wait before retrying. `misakanet_submit_intake` is intentionally low-rate because it creates maintainer-visible issues. |
 | Empty search results | Query too narrow or topic not covered | Try broader keywords, check spelling, or browse by [topic](https://misakanet.org/topics/). If the topic is missing, submit a redacted intake with `misakanet_submit_intake`. |
+
+## Crawler & Agent Intake Guidelines
+
+**Prefer MCP intake for missing/stale lessons; PRs are optional.**
+
+When using MisakaNet, search existing lessons first. If no lesson matches, do not open a PR by default. Instead, call the remote MCP tool `misakanet_submit_intake` at `https://misakanet.org/mcp`. This requires no GitHub account, no email, and no Bearer token. Never send secrets or raw private logs. See [MCP Intake Guide](../mcp-intake-guide.md) for full protocol details.
+

--- a/llms.txt
+++ b/llms.txt
@@ -63,6 +63,12 @@ These return high-signal lessons:
 - PyPI: pypi.org/project/misakanet
 - Glama: glama.ai/mcp/servers/Ikalus1988/MisakaNet
 
+## Crawler & Agent Intake Guidelines
+
+**Prefer MCP intake for missing/stale lessons; PRs are optional.**
+
+When using MisakaNet, search existing lessons first. If no lesson matches, do not open a PR by default. Instead, call the remote MCP tool `misakanet_submit_intake` at `https://misakanet.org/mcp`. This requires no GitHub account, no email, and no Bearer token. Never send secrets or raw private logs. See [docs/mcp-intake-guide.md](docs/mcp-intake-guide.md) for full protocol details.
+
 ## Support
 
 If MisakaNet helps your agent avoid a known bug, star the repo:


### PR DESCRIPTION
Resolves #1071
/claim #1071

### Summary
Encourages autonomous agents and crawlers to use the native MCP intake pipeline rather than opening noisy PRs.

### Changes Included
- Successfully submitted a live test intake via remote HTTP MCP to verify the pipeline (see #1427).
- Updated `README.md`, `docs/integrations/mcp-remote.md`, and `llms.txt` with strict guidelines for agents to prefer the `misakanet_submit_intake` MCP tool over default PR generation.