### PR TITLE
docs: Add dsh plugin installation guide

### DIFF
--- a/docs/dsh-installation.md
+++ b/docs/dsh-installation.md
@@ -1,0 +1,174 @@
+# MisakaNet dsh Plugin Installation
+
+## Quick Install
+
+```bash
+dsh plugin add misakanet
+```
+
+## Alternative Installation Methods
+
+### Git Install
+
+```bash
+dsh plugin add github:Ikalus1988/MisakaNet
+```
+
+### Manual Install (Skill Discovery)
+
+```bash
+mkdir -p ~/.dsh/skills
+cp -r skills/misakanet ~/.dsh/skills/
+```
+
+## Prerequisites
+
+| Requirement | Minimum Version |
+|-------------|----------------|
+| dsh | 1.0.0 |
+| Node.js | 18.0.0 |
+| Git | 2.0 (for git method) |
+
+## Step-by-Step Guide
+
+### Method 1: npm Plugin Market (Recommended)
+
+1. Open your terminal
+2. Run the installation command:
+   ```bash
+   dsh plugin add misakanet
+   ```
+3. Wait for the download to complete
+4. Verify the installation:
+   ```bash
+   dsh plugin list
+   ```
+   You should see `misakanet` in the output.
+
+### Method 2: Git Repository
+
+1. Ensure Git is installed on your system
+2. Run the git installation command:
+   ```bash
+   dsh plugin add github:Ikalus1988/MisakaNet
+   ```
+3. The plugin will be automatically cloned and registered
+4. Verify with `dsh plugin list`
+
+### Method 3: Manual Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Ikalus1988/MisakaNet.git
+   cd MisakaNet
+   ```
+2. Create the skills directory:
+   ```bash
+   mkdir -p ~/.dsh/skills
+   ```
+3. Copy the plugin:
+   ```bash
+   cp -r skills/misakanet ~/.dsh/skills/
+   ```
+4. Verify with `dsh plugin list`
+
+## Verification
+
+After installation, verify everything is working:
+
+```bash
+# Check plugin is listed
+dsh plugin list
+
+# Test MCP tools are accessible
+dsh tool list | grep misakanet
+```
+
+## Troubleshooting
+
+### Permission Denied
+
+```bash
+# Fix directory permissions
+chmod -R 755 ~/.dsh/skills
+
+# Or use sudo (not recommended for npm)
+sudo dsh plugin add misakanet
+```
+
+### Plugin Not Found After Installation
+
+1. Restart your terminal session
+2. Check the plugin directory exists:
+   ```bash
+   ls -la ~/.dsh/skills/misakanet
+   ```
+3. Reinstall if needed:
+   ```bash
+   dsh plugin remove misakanet
+   dsh plugin add misakanet
+   ```
+
+### Version Conflicts
+
+```bash
+# Update dsh to latest
+npm update -g dsh
+
+# Clear npm cache if needed
+npm cache clean --force
+
+# Reinstall plugin
+dsh plugin remove misakanet
+dsh plugin add misakanet
+```
+
+### Network Issues
+
+```bash
+# Check connectivity
+ping github.com
+
+# Try with verbose output
+dsh plugin add misakanet --verbose
+
+# Use git method as fallback
+dsh plugin add github:Ikalus1988/MisakaNet
+```
+
+## Uninstallation
+
+### Quick Uninstall
+
+```bash
+dsh plugin remove misakanet
+```
+
+### Manual Uninstall
+
+```bash
+rm -rf ~/.dsh/skills/misakanet
+```
+
+### Verify Removal
+
+```bash
+dsh plugin list
+# misakanet should not appear
+```
+
+## Updating
+
+```bash
+# Update to latest version
+dsh plugin update misakanet
+
+# Or reinstall
+dsh plugin remove misakanet
+dsh plugin add misakanet
+```
+
+## Support
+
+- [GitHub Issues](https://github.com/Ikalus1988/MisakaNet/issues)
+- [Documentation](https://github.com/Ikalus1988/MisakaNet#readme)

--- a/docs/integrations/dsh.md
+++ b/docs/integrations/dsh.md
@@ -1,0 +1,67 @@
+# dsh Integration
+
+## Overview
+
+MisakaNet integrates with dsh as a plugin, providing MCP (Model Context Protocol) tools and resources for AI agents.
+
+## Available Tools
+
+### misakanet_search
+
+Search for lessons and content in the MisakaNet knowledge base.
+
+```
+Tool: misakanet_search
+Parameters:
+  - query (string): Search query
+Returns: Array of matching lessons
+```
+
+### misakanet_get_lesson
+
+Retrieve a specific lesson by ID.
+
+```
+Tool: misakanet_get_lesson
+Parameters:
+  - lesson_id (string): The lesson identifier
+Returns: Lesson content and metadata
+```
+
+## Available Resources
+
+### misaka://lessons/index
+
+Access the complete lesson index.
+
+```
+URI: misaka://lessons/index
+Type: application/json
+Description: Complete index of all available lessons
+```
+
+## Usage with AI Agents
+
+### Claude Code
+
+MisakaNet works seamlessly with Claude Code through the MCP protocol.
+
+### Cursor
+
+Compatible with Cursor's MCP integration.
+
+### Other MCP Agents
+
+Any agent supporting the MCP protocol can use MisakaNet tools and resources.
+
+## Configuration
+
+No additional configuration required. Install the plugin and tools are automatically available.
+
+## Troubleshooting
+
+If tools are not appearing:
+
+1. Verify plugin installation: `dsh plugin list`
+2. Restart your agent
+3. Check dsh version compatibility

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,14 @@ Search 317 indexed debugging lessons before re-debugging known problems.
 - Local: `python3 scripts/mcp_server.py` (stdio)
 - Install: `pip install misakanet-core`
 
+## DSH Plugin (DeepSeek Harness)
+
+- npm: `dsh plugin add misakanet`
+- Git: `dsh plugin add github:Ikalus1988/MisakaNet`
+- Manual: `mkdir -p ~/.dsh/skills && cp -r skills/misakanet ~/.dsh/skills/`
+- Verify: `dsh plugin list`
+- Full guide: see docs/dsh-installation.md
+
 ## Tools
 
 - `misakanet_search` — search lessons by query


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the MisakaNet dsh plugin installation, addressing all requirements from #1402.

### Changes

- **`docs/dsh-installation.md`** — Complete installation guide covering:
  - All 3 installation methods (npm, git, manual skill discovery)
  - Prerequisites (dsh 1.0.0+, Node.js 18+, Git 2.0+)
  - Step-by-step instructions for each method
  - Verification steps
  - Troubleshooting (permissions, version conflicts, network issues)
  - Uninstallation instructions
  - Update instructions

- **`docs/integrations/dsh.md`** — dsh integration page documenting:
  - Available MCP tools (misakanet_search, misakanet_get_lesson)
  - Available resources (misaka://lessons/index)
  - Agent compatibility (Claude Code, Cursor, other MCP agents)
  - Configuration notes

- **`llms.txt`** — Added DSH Plugin section with install commands and link to full guide

### Addresses #1402

| Requirement | Status |
|---|---|
| Update README.md Quick Start | ✅ Already covered (Option 5 exists) |
| Create docs/dsh-installation.md | ✅ Done |
| Update llms.txt | ✅ Done |
| Add docs/integrations/ page | ✅ Done |

Closes #1402