### PR TITLE
feat(ops): trigger sync_answered_questions.py on answered label/close (#1462)

### DIFF
--- a/.github/workflows/sync-question-answers.yml
+++ b/.github/workflows/sync-question-answers.yml
@@ -8,13 +8,34 @@ name: Sync Question Answers
 on:
   schedule:
     - cron: '20 7 * * *'  # Daily 07:20 UTC
+  issues:
+    types: [labeled, closed]
   workflow_dispatch:
+    inputs:
+      issue:
+        description: "Specific issue number to sync"
+        required: false
+        type: string
+
+concurrency:
+  group: sync-question-answers-${{ github.event.issue.number || 'all' }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
   sync:
+    # Trigger on:
+    # 1. Scheduled daily cron
+    # 2. Manual workflow_dispatch
+    # 3. 'labeled' event when label is 'answered'
+    # 4. 'closed' event when issue has 'answered' label
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'answered') ||
+      (github.event_name == 'issues' && github.event.action == 'closed' && contains(github.event.issue.labels.*.name, 'answered'))
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,5 +49,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Sync question answers to D1
+      - name: Sync single question answer to D1
+        if: github.event_name == 'issues' || (github.event_name == 'workflow_dispatch' && inputs.issue != '')
+        run: |
+          ISSUE_NUM="${{ github.event.issue.number || inputs.issue }}"
+          python3 scripts/sync_answered_questions.py --issue "$ISSUE_NUM"
+
+      - name: Sync all question answers to D1 (batch/cron)
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.issue == '' || inputs.issue == null))
         run: python3 scripts/sync_answered_questions.py


### PR DESCRIPTION
## Summary
Closes #1462.
/claim #1462

This PR introduces an event-driven workflow trigger for `scripts/sync_answered_questions.py` to close the answer-delivery latency window (from up to 24h daily cron down to sub-minute):

### Changes
1. **Event Triggers**:
   - Added `issues: types: [labeled, closed]` to `.github/workflows/sync-question-answers.yml`.
   - Filtered on `labeled` event when label is `answered`.
   - Filtered on `closed` event when issue carries the `answered` label.
2. **Targeted Execution**:
   - For issue events or `workflow_dispatch` with an issue number, executes `python3 scripts/sync_answered_questions.py --issue <NUM>`.
   - For scheduled cron or batch dispatch, runs the full batch sync.
3. **Concurrency Guard**:
   - Added concurrency group `sync-question-answers-${{ github.event.issue.number || 'all' }}` with `cancel-in-progress: false` to ensure no duplicate runs or race conditions during rapid label updates.

### Verification
- Validated workflow YAML syntax and structure against existing repository actions.
- Preserved existing secrets (`GH_TOKEN`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and Python 3.12 environment setup.
