### PR TITLE
test: add dsh plugin integration suite

### DIFF
--- a/.github/workflows/dsh-integration.yml
+++ b/.github/workflows/dsh-integration.yml
@@ -47,4 +47,9 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Run dsh integration tests
-        run: node --test tests/dsh/*.test.mjs
+        run: >-
+          node --test --test-concurrency=1
+          tests/dsh/compatibility.test.mjs
+          tests/dsh/functionality.test.mjs
+          tests/dsh/install.test.mjs
+          tests/dsh/performance.test.mjs

--- a/.github/workflows/dsh-integration.yml
+++ b/.github/workflows/dsh-integration.yml
@@ -1,0 +1,50 @@
+name: dsh Plugin Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'index.js'
+      - 'index.d.ts'
+      - 'package.json'
+      - 'SKILL.md'
+      - 'skills/**'
+      - 'scripts/mcp_server.py'
+      - 'misakanet/server/**'
+      - 'tests/dsh/**'
+      - '.github/workflows/dsh-integration.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dsh-integration:
+    name: ${{ matrix.os }} / Node ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ['18', '20', '22']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Install package metadata dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run dsh integration tests
+        run: node --test tests/dsh/*.test.mjs

--- a/docs/integrations/dsh.md
+++ b/docs/integrations/dsh.md
@@ -71,7 +71,11 @@ If tools are not appearing:
 The repository includes a Node built-in test suite for the dsh plugin contract:
 
 ```bash
-node --test tests/dsh/*.test.mjs
+node --test --test-concurrency=1 \
+  tests/dsh/compatibility.test.mjs \
+  tests/dsh/functionality.test.mjs \
+  tests/dsh/install.test.mjs \
+  tests/dsh/performance.test.mjs
 ```
 
 The suite covers:

--- a/docs/integrations/dsh.md
+++ b/docs/integrations/dsh.md
@@ -65,3 +65,22 @@ If tools are not appearing:
 1. Verify plugin installation: `dsh plugin list`
 2. Restart your agent
 3. Check dsh version compatibility
+
+## Integration Test Coverage
+
+The repository includes a Node built-in test suite for the dsh plugin contract:
+
+```bash
+node --test tests/dsh/*.test.mjs
+```
+
+The suite covers:
+
+- npm, git checkout, and manual file-copy installation paths
+- MCP tool discovery and execution for `misakanet_search` and `misakanet_get_lesson`
+- resource discovery/read access for `misaka://lessons/index`
+- explicit error handling for unknown tools, missing lessons, and unknown resources
+- Claude Code, Cursor, and generic MCP agent configuration compatibility
+- startup latency and multiple in-flight JSON-RPC requests
+
+CI runs these tests across Linux, macOS, and Windows with Node.js 18, 20, and 22.

--- a/tests/dsh/compatibility.test.mjs
+++ b/tests/dsh/compatibility.test.mjs
@@ -1,0 +1,55 @@
+// dsh/client compatibility tests for common MCP-capable agents.
+// Run: node --test tests/dsh/compatibility.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { McpStdioClient, pythonCommand, repoRoot } from './dsh-test-helpers.mjs';
+
+function mcpServerConfig(clientName) {
+  return {
+    mcpServers: {
+      misakanet: {
+        command: pythonCommand,
+        args: ['scripts/mcp_server.py'],
+        env: { MISAKANET_CLIENT: clientName },
+      },
+    },
+  };
+}
+
+test('Claude Code, Cursor, and generic MCP clients can use the same stdio server config shape', () => {
+  for (const clientName of ['claude-code', 'cursor', 'generic-mcp-agent']) {
+    const config = mcpServerConfig(clientName);
+    assert.equal(config.mcpServers.misakanet.command, pythonCommand);
+    assert.deepEqual(config.mcpServers.misakanet.args, ['scripts/mcp_server.py']);
+    assert.equal(config.mcpServers.misakanet.env.MISAKANET_CLIENT, clientName);
+    assert.doesNotThrow(() => JSON.stringify(config));
+  }
+});
+
+test('client-facing docs mention the requested dsh compatibility targets', () => {
+  const docs = fs.readFileSync(path.join(repoRoot, 'docs', 'integrations', 'dsh.md'), 'utf8').toLowerCase();
+  for (const expected of ['claude code', 'cursor', 'mcp agents']) {
+    assert.match(docs, new RegExp(expected.replaceAll(' ', '\\s+')));
+  }
+});
+
+test('MCP handshake uses standard capabilities expected by MCP-compatible agents', async () => {
+  const client = new McpStdioClient();
+  try {
+    const init = await client.request('initialize');
+    assert.equal(init.result.serverInfo.name, 'misakanet');
+    assert.ok(init.result.capabilities.tools);
+    assert.ok(init.result.capabilities.resources);
+    assert.ok(init.result.capabilities.prompts);
+
+    client.notify('notifications/initialized');
+    const tools = await client.request('tools/list');
+    assert.ok(tools.result.tools.every((tool) => tool.name && tool.description && tool.inputSchema));
+  } finally {
+    await client.close();
+  }
+});

--- a/tests/dsh/dsh-test-helpers.mjs
+++ b/tests/dsh/dsh-test-helpers.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+export const pythonCommand = process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
+
+export function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'));
+}
+
+export function makeTempDir(prefix = 'misakanet-dsh-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+export async function importModule(modulePath) {
+  const href = pathToFileURL(modulePath).href;
+  return import(`${href}?t=${Date.now()}-${Math.random()}`);
+}
+
+export async function run(command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    shell: false,
+    ...options,
+    env: { ...process.env, ...(options.env || {}) },
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk) => { stdout += chunk; });
+  child.stderr?.on('data', (chunk) => { stderr += chunk; });
+  const [code, signal] = await once(child, 'exit');
+  return { code, signal, stdout, stderr };
+}
+
+export function contentJson(response) {
+  assert.equal(response?.jsonrpc, '2.0');
+  const text = response?.result?.content?.[0]?.text;
+  assert.equal(typeof text, 'string');
+  return JSON.parse(text);
+}
+
+export function firstPublishedLessonPath() {
+  for (const subdir of ['core', 'contrib']) {
+    const dir = path.join(repoRoot, 'lessons', subdir);
+    if (!fs.existsSync(dir)) continue;
+    const file = fs.readdirSync(dir).find((name) => name.endsWith('.md'));
+    if (file) return path.posix.join('lessons', subdir, file);
+  }
+  throw new Error('No published lesson markdown files found under lessons/core or lessons/contrib');
+}
+
+export class McpStdioClient {
+  constructor() {
+    this.nextId = 1;
+    this.buffer = '';
+    this.pending = new Map();
+    this.stderr = '';
+    this.child = spawn(pythonCommand, ['scripts/mcp_server.py'], {
+      cwd: repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: '1',
+        MISAKANET_USAGE_DISABLE_REMOTE: '1',
+      },
+    });
+
+    this.child.stdout.setEncoding('utf8');
+    this.child.stderr.setEncoding('utf8');
+    this.child.stdout.on('data', (chunk) => this.#handleStdout(chunk));
+    this.child.stderr.on('data', (chunk) => { this.stderr += chunk; });
+    this.child.on('exit', (code, signal) => {
+      const error = new Error(`MCP server exited before response (code=${code}, signal=${signal})\n${this.stderr}`);
+      for (const { reject, timer } of this.pending.values()) {
+        clearTimeout(timer);
+        reject(error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  #handleStdout(chunk) {
+    this.buffer += chunk;
+    let newline;
+    while ((newline = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (error) {
+        continue;
+      }
+      const id = message.id;
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+        pending.resolve(message);
+      }
+    }
+  }
+
+  request(method, params = {}, timeoutMs = 5000) {
+    const id = this.nextId++;
+    const payload = { jsonrpc: '2.0', id, method, params };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timed out waiting for ${method} response. stderr:\n${this.stderr}`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+
+  notify(method, params = {}) {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+  }
+
+  async close() {
+    if (this.child.exitCode !== null) return;
+    this.child.stdin.end();
+    const exit = once(this.child, 'exit');
+    const timeout = new Promise((resolve) => setTimeout(resolve, 1000, 'timeout'));
+    if ((await Promise.race([exit, timeout])) === 'timeout') this.child.kill('SIGTERM');
+  }
+}

--- a/tests/dsh/functionality.test.mjs
+++ b/tests/dsh/functionality.test.mjs
@@ -1,0 +1,97 @@
+// dsh MCP functionality tests against the real stdio server.
+// Run: node --test tests/dsh/functionality.test.mjs
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+
+import { contentJson, firstPublishedLessonPath, McpStdioClient } from './dsh-test-helpers.mjs';
+
+async function withClient(fn) {
+  const client = new McpStdioClient();
+  try {
+    await fn(client);
+  } finally {
+    await client.close();
+  }
+}
+
+test('MCP initialize and tool discovery expose MisakaNet tools to dsh clients', async () => {
+  await withClient(async (client) => {
+    const init = await client.request('initialize');
+    assert.equal(init.result.serverInfo.name, 'misakanet');
+    assert.ok(init.result.protocolVersion);
+    assert.ok(init.result.capabilities.tools);
+    assert.ok(init.result.capabilities.resources);
+
+    const list = await client.request('tools/list');
+    const tools = list.result.tools;
+    const names = new Set(tools.map((tool) => tool.name));
+    assert.ok(names.has('misakanet_search'));
+    assert.ok(names.has('misakanet_get_lesson'));
+
+    const search = tools.find((tool) => tool.name === 'misakanet_search');
+    assert.deepEqual(search.inputSchema.required, ['query']);
+    assert.equal(search.inputSchema.properties.detail.enum.includes('compact'), true);
+  });
+});
+
+test('misakanet_search executes through JSON-RPC and returns structured content', async () => {
+  await withClient(async (client) => {
+    const response = await client.request('tools/call', {
+      name: 'misakanet_search',
+      arguments: { query: 'DCO sign-off failed', top: 3, detail: 'compact' },
+    });
+    const payload = contentJson(response);
+    assert.ok(
+      Array.isArray(payload.results) || payload.no_match === true || typeof payload.error === 'string',
+      `unexpected search payload: ${JSON.stringify(payload)}`,
+    );
+  });
+});
+
+test('misakanet_get_lesson reads a real published lesson by path', async () => {
+  await withClient(async (client) => {
+    const lessonPath = firstPublishedLessonPath();
+    const response = await client.request('tools/call', {
+      name: 'misakanet_get_lesson',
+      arguments: { path: lessonPath },
+    });
+    const payload = contentJson(response);
+    assert.equal(payload.path.replaceAll('\\', '/'), lessonPath);
+    assert.equal(typeof payload.content, 'string');
+    assert.ok(payload.content.length > 20);
+  });
+});
+
+test('misaka://lessons/index resource is discoverable and readable', async () => {
+  await withClient(async (client) => {
+    const listed = await client.request('resources/list');
+    const resources = listed.result.resources;
+    assert.ok(resources.some((resource) => resource.uri === 'misaka://lessons/index'));
+
+    const read = await client.request('resources/read', { uri: 'misaka://lessons/index' });
+    const text = read.result.contents[0].text;
+    const payload = JSON.parse(text);
+    assert.ok(Array.isArray(payload.lessons));
+    assert.equal(payload.lessons.length, payload.count);
+    assert.ok(payload.lessons.length > 0);
+  });
+});
+
+test('tool and resource error handling is explicit and non-crashing', async () => {
+  await withClient(async (client) => {
+    const unknownTool = await client.request('tools/call', { name: 'definitely_not_a_tool', arguments: {} });
+    assert.equal(unknownTool.error.code, -32601);
+    assert.match(unknownTool.error.message, /Unknown tool/);
+
+    const missingLesson = await client.request('tools/call', {
+      name: 'misakanet_get_lesson',
+      arguments: { id: 'not-a-real-lesson-id-for-dsh-tests' },
+    });
+    assert.match(contentJson(missingLesson).error, /Lesson not found/);
+
+    const missingResource = await client.request('resources/read', { uri: 'misaka://missing/resource' });
+    const missingResourcePayload = JSON.parse(missingResource.result.contents[0].text);
+    assert.match(missingResourcePayload.error, /Unknown resource/);
+  });
+});

--- a/tests/dsh/install.test.mjs
+++ b/tests/dsh/install.test.mjs
@@ -1,0 +1,58 @@
+// dsh plugin installation contract tests.
+// Run: node --test tests/dsh/install.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { importModule, makeTempDir, readJson, repoRoot, run } from './dsh-test-helpers.mjs';
+
+test('npm package includes the files dsh needs for plugin installation', async () => {
+  const command = process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : 'npm';
+  const args = process.platform === 'win32'
+    ? ['/d', '/s', '/c', 'npm pack --dry-run --json']
+    : ['pack', '--dry-run', '--json'];
+  const { code, stdout, stderr } = await run(command, args);
+  assert.equal(code, 0, stderr);
+  const [pack] = JSON.parse(stdout);
+  const files = new Set(pack.files.map((entry) => entry.path));
+
+  for (const required of ['package.json', 'index.js', 'index.d.ts', 'SKILL.md', 'skills/misakanet/SKILL.md']) {
+    assert.ok(files.has(required), `npm pack should include ${required}`);
+  }
+
+  assert.ok(!files.has('dsh.bundle.patch'), 'MisakaNet must stay a library plugin, not a Cordis loader patch');
+});
+
+test('git/manual checkout exposes an importable no-op dsh plugin entry', async () => {
+  const plugin = await importModule(path.join(repoRoot, 'index.js'));
+  assert.equal(plugin.name, 'misakanet');
+  assert.equal(typeof plugin.apply, 'function');
+  assert.doesNotThrow(() => plugin.apply({ services: new Map() }, { mcpUrl: 'https://misakanet.org/mcp' }));
+});
+
+test('manual file-copy install can be imported from a node_modules package directory', async () => {
+  const tmp = makeTempDir();
+  const packageDir = path.join(tmp, 'node_modules', 'misakanet');
+  fs.mkdirSync(packageDir, { recursive: true });
+
+  for (const file of ['package.json', 'index.js', 'index.d.ts', 'SKILL.md']) {
+    fs.copyFileSync(path.join(repoRoot, file), path.join(packageDir, file));
+  }
+  fs.cpSync(path.join(repoRoot, 'skills'), path.join(packageDir, 'skills'), { recursive: true });
+
+  const plugin = await importModule(path.join(packageDir, 'index.js'));
+  assert.equal(plugin.name, 'misakanet');
+  assert.equal(typeof plugin.apply, 'function');
+});
+
+test('package metadata advertises a dependency-free ESM plugin surface', () => {
+  const pkg = readJson('package.json');
+  assert.equal(pkg.name, 'misakanet');
+  assert.equal(pkg.type, 'module');
+  assert.equal(pkg.main, 'index.js');
+  assert.equal(pkg.types, 'index.d.ts');
+  assert.deepEqual(pkg.dependencies ?? {}, {});
+  assert.ok(pkg.files.includes('SKILL.md'));
+  assert.ok(pkg.files.includes('skills/'));
+});

--- a/tests/dsh/performance.test.mjs
+++ b/tests/dsh/performance.test.mjs
@@ -1,0 +1,44 @@
+// dsh plugin performance smoke tests.
+// Run: node --test tests/dsh/performance.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { performance } from 'node:perf_hooks';
+
+import { McpStdioClient, run, pythonCommand } from './dsh-test-helpers.mjs';
+
+test('MCP server responds to initialize within a practical plugin startup budget', async () => {
+  const client = new McpStdioClient();
+  const started = performance.now();
+  try {
+    const init = await client.request('initialize', {}, 5000);
+    const elapsed = performance.now() - started;
+    assert.equal(init.result.serverInfo.name, 'misakanet');
+    assert.ok(elapsed < 5000, `initialize took ${elapsed.toFixed(1)}ms`);
+  } finally {
+    await client.close();
+  }
+});
+
+test('server remains stable while multiple dsh requests are in flight', async () => {
+  const client = new McpStdioClient();
+  try {
+    const requests = [];
+    for (let i = 0; i < 12; i += 1) {
+      requests.push(client.request(i % 2 === 0 ? 'tools/list' : 'resources/list'));
+    }
+    const responses = await Promise.all(requests);
+    assert.equal(responses.length, 12);
+    assert.ok(responses.every((response) => response.jsonrpc === '2.0' && response.result));
+  } finally {
+    await client.close();
+  }
+});
+
+test('server import/startup path stays lightweight enough for Node 18/20/22 CI', async () => {
+  const start = performance.now();
+  const result = await run(pythonCommand, ['-c', 'from scripts.mcp_server import handle_request; print(handle_request({"jsonrpc":"2.0","id":1,"method":"initialize"})["result"]["serverInfo"]["name"])']);
+  const elapsed = performance.now() - start;
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /misakanet/);
+  assert.ok(elapsed < 5000, `python import/initialize took ${elapsed.toFixed(1)}ms`);
+});


### PR DESCRIPTION
## Summary
- add a Node built-in `tests/dsh/` integration suite for the MisakaNet dsh plugin contract
- cover npm/git/manual install shape, MCP tool discovery and execution, resource access, error handling, compatibility config, startup latency, and concurrent JSON-RPC requests
- add a dedicated GitHub Actions matrix across Linux, macOS, Windows and Node.js 18/20/22
- document the dsh integration test command and coverage

## Validation
- `node --test tests/dsh/*.test.mjs` — 15 passed locally
- `npm install --ignore-scripts && node --test tests/dsh/*.test.mjs` — 15 passed locally
- `node --test --test-concurrency=1 tests/dsh/compatibility.test.mjs tests/dsh/functionality.test.mjs tests/dsh/install.test.mjs tests/dsh/performance.test.mjs` — 15 passed locally; CI uses this explicit cross-platform form because Windows shells do not expand POSIX globs consistently

Closes #1403

/claim #1403
