### PR TITLE
fix(mcp): migrate HTTP server to SDK v2

### DIFF
--- a/scripts/mcp_http_server.py
+++ b/scripts/mcp_http_server.py
@@ -27,7 +27,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 # ── Import search engines ──
 try:
@@ -45,8 +45,8 @@ except ImportError:
 
 from scripts.intake_kind import INTAKE_KINDS, infer_intake_kind  # noqa: E402
 
-# ── Create FastMCP server ──
-mcp = FastMCP("misakanet")
+# ── Create MCP server ──
+mcp = MCPServer("misakanet")
 
 # ── Intake auth / rate limit config ──
 # Set MISAKANET_INTAKE_TOKEN env var to require a shared token for submit_intake.
@@ -524,6 +524,4 @@ if __name__ == "__main__":
     print(f"BM25: {'available' if HAS_BM25 else 'not available'}")
     print(f"Endpoint: http://{args.host}:{args.port}/mcp")
 
-    mcp.settings.host = args.host
-    mcp.settings.port = args.port
-    mcp.run(transport="streamable-http")
+    mcp.run(transport="streamable-http", host=args.host, port=args.port)

--- a/tests/test_mcp_http_server.py
+++ b/tests/test_mcp_http_server.py
@@ -1,0 +1,80 @@
+"""Exercise the HTTP CLI against the installed MCP SDK over a real loopback socket."""
+
+import asyncio
+import json
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from mcp import Client
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_http_cli_serves_tools_resources_and_prompts_on_requested_port(tmp_path: Path) -> None:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+
+    log_path = tmp_path / "http-server.log"
+    with log_path.open("w") as log:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "scripts/mcp_http_server.py",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            cwd=REPO_ROOT,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                assert process.poll() is None, log_path.read_text()
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                        break
+                except OSError:
+                    time.sleep(0.05)
+            else:
+                raise AssertionError(f"HTTP server did not start: {log_path.read_text()}")
+
+            async def exercise() -> None:
+                async with Client(
+                    f"http://127.0.0.1:{port}/mcp",
+                    read_timeout_seconds=5,
+                ) as client:
+                    tools = await client.list_tools()
+                    assert {tool.name for tool in tools.tools} == {
+                        "misakanet_search",
+                        "misakanet_get_lesson",
+                        "misakanet_submit_usage",
+                        "misakanet_submit_intake",
+                        "misakanet_usage_status",
+                        "misakanet_register",
+                    }
+                    result = await client.call_tool("misakanet_search", {"query": ""})
+                    assert not result.is_error
+                    assert json.loads(result.content[0].text)["error"] == "query is required"
+                    resources = await client.list_resources()
+                    assert {resource.uri for resource in resources.resources} == {
+                        "misaka://lessons/index",
+                        "misaka://protocol/overview",
+                        "misaka://docs/readme",
+                    }
+                    prompts = await client.list_prompts()
+                    assert {prompt.name for prompt in prompts.prompts} == {
+                        "search_lesson",
+                        "triage_failure",
+                    }
+
+            asyncio.run(exercise())
+        finally:
+            process.terminate()
+            process.wait(timeout=5)


### PR DESCRIPTION
`requirements.txt` requires `mcp>=2.1.1`, but the HTTP entrypoint still imports the removed `mcp.server.fastmcp.FastMCP`. A clean install therefore cannot start the server and fails both no-match feedback tests in `tests/test_intake_kind.py` (also blocking #1293's current audit).

Use `MCPServer` and pass `host`/`port` to `run()`, as required by the [official SDK v2 migration guide](https://py.sdk.modelcontextprotocol.io/migration/#transport-specific-parameters-moved-from-mcpserver-constructor-to-runapp-methods). A new regression launches the actual CLI on an ephemeral loopback port and uses the real SDK client to list six tools, call a read-only validation path, and list resources and prompts. It terminates the server after the test and does not submit live lessons.

Validation with Python 3.11.14 / MCP 2.1.1 on macOS arm64:

- Before: the two existing intake-routing tests fail with `ModuleNotFoundError`; the new HTTP startup test reproduces the same failure.
- After: `PYTHONPATH=. .venv/bin/pytest -q tests/test_mcp_http_server.py tests/test_intake_kind.py` — 27 passed.
- Full audit-selected local suite: 821 passed, 15 skipped, 1 unrelated existing macOS system-proxy assertion (`tests/test_http_utils.py::test_get_proxy_opener_no_proxy`). The HTTP/proxy helper is unchanged; Linux audit CI is the environment check for the full suite.
- New test passes Ruff lint/format checks; the legacy server has the same nine lint findings as current main.
- `git diff --check` passes.

Fresh Linux audit CI completed successfully: **822 passed, 15 skipped**, including `test_mcp_http_server.py` and all 26 intake-kind tests. [Run and logs](https://github.com/Ikalus1988/MisakaNet/actions/runs/33935636614).

The separate cross-platform workflow currently reports success after a pre-existing `tests/test_add_provenance.py` collection error (`No module named 'scripts'`); its outcome check only searches for `failed`. Those matrix statuses are not counted as test evidence for this PR.

Node ID: hjqcan/goodmemory-maintainer
