### PR TITLE
feat(lesson): add evidence_refs validation and doc support (#1439)

### DIFF
--- a/docs/lesson-checklist.md
+++ b/docs/lesson-checklist.md
@@ -35,6 +35,7 @@
 - [ ] **related lessons**：引用其他 lesson 时用相对路径
 - [ ] **适用环境说明**：若与环境相关，标注 `platform:wsl` / `platform:linux` / `platform:docker` 等
 - [ ] **来源标注**：`source` 字段填写贡献者标识而非泛称
+- [ ] **证据引用（evidence_refs）**：可选，提供可验证的证据来源（如 `repro:https://...`、`ci:https://...`、`issue:#1234`、`commit:<sha>` 或 URL）
 - [ ] **无超长行**：每行 <= 120 字符（代码块除外）
 - [ ] **英文用语**：术语统一（如 "root cause" 不混用 "reason"）
 

--- a/docs/trust-semantics.md
+++ b/docs/trust-semantics.md
@@ -94,6 +94,32 @@ Claiming "verified" when lessons are only "indexed" erodes trust when a lesson t
 
 To promote a lesson, edit `evidence_level` in its frontmatter in the same PR that carries the evidence (review comment, reproduction log, CI run link, or the usage report).
 
+### Evidence References (`evidence_refs`) (Issue #1439)
+
+Lessons can optionally specify `evidence_refs` in their frontmatter to declare verifiable evidence sources at contribution time:
+
+```yaml
+---
+title: "Fix ECONNRESET in Redis connection pool under load"
+domain: "devops"
+tags: ["redis", "connection-pool", "econnreset"]
+status: "published"
+evidence_level: "E3"
+evidence_refs:
+  - "ci:https://github.com/org/repo/actions/runs/12345678"
+  - "repro:https://gist.github.com/user/abcdef123456"
+  - "issue:#1439"
+  - "commit:a1b2c3d4e5f6"
+---
+```
+
+Supported formats:
+- `repro:https://...` — Link to reproduction logs / environment steps.
+- `ci:https://...` — Link to CI run or test action proving the fix.
+- `issue:#<num>` — Issue reference where the problem/fix is tracked.
+- `commit:<sha>` — Git commit SHA introducing the fix or reproduction test.
+- `https://...` — Direct URL to external public evidence/documentation.
+
 ### me_events: live reuse signals (tool-level semantics)
 
 `misakanet_me_events` aggregates a lesson's **live reuse evidence** — helpful votes (KV), regression-benchmark citations, and cross-node confirmations. It uses the E-level vocabulary as *signal strength*, not as the frontmatter promotion chain:

--- a/schemas/lesson.json
+++ b/schemas/lesson.json
@@ -4,7 +4,11 @@
   "title": "MisakaNet Lesson",
   "description": "Schema for validating MisakaNet lesson Markdown frontmatter",
   "type": "object",
-  "required": ["title", "domain", "status"],
+  "required": [
+    "title",
+    "domain",
+    "status"
+  ],
   "properties": {
     "title": {
       "type": "string",
@@ -19,7 +23,10 @@
     },
     "tags": {
       "type": "array",
-      "items": { "type": "string", "minLength": 2 },
+      "items": {
+        "type": "string",
+        "minLength": 2
+      },
       "minItems": 1,
       "maxItems": 10,
       "uniqueItems": true,
@@ -33,12 +40,22 @@
     },
     "status": {
       "type": "string",
-      "enum": ["published", "draft", "archived"],
+      "enum": [
+        "published",
+        "draft",
+        "archived"
+      ],
       "description": "Publication status"
     },
     "evidence_level": {
       "type": "string",
-      "enum": ["E0", "E1", "E2", "E3", "E4"],
+      "enum": [
+        "E0",
+        "E1",
+        "E2",
+        "E3",
+        "E4"
+      ],
       "default": "E0",
       "description": "How well this lesson is evidenced — E0 self-reported, E1 maintainer reviewed, E2 locally reproduced, E3 CI/sandbox verified, E4 reused by another contributor. Missing means E0. See docs/trust-semantics.md"
     },
@@ -60,34 +77,59 @@
       "properties": {
         "intents": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true,
           "description": "Agent intent keywords/actions that match this lesson"
         },
         "commands": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true,
           "description": "Shell commands, script names, or tools that trigger this lesson"
         },
         "environments": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true,
           "description": "Environment/OS/hardware tags (e.g. wsl, gpu, cuda, linux, docker)"
         },
         "risks": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true,
           "description": "Risk taxonomy tags (e.g. memory_pressure, no_checkpoint, batch_overflow, silent_failure)"
         },
         "severity": {
           "type": "string",
-          "enum": ["low", "medium", "high", "critical"],
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
           "description": "Risk severity level for this lesson"
         }
       }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^(repro:https?://.+|ci:https?://.+|issue:#[0-9]+|commit:[0-9a-fA-F]{7,40}|https?://.+)$"
+      },
+      "description": "Verifiable evidence sources for this lesson (repro logs, CI runs, issue numbers, commit SHAs, or URLs)."
     }
   }
 }

--- a/scripts/lesson_gate.py
+++ b/scripts/lesson_gate.py
@@ -116,6 +116,42 @@ def validate_evidence(evidence_level) -> list[str]:
     return []
 
 
+EVIDENCE_REF_RE = re.compile(
+    r"^(?:repro:https?://\S+|ci:https?://\S+|issue:#[0-9]+|commit:[0-9a-fA-F]{7,40}|https?://\S+)$"
+)
+
+
+def validate_evidence_refs(evidence_refs) -> list[str]:
+    """Validate evidence_refs field if present (Issue #1439).
+
+    Supported formats:
+      - repro:https://... (reproduction log)
+      - ci:https://... (CI run)
+      - issue:#1234 (issue reference)
+      - commit:<sha> (commit hash)
+      - https://... (direct URL)
+    """
+    if evidence_refs is None:
+        return []
+    if not isinstance(evidence_refs, list):
+        return ["evidence_refs must be a list of strings"]
+    errors = []
+    for ref in evidence_refs:
+        if not isinstance(ref, str):
+            errors.append(f"evidence_refs item must be a string, got {type(ref).__name__}")
+            continue
+        ref_str = ref.strip()
+        if not ref_str:
+            errors.append("evidence_refs item cannot be empty")
+            continue
+        if not EVIDENCE_REF_RE.match(ref_str):
+            errors.append(
+                f"invalid evidence_ref format: {ref!r} "
+                "(expected repro:https://..., ci:https://..., issue:#1234, commit:<sha>, or https://...)"
+            )
+    return errors
+
+
 def validate_content_len(content: str) -> bool:
     return len(content.strip()) >= MIN_CONTENT_CHARS
 
@@ -342,6 +378,7 @@ def validate_file(path: Path, repo: Path = REPO, dirs: tuple[str, ...] | None = 
         errors += validate_tags(fm.get("tags")) if "tags" in fm else []
         errors += validate_status(fm.get("status")) if "status" in fm else []
         errors += validate_evidence(fm.get("evidence_level")) if "evidence_level" in fm else []
+        errors += validate_evidence_refs(fm.get("evidence_refs")) if "evidence_refs" in fm else []
 
     if not validate_content_len(content):
         errors.append(f"content too short (< {MIN_CONTENT_CHARS} chars excluding frontmatter)")

--- a/scripts/update_lessons_json.py
+++ b/scripts/update_lessons_json.py
@@ -138,6 +138,10 @@ def main():
             confidence = meta.get("confidence", 0.5)
             if not isinstance(confidence, (int, float)):
                 confidence = 0.5
+            evidence_refs = meta.get("evidence_refs", [])
+            if not isinstance(evidence_refs, list):
+                evidence_refs = [evidence_refs] if evidence_refs else []
+
             entries.append({
                 "id": f.stem,
                 "title": title,
@@ -156,6 +160,7 @@ def main():
                 "verified": verified,
                 "evidence_level": evidence_level,
                 "evidence_source": evidence_source,
+                "evidence_refs": evidence_refs,
                 # trust = quality(confidence) scaled by evidence (E0 keeps 70%,
                 # E4 keeps 100%) — shown on search pages instead of a composite.
                 "trust_score": trust_score(confidence, evidence_level),

--- a/tests/test_lesson_gate.py
+++ b/tests/test_lesson_gate.py
@@ -23,6 +23,7 @@ from scripts.lesson_gate import (  # noqa: E402
     parse_frontmatter,
     validate_content_len,
     validate_evidence,
+    validate_evidence_refs,
     validate_file,
     validate_required,
     validate_status,
@@ -137,6 +138,34 @@ class TestStatusAndEvidence:
 
     def test_valid_evidence_passes(self):
         assert not validate_evidence("E0")
+
+    @pytest.mark.parametrize("good_ref", [
+        "repro:https://gist.github.com/abc/123",
+        "ci:https://github.com/org/repo/actions/runs/12345",
+        "issue:#1234",
+        "commit:a1b2c3d",
+        "commit:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "https://example.com/logs/run.txt"
+    ])
+    def test_valid_evidence_refs_pass(self, good_ref):
+        assert not validate_evidence_refs([good_ref])
+
+    @pytest.mark.parametrize("bad_ref", [
+        "not_a_valid_ref",
+        "issue:1234",
+        "commit:invalidsha!",
+        "repro:ftp://something",
+        "",
+        123
+    ])
+    def test_invalid_evidence_refs_fail(self, bad_ref):
+        assert validate_evidence_refs([bad_ref])
+
+    def test_evidence_refs_none_passes(self):
+        assert not validate_evidence_refs(None)
+
+    def test_evidence_refs_not_list_fails(self):
+        assert validate_evidence_refs("issue:#123")
 
 
 # ── content length ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Resolves #1439.

This PR adds support for evidence-backed lesson submissions by introducing the optional `evidence_refs` field in lesson frontmatter.

### Changes
1. **Schema**: Added `evidence_refs` array validation to `schemas/lesson.json`.
2. **Quality Gate (`scripts/lesson_gate.py`)**:
   - Added `validate_evidence_refs` to check format of each item:
     - `repro:https://...`
     - `ci:https://...`
     - `issue:#1234`
     - `commit:<sha>`
     - `https://...`
   - Integrated into `validate_file`.
3. **Data Generator (`scripts/update_lessons_json.py`)**: Exposes `evidence_refs` for search/UI consumption in `data/lessons.json`.
4. **Documentation**:
   - Added `evidence_refs` guide to `docs/trust-semantics.md`.
   - Added checklist item to `docs/lesson-checklist.md`.
5. **Unit Tests**: Added comprehensive test cases in `tests/test_lesson_gate.py` (59 passed).

/claim #1439
