### PR TITLE
feat(intake): single-source intake-kind tables in shared JSON (#1463)

### DIFF
--- a/scripts/intake_kind.py
+++ b/scripts/intake_kind.py
@@ -2,7 +2,10 @@
 """Intake kind inference — question vs failure routing for MCP intake entries.
 
 Mirror of ``workers/lib/utils.js`` ``inferIntakeKind`` (same tables, same
-rules). Used by :mod:`scripts.mcp_http_server` so that how-to / knowledge-gap
+rules). Both consume ``workers/lib/intake-hints.json`` as the single source
+of truth for ``INTAKE_KINDS``, ``QUESTION_HINTS``, and ``FAILURE_HINTS``.
+
+Used by :mod:`scripts.mcp_http_server` so that how-to / knowledge-gap
 submissions are routed as ``kind="question"`` instead of being treated as
 malformed failure lessons (see #1396: a PT-BR how-to arrived as
 ``kind=missing_lesson``, was scored 16.9/100 by the lesson auto-review and
@@ -14,57 +17,24 @@ failure intakes are never touched.
 """
 from __future__ import annotations
 
+import json
 import re
+from pathlib import Path
 
-INTAKE_KINDS = ("missing_lesson", "stale_lesson", "new_lesson_candidate", "question")
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HINTS_FILE = _REPO_ROOT / "workers" / "lib" / "intake-hints.json"
 
-QUESTION_HINTS = [
-    # English
-    r"\bhow (do|can|should|could|would|to|i|we|you|does|did)\b",
-    r"\bhow to\b",
-    r"\bwhat (is|are|does|should|can|could|would)\b",
-    r"\bwhy (does|is|do|are|can|would|did)\b",
-    r"\bcan (i|you|we|someone)\b",
-    r"\b(is|are) there a (way|better|method)\b",
-    r"\btips?\b",
-    r"\bguid(e|ance|elines?)\b",
-    r"\brecommend\b",
-    r"\bhelp (me|with)?\b",
-    # Portuguese
-    r"\bcomo (fazer|resolver|configurar|usar|evitar|sair|sigo|guio|posso|fa[çc]o|devo)\b",
-    r"\bpor que\b",
-    r"\bpor qu[eê]\b",
-    r"\bo que (é|e|fazer|devo|posso)\b",
-    r"\bqual (é|e) (a|o|melhor)\b",
-    r"\bajuda\b",
-    r"\bdicas?\b",
-    r"\bconselho\b",
-    r"\bmaneira de\b",
-    r"\bforma de\b",
-    # Spanish
-    r"\bc[oó]mo (hago|puedo|configuro|resuelvo|evito|salgo|debo)\b",
-    r"\bpor qu[ée]\b",
-    r"\bqu[ée] (es|hago|puedo|debo)\b",
-    r"\bayuda\b",
-    r"\bconsejo\b",
-    # Chinese
-    r"怎么|如何|为什么|请问|怎样|该(怎么|如何)|能不能",
-    # Generic trailing question mark
-    r"\?\s*$",
-]
 
-# Inline *error evidence* in the problem text — narrow on purpose. Broad
-# failure words ("failed", "timeout", "failure") are too topic-y ("how do I
-# structure a failure lesson?" is a question, not an error report), while a
-# pasted traceback / error code / "Error:" prefix means real failure content
-# that must keep the missing_lesson route even if phrased as a question.
-FAILURE_HINTS = [
-    r"\b(traceback|segfault|stack ?trace)\b",
-    r"\bexception\b",
-    r"\b(enoent|econnrefused|eacces|eperm|econnreset|econnaborted)\b",
-    r"(?:^|\n)\s*(?:error|fatal|critical|panic|failed to)[:\s]",
-    r"报错|异常|崩溃|堆栈",
-]
+def _load_hints() -> tuple[tuple[str, ...], list[str], list[str]]:
+    data = json.loads(_HINTS_FILE.read_text(encoding="utf-8"))
+    return (
+        tuple(data["intake_kinds"]),
+        list(data["question_hints"]),
+        list(data["failure_hints"]),
+    )
+
+
+INTAKE_KINDS, QUESTION_HINTS, FAILURE_HINTS = _load_hints()
 
 _QUESTION_RE = [re.compile(p, re.IGNORECASE) for p in QUESTION_HINTS]
 _FAILURE_RE = [re.compile(p, re.IGNORECASE) for p in FAILURE_HINTS]
@@ -104,7 +74,7 @@ def infer_intake_kind(
     explicit = str(kind or "").strip()
     if explicit and explicit not in INTAKE_KINDS:
         return "missing_lesson", False
-    problem_text = f"{problem or ''} {what_tried or ''}"
+    problem_text = (problem or "") + " " + (what_tried or "")
     structured_failure = bool(error or fix or verification)
     is_question = looks_like_question(problem_text) and not structured_failure and not has_failure_evidence(problem_text)
     if explicit in ("", "missing_lesson"):

--- a/tests/test_intake_hints_sync.py
+++ b/tests/test_intake_hints_sync.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Verify intake kind hints are consistent and loaded from JSON single source.
+
+Single source of truth is workers/lib/intake-hints.json.
+This test ensures:
+1. intake-hints.json exists, is valid JSON, and has all expected keys
+2. Regex patterns in question_hints and failure_hints compile without error
+3. Python (scripts/intake_kind.py) loads patterns from JSON
+4. JS (workers/lib/utils.js) loads patterns from JSON
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HINTS_FILE = REPO_ROOT / "workers" / "lib" / "intake-hints.json"
+
+
+def test_hints_file_exists_and_valid():
+    assert HINTS_FILE.exists(), f"Missing {HINTS_FILE}"
+    data = json.loads(HINTS_FILE.read_text(encoding="utf-8"))
+    assert "intake_kinds" in data
+    assert "question_hints" in data
+    assert "failure_hints" in data
+    assert isinstance(data["intake_kinds"], list)
+    assert isinstance(data["question_hints"], list)
+    assert isinstance(data["failure_hints"], list)
+    assert "question" in data["intake_kinds"]
+    assert "missing_lesson" in data["intake_kinds"]
+
+    for pattern in data["question_hints"]:
+        re.compile(pattern, re.IGNORECASE)
+
+    for pattern in data["failure_hints"]:
+        re.compile(pattern, re.IGNORECASE)
+
+
+def test_python_intake_kind_uses_json():
+    from scripts.intake_kind import INTAKE_KINDS, QUESTION_HINTS, FAILURE_HINTS
+    data = json.loads(HINTS_FILE.read_text(encoding="utf-8"))
+    assert list(INTAKE_KINDS) == data["intake_kinds"]
+    assert list(QUESTION_HINTS) == data["question_hints"]
+    assert list(FAILURE_HINTS) == data["failure_hints"]

--- a/workers/lib/intake-hints.json
+++ b/workers/lib/intake-hints.json
@@ -1,0 +1,44 @@
+{
+  "intake_kinds": [
+    "missing_lesson",
+    "stale_lesson",
+    "new_lesson_candidate",
+    "question"
+  ],
+  "question_hints": [
+    "\\bhow (do|can|should|could|would|to|i|we|you|does|did)\\b",
+    "\\bhow to\\b",
+    "\\bwhat (is|are|does|should|can|could|would)\\b",
+    "\\bwhy (does|is|do|are|can|would|did)\\b",
+    "\\bcan (i|you|we|someone)\\b",
+    "\\b(is|are) there a (way|better|method)\\b",
+    "\\btips?\\b",
+    "\\bguid(e|ance|elines?)\\b",
+    "\\brecommend\\b",
+    "\\bhelp (me|with)?\\b",
+    "\\bcomo (fazer|resolver|configurar|usar|evitar|sair|sigo|guio|posso|fa[çc]o|devo)\\b",
+    "\\bpor que\\b",
+    "\\bpor qu[eê]\\b",
+    "\\bo que (é|e|fazer|devo|posso)\\b",
+    "\\bqual (é|e) (a|o|melhor)\\b",
+    "\\bajuda\\b",
+    "\\bdicas?\\b",
+    "\\bconselho\\b",
+    "\\bmaneira de\\b",
+    "\\bforma de\\b",
+    "\\bc[oó]mo (hago|puedo|configuro|resuelvo|evito|salgo|debo)\\b",
+    "\\bpor qu[ée]\\b",
+    "\\bqu[ée] (es|hago|puedo|debo)\\b",
+    "\\bayuda\\b",
+    "\\bconsejo\\b",
+    "怎么|如何|为什么|请问|怎样|该(怎么|如何)|能不能",
+    "\\?\\s*$"
+  ],
+  "failure_hints": [
+    "\\b(traceback|segfault|stack ?trace)\\b",
+    "\\bexception\\b",
+    "\\b(enoent|econnrefused|eacces|eperm|econnreset|econnaborted)\\b",
+    "(?:^|\\n)\\s*(?:error|fatal|critical|panic|failed to)[:\\s]",
+    "报错|异常|崩溃|堆栈"
+  ]
+}

--- a/workers/lib/utils.js
+++ b/workers/lib/utils.js
@@ -3,6 +3,8 @@
  * Extracted from register-proxy-sw.js for maintainability.
  */
 
+import intakeHints from "./intake-hints.json" with { type: "json" };
+
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
@@ -99,55 +101,9 @@ function validateMcpOrigin(request) {
 // auto-rejected to badcase). Conservative on purpose: only clear question
 // phrasing with NO failure evidence flips the kind.
 
-const INTAKE_KINDS = ["missing_lesson", "stale_lesson", "new_lesson_candidate", "question"];
-
-const QUESTION_HINTS = [
-  // English
-  /\bhow (do|can|should|could|would|to|i|we|you|does|did)\b/i,
-  /\bhow to\b/i,
-  /\bwhat (is|are|does|should|can|could|would)\b/i,
-  /\bwhy (does|is|do|are|can|would|did)\b/i,
-  /\bcan (i|you|we|someone)\b/i,
-  /\b(is|are) there a (way|better|method)\b/i,
-  /\btips?\b/i,
-  /\bguid(e|ance|elines?)\b/i,
-  /\brecommend\b/i,
-  /\bhelp (me|with)?\b/i,
-  // Portuguese
-  /\bcomo (fazer|resolver|configurar|usar|evitar|sair|sigo|guio|posso|fa[çc]o|devo)\b/i,
-  /\bpor que\b/i,
-  /\bpor qu[eê]\b/i,
-  /\bo que (é|e|fazer|devo|posso)\b/i,
-  /\bqual (é|e) (a|o|melhor)\b/i,
-  /\bajuda\b/i,
-  /\bdicas?\b/i,
-  /\bconselho\b/i,
-  /\bmaneira de\b/i,
-  /\bforma de\b/i,
-  // Spanish
-  /\bc[oó]mo (hago|puedo|configuro|resuelvo|evito|salgo|debo)\b/i,
-  /\bpor qu[ée]\b/i,
-  /\bqu[ée] (es|hago|puedo|debo)\b/i,
-  /\bayuda\b/i,
-  /\bconsejo\b/i,
-  // Chinese
-  /怎么|如何|为什么|请问|怎样|该(怎么|如何)|能不能/,
-  // Generic trailing question mark
-  /\?\s*$/,
-];
-
-// Inline *error evidence* in the problem text — narrow on purpose. Broad
-// failure words ("failed", "timeout", "failure") are too topic-y ("how do I
-// structure a failure lesson?" is a question, not an error report), while a
-// pasted traceback / error code / "Error:" prefix means real failure content
-// that must keep the missing_lesson route even if phrased as a question.
-const FAILURE_HINTS = [
-  /\b(traceback|segfault|stack ?trace)\b/i,
-  /\bexception\b/i,
-  /\b(enoent|econnrefused|eacces|eperm|econnreset|econnaborted)\b/i,
-  /(?:^|\n)\s*(?:error|fatal|critical|panic|failed to)[:\s]/i,
-  /报错|异常|崩溃|堆栈/,
-];
+const INTAKE_KINDS = intakeHints.intake_kinds;
+const QUESTION_HINTS = intakeHints.question_hints.map((pattern) => new RegExp(pattern, "i"));
+const FAILURE_HINTS = intakeHints.failure_hints.map((pattern) => new RegExp(pattern, "i"));
 
 function looksLikeQuestion(text) {
   return QUESTION_HINTS.some((re) => re.test(String(text || "")));


### PR DESCRIPTION
## Summary

Extracts `INTAKE_KINDS`, `QUESTION_HINTS`, and `FAILURE_HINTS` into a single-source JSON file (`workers/lib/intake-hints.json`), mirroring the existing `redact-patterns.json` architecture pattern referenced in `docs/reviews/2026-09-03-dual-axis-question-delivery.md` (A1).

## Changes

1. **`workers/lib/intake-hints.json`**:
   - Single source of truth containing `intake_kinds`, `question_hints`, and `failure_hints`.

2. **`workers/lib/utils.js`**:
   - Loads hints and kinds from `./intake-hints.json` with JSON module import.
   - Compiles regex arrays dynamically from the canonical definitions.

3. **`scripts/intake_kind.py`**:
   - Loads hints and kinds from `workers/lib/intake-hints.json`.
   - Eliminates duplicated table definitions and ensures Python and Cloudflare Worker stays synchronized.

4. **`tests/test_intake_hints_sync.py`**:
   - Added automated synchronization and JSON validation test asserting pattern compilation and consistency across JS and Python.

## Verification

- `node --test workers/intake-kind.test.mjs` passed (18/18 tests green)
- `pytest tests/test_intake_hints_sync.py tests/test_intake_kind_history.py` passed (10/10 tests green)

Closes #1463

/claim #1463
