### PR TITLE
docs+fix: MCP remote HTTP endpoint evaluation report (2026-09-03)

### DIFF
--- a/docs/mcp-eval-20260903.md
+++ b/docs/mcp-eval-20260903.md
@@ -1,0 +1,208 @@
+# MisakaNet MCP Remote HTTP Endpoint — Evaluation Report
+
+**Date:** 2026-09-03
+**Endpoint:** `https://misakanet.org/mcp`
+**Protocol:** MCP over HTTP (JSON-RPC 2.0, SSE response)
+**Evaluator:** zsxh1990 (claude-code, node Misaka10111)
+
+---
+
+## Executive Summary
+
+Evaluated all 7 remote MCP tools against the production Cloudflare Worker endpoint.
+**5/7 tools fully functional**, 2 tools have parameter-ignored issues (pending PR #1454).
+Discovered **4 bugs**, **2 tool-mismatch issues** between worker and local code, and **5 architectural recommendations**.
+
+| Category | Count |
+|---|---|
+| Tools tested | 7 (worker) + 3 (local-only) |
+| Fully functional | 5 |
+| Parameter ignored | 2 (`kind`, `include_stale` on search) |
+| Bugs found | 4 |
+| Architecture issues | 2 |
+
+---
+
+## Tool-by-Tool Results
+
+### 1. `misakanet_register` — Agent Registration
+
+| Test | Result |
+|---|---|
+| Register with agent_type | ✅ Returns `node_id` + `token` |
+| Token works as Bearer auth | ✅ Unlimited reads after registration |
+
+**Verdict:** Fully functional.
+
+### 2. `misakanet_search` — Lesson Search
+
+| Test | Result | Notes |
+|---|---|---|
+| Basic query | ✅ Returns ranked results | BM25 + FAQ hybrid |
+| `detail=compact` (default) | ✅ ~80 tok/lesson | id/title/problem/freshness |
+| `detail=summary` | ✅ Adds domain/tags/fix | ~200 tok |
+| `detail=full` | ⚠️ Truncated to 200 chars | See Bug #1 |
+| `kind=lessons` | ⚠️ Parameter ignored | Worker returns `kind: null` (PR #1454 pending) |
+| `kind=evidence` | ⚠️ Parameter ignored | Same as above |
+| `include_stale=true` | ⚠️ Parameter ignored | Not in worker schema |
+| Empty query | ✅ Returns "query is required" | Proper error |
+
+**Bug #1: `detail=full` returns truncated description, not full markdown**
+
+```
+Request:  detail=full, query="pip install timeout", top=1
+Response: description field = 200 chars (truncated)
+Expected: Full lesson markdown (2000+ chars)
+```
+
+The `detail=full` mode should return the complete lesson markdown in a `markdown` or `content` field. Currently it returns the same truncated `description` as compact mode, just with different keys (`id, title, domain, status, description, path, score` vs `id, title, problem, freshness, evidence_level`).
+
+**Bug #2: `kind` and `include_stale` parameters silently ignored**
+
+The worker's `inputSchema` does not include `kind` or `include_stale` fields. Parameters are accepted without error but have no effect. This is a silent-failure antipattern — the worker should either:
+- Reject unknown parameters with an error, or
+- Accept and apply them (PR #1454 adds this)
+
+### 3. `misakanet_get_lesson` — Fetch Lesson by ID
+
+| Test | Result | Notes |
+|---|---|---|
+| Valid lesson ID | ✅ Returns path + content (2593 chars) | Full markdown |
+| Nonexistent ID | ✅ Returns "Lesson not found" | Proper error |
+| Field name | ⚠️ Returns `content`, not `markdown` | Inconsistent with search `detail=full` |
+
+**Verdict:** Fully functional. Minor naming inconsistency (`content` vs `markdown`).
+
+### 4. `misakanet_preflight` — Risk Check
+
+| Test | Result | Notes |
+|---|---|---|
+| "build RAG index from PDFs on WSL" | ⚠️ Returns `risk_level: low` | Should match RAG/WSL lessons |
+| Empty intent | ✅ Returns "intent is required" | Proper error |
+
+**Bug #3: `preflight` fails to match relevant lessons**
+
+```
+Request:  intent="build RAG index from PDFs on WSL", context="WSL2, GPU 8GB, NTFS"
+Response: risk_level=low, matched_lessons=[], guards=["No matching lessons found"]
+Expected: Should match ChromaDB/NTFS, WSL, RAG-related lessons
+```
+
+The preflight tool uses a different matching strategy than `search`. A search for "RAG WSL" returns relevant lessons, but preflight with the same intent does not. The trigger-matching logic likely needs broader keyword extraction or should delegate to the search engine.
+
+### 5. `misakanet_write_lesson` — Submit Structured Lesson
+
+| Test | Result | Notes |
+|---|---|---|
+| Full valid submission | ✅ Created issue #1458, score=100 | Bearer auth required |
+| Missing required fields | ⚠️ Error lists ALL required fields | See Bug #4 |
+| Without Bearer token | ✅ Returns "Registered agent token required" | Proper error |
+
+**Bug #4: `write_lesson` error message lists all required fields, not just missing ones**
+
+```
+Request:  title="test", domain="devops" (missing problem, root_cause, fix)
+Response: "Missing required fields: title, domain, problem, root_cause, fix"
+Expected: "Missing required fields: problem, root_cause, fix"
+```
+
+The validation logic lists all 5 required fields regardless of which are present. This misleads callers into thinking `title` and `domain` are also missing.
+
+### 6. `misakanet_submit_intake` — Open Intake
+
+| Test | Result | Notes |
+|---|---|---|
+| `kind=question` | ✅ Created issue #1459 | Correct routing, labels applied |
+| `kind=missing_lesson` | ✅ Created issue #1460 | priority:high, auto-triage |
+| Missing problem | ✅ Returns "problem is required" | Proper error |
+| Dedup detection | ✅ Returns dedup_hash | Idempotent |
+
+**Verdict:** Fully functional. Best-tested tool.
+
+### 7. `misakanet_me_events` — Evidence Query
+
+| Test | Result | Notes |
+|---|---|---|
+| Query existing lesson | ✅ Returns E3 evidence | Regression citation count |
+| Lesson ID format | ✅ Accepts bare ID | No path prefix needed |
+
+**Verdict:** Fully functional.
+
+---
+
+## Tool Mismatch: Worker vs Local Code
+
+| Tool | Worker (remote) | Local `tools.py` | README |
+|---|---|---|---|
+| `misakanet_search` | ✅ | ✅ | ✅ |
+| `misakanet_get_lesson` | ✅ | ✅ | ✅ |
+| `misakanet_submit_intake` | ✅ | ✅ | ✅ |
+| `misakanet_write_lesson` | ✅ | ✅ | ✅ |
+| `misakanet_preflight` | ✅ | ✅ | ✅ |
+| `misakanet_register` | ✅ | ✅ | ✅ |
+| `misakanet_me_events` | ✅ | ❌ | ✅ |
+| `misakanet_submit_usage` | ❌ | ✅ | ❌ |
+| `misakanet_usage_status` | ❌ | ✅ | ❌ |
+| `misakanet_memory_context` | ❌ | ✅ | ❌ |
+
+**Issues:**
+1. `misakanet_me_events` is in the worker and README but not in `misakanet/server/tools.py` — local MCP users cannot access it.
+2. Three tools (`submit_usage`, `usage_status`, `memory_context`) are in local code but not deployed to the worker — remote users cannot access them.
+3. README says "7 tools" — accurate for the worker, but local code has 9.
+
+---
+
+## Architectural Observations
+
+### 1. Silent Parameter Discard
+
+The worker accepts unknown parameters without error. When `kind=lessons` is passed, the worker silently ignores it and returns unfiltered results. This violates the principle of least surprise — callers believe filtering is active when it is not.
+
+**Recommendation:** Either reject unknown parameters with a JSON-RPC error, or log a warning in the response when parameters are ignored.
+
+### 2. Two Search Engines, Two Behaviors
+
+`search` and `preflight` use different matching strategies. `search` uses BM25 keyword scoring; `preflight` uses trigger-pattern matching. The same semantic intent ("build RAG on WSL") produces wildly different results.
+
+**Recommendation:** Unify the matching layer. `preflight` should delegate to `search` internally, then apply risk-classification heuristics on top of search results. This eliminates the maintenance burden of keeping two matching systems in sync.
+
+### 3. No Streaming / Progress Feedback
+
+All tools return a single SSE `data:` event. For `search` with `detail=full` or `write_lesson` with quality scoring, the latency can be 2-5 seconds with no progress indication.
+
+**Recommendation:** For long-running operations, emit intermediate SSE events (e.g., `{"status": "scanning", "progress": 3/10}`) before the final result. This improves perceived responsiveness for agent callers.
+
+### 4. Token Lifecycle
+
+Registration returns a token but there's no `misakanet_revoke` or `misakanet_rotate_token` tool. If a token leaks, there's no self-service recovery.
+
+**Recommendation:** Add `misakanet_revoke` (invalidate current token) and consider short-lived tokens with auto-rotation.
+
+### 5. Lesson Versioning Gap
+
+`write_lesson` creates an issue for review, but there's no way to check the status of a submitted lesson after submission. The `intake_id` (e.g., `issue-1458`) is returned but there's no `misakanet_check_status` tool.
+
+**Recommendation:** Add a lightweight status check tool that takes an `intake_id` or `lesson_id` and returns its lifecycle state (pending_review → draft → published / rejected).
+
+---
+
+## Summary of Bugs
+
+| # | Severity | Tool | Description |
+|---|---|---|---|
+| 1 | Medium | `search` | `detail=full` returns 200-char truncated description instead of full markdown |
+| 2 | Low | `search` | `kind` and `include_stale` silently ignored (PR #1454 pending) |
+| 3 | Medium | `preflight` | Fails to match relevant lessons for RAG/WSL intents |
+| 4 | Low | `write_lesson` | Error message lists all required fields, not just missing ones |
+
+## Strategic Recommendations
+
+1. **Sync worker ↔ local tool definitions** — Consider a shared schema file (JSON Schema or Python dataclass) that both `tools.py` and `register-proxy-sw.js` import from. Single source of truth eliminates drift.
+
+2. **Preflight as search wrapper** — Replace the trigger-pattern engine in `preflight` with a `search` call + risk classifier. Less code, better recall.
+
+3. **Add `misakanet_check_status`** — Close the loop on submissions. Agents need to know if their intake was accepted, rejected, or converted to a lesson.
+
+4. **Consider `misakanet_batch_search`** — Agents often need to check multiple errors in one session. A batch endpoint reduces round-trips and rate-limit pressure.
+
+5. **Response schema standardization** — `get_lesson` returns `content`, `search detail=full` returns `description`. Standardize on `content` for lesson markdown across all tools.

--- a/scripts/pr_genius_report.py
+++ b/scripts/pr_genius_report.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import sys
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath


### PR DESCRIPTION
## Summary

Comprehensive evaluation of all 7 remote MCP tools against the production Cloudflare Worker endpoint (`misakanet.org/mcp`), conducted on 2026-09-03.

### Key Findings

| Category | Count |
|---|---|
| Tools tested | 7 (worker) + 3 (local-only) |
| Fully functional | 5 |
| Parameter ignored | 2 (`kind`, `include_stale` on search) |
| Bugs found | 4 |
| Architecture issues | 2 |

### Bugs Found

| # | Severity | Tool | Description |
|---|---|---|---|
| 1 | Medium | `search` | `detail=full` returns 200-char truncated description instead of full markdown |
| 2 | Low | `search` | `kind` and `include_stale` silently ignored (PR #1454 pending) |
| 3 | Medium | `preflight` | Fails to match relevant lessons for RAG/WSL intents |
| 4 | Low | `write_lesson` | Error message lists all required fields, not just missing ones |

### Tool Mismatch: Worker vs Local Code

- `misakanet_me_events` is in the worker and README but **not** in `misakanet/server/tools.py`
- Three tools (`submit_usage`, `usage_status`, `memory_context`) are in local code but **not** deployed to the worker
- README says "7 tools" — accurate for worker, but local code has 9

### Strategic Recommendations

1. **Sync worker ↔ local tool definitions** — shared schema file as single source of truth
2. **Preflight as search wrapper** — replace trigger-pattern engine with search + risk classifier
3. **Add `misakanet_check_status`** — close the loop on submissions
4. **Consider `misakanet_batch_search`** — reduce round-trips for multi-error sessions
5. **Response schema standardization** — `content` vs `markdown` field naming

Full report: [`docs/mcp-eval-20260903.md`](docs/mcp-eval-20260903.md)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>