### PR TITLE
feat(dsh): declare dsh.bundle — register stdio MCP server as mcp__mis…

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,32 @@
+# MisakaNet dsh bundle patch (2026-09-05, B1)
+#
+# Registers MisakaNet's stdio MCP server into any dsh profile that lists
+# `misakanet` in `dsh.profile.bundles`. Tools are published on ctx.tools as
+# `mcp__misakanet__<tool>` (misakanet_search / misakanet_get_lesson / …),
+# served by the repo's own python server (scripts/mcp_server.py), which
+# self-locates the repo root from __file__ — no other wiring needed.
+#
+# Requirements & behavior:
+# * The python MCP server exists only in repo/git+ installs
+#   (git+https://github.com/Ikalus1988/MisakaNet.git). The npm skill-only
+#   bundle ships no python, so on such installs this row stays disconnected
+#   instead of failing boot (failOnStartupError: false).
+# * The profile must resolve '@deepseek-ai/dsh-mcp-client' (web/code presets
+#   include it). Boot cwd is inherited; run dsh from the repo root for the
+#   stdio server to start (the plugin-spec sandbox boots at the repo clone).
+# * One row, one id — no double-insert: later patches override by id, and
+#   this id (misakanet-mcp) is unique to this bundle.
+
+- insert:
+    - id: misakanet-mcp
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        transport: stdio
+        serverName: misakanet
+        command: python3
+        args:
+          - scripts/mcp_server.py
+        env: {}
+        cwd: ''
+        toolCallTimeoutMs: 60000
+        failOnStartupError: false

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "misakanet",
   "version": "2.23.1",
   "license": "Apache-2.0",
-  "description": "MisakaNet failure-memory skill — verified debugging lessons for AI agents. DSH bundle: registers the stdio MCP server (misakanet_search/get_lesson) as mcp__misakanet__* tools; skill/CLI surfaces stay available in any profile.",
+  "description": "MisakaNet failure-memory skill — verified debugging lessons for AI agents. DSH bundle: registers the stdio MCP server as mcp__misakanet__* tools (misakanet_search/get_lesson/…). Live bundle tools require a git+ install (the npm skill-only bundle ships no python server); skill/CLI surfaces work in any profile.",
   "files": [
     "SKILL.md",
     "skills/",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,19 @@
   "name": "misakanet",
   "version": "2.23.1",
   "license": "Apache-2.0",
-  "description": "MisakaNet failure-memory skill — verified debugging lessons for AI agents, discoverable by any DSH profile (CLI/MCP, not a Cordis entry)",
+  "description": "MisakaNet failure-memory skill — verified debugging lessons for AI agents. DSH bundle: registers the stdio MCP server (misakanet_search/get_lesson) as mcp__misakanet__* tools; skill/CLI surfaces stay available in any profile.",
   "files": [
     "SKILL.md",
     "skills/",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "cordis.patch.yml"
   ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
   "scripts": {
     "deploy:web": "cd web && npx wrangler deploy",
     "deploy:api": "cd workers && npx wrangler deploy --config wrangler.api.jsonc",

--- a/tests/test_dsh_bundle.py
+++ b/tests/test_dsh_bundle.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Contract tests for the MisakaNet dsh bundle declaration (PR #1484 review).
+
+Guards the packaging contract that the dsh.so / MCP-registry verification and
+`dsh plugin` rely on:
+
+* package.json declares ``dsh.bundle.patch`` pointing at ``cordis.patch.yml``
+  and ships the patch in its npm ``files`` whitelist;
+* the patch contains exactly one insert row (id ``misakanet-mcp``) whose
+  config is a valid @deepseek-ai/dsh-mcp-client stdio declaration
+  (serverName matching ^[A-Za-z0-9_-]{1,32}$, command python3, args pointing
+  at the repo's scripts/mcp_server.py, failOnStartupError false);
+* the row id is unique across the repo (no double-insert drift).
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+
+SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+
+
+def _pkg() -> dict:
+    return json.loads((REPO / "package.json").read_text(encoding="utf-8"))
+
+
+def test_bundle_patch_declared_and_shipped():
+    pkg = _pkg()
+    patch_rel = pkg["dsh"]["bundle"]["patch"]
+    assert patch_rel == "./cordis.patch.yml", patch_rel
+    assert (REPO / "cordis.patch.yml").exists()
+    assert "cordis.patch.yml" in pkg.get("files", []), "patch must ship in npm files"
+
+
+def test_patch_single_insert_row_with_mcp_client_stdio_config():
+    patch = yaml.safe_load((REPO / "cordis.patch.yml").read_text(encoding="utf-8"))
+    inserts = [row for op in patch for row in op.get("insert", [])]
+    assert len(inserts) == 1, f"expected exactly one insert row, got {len(inserts)}"
+    row = inserts[0]
+    assert row["id"] == "misakanet-mcp"
+    assert row["name"] == "@deepseek-ai/dsh-mcp-client"
+    cfg = row["config"]
+    assert cfg["transport"] == "stdio"
+    assert cfg["serverName"] == "misakanet"
+    assert SERVER_NAME_RE.match(cfg["serverName"]), cfg["serverName"]
+    assert cfg["command"] == "python3"
+    assert cfg["args"] == ["scripts/mcp_server.py"]
+    assert (REPO / "scripts" / "mcp_server.py").exists()
+    assert cfg.get("failOnStartupError") is False
+
+
+def test_row_id_unique_across_repo():
+    id_hits = []
+    for p in (REPO / "cordis.patch.yml").parent.rglob("*.patch.yml"):
+        try:
+            doc = yaml.safe_load(p.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        for op in doc or []:
+            for row in op.get("insert", []):
+                if row.get("id") == "misakanet-mcp":
+                    id_hits.append(str(p.relative_to(REPO)))
+    assert id_hits == ["cordis.patch.yml"], id_hits
+
+
+if __name__ == "__main__":
+    sys.exit(0)


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
…akanet__* (B1)

Makes MisakaNet a declared dsh bundle (L5.4 inventory active) instead of an 'installed but undeclared' plugin:
- package.json: "dsh": {"bundle": {"patch": "./cordis.patch.yml"}}; patch file added to npm files whitelist
- cordis.patch.yml: single insert row id=misakanet-mcp (unique, no double-insert) loading @deepseek-ai/dsh-mcp-client in stdio mode → tools misakanet_search/get_lesson/... on ctx.tools

Semantics: python MCP server ships only in repo/git+ installs (npm skill-only bundle stays skill-only; row disconnects gracefully via failOnStartupError:false). Requires profile resolving dsh-mcp-client (web/code presets) and boot cwd at the repo clone (matches the plugin-spec sandbox, so L5.4 should go active there).

## Summary

<!-- What does this PR do? One sentence is fine. -->

## Type of Change

- [ ] 📚 New lesson submission
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] Other (please describe)

## Lessons Added (if applicable)

<!-- List lesson filenames if adding new lessons -->

## Checklist

- [ ] My commit has `Signed-off-by:` (DCO required)
- [ ] I have tested that the changes work correctly
- [ ] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds) — maintainer will regenerate after merge

## Before submitting — check related lessons

<!-- If your PR fixes a known issue, check if a lesson already covers it: -->

- [DCO sign-off fix](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/dco-auto-fix-workflow.md)
- [Secret scan / token fix](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/codeql-alert-dismissal-false-positive.md)
- [pip install timeout/SSL](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/contrib/pip-install-timeout-ssl.md)
- [GitHub API 401](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/github-401-credential-lookup.md)
- [🔍 Search all lessons](https://ikalus1988.github.io/MisakaNet/search/)

<!-- Don't worry about perfection. Small fixes are welcome too. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Declare MisakaNet as a dsh bundle via `dsh.bundle.patch` in `package.json`

- Add `cordis.patch.yml` registering the stdio MCP server as `mcp__misakanet__*` tools

- Whitelist the new patch file in the npm `files` array and update description

- Gracefully no-op on skill-only installs via `failOnStartupError: false`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json (dsh.bundle.patch)"] -- "loads" --> B["cordis.patch.yml"]
  B -- "inserts row id=misakanet-mcp" --> C["@deepseek-ai/dsh-mcp-client (stdio)"]
  C -- "spawns" --> D["scripts/mcp_server.py"]
  D -- "exposes" --> E["mcp__misakanet__search / get_lesson / ..."]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cordis.patch.yml</strong><dd><code>Register stdio MCP server as misakanet-mcp row</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cordis.patch.yml

<ul><li>New file: dsh bundle patch with a single insert row <code>id: misakanet-mcp</code><br> <li> Registers <code>@deepseek-ai/dsh-mcp-client</code> in stdio mode for the python MCP <br>server<br> <li> Configures <code>command: python3</code> with <code>args: [scripts/mcp_server.py]</code><br> <li> Sets <code>failOnStartupError: false</code> so skill-only npm installs skip <br>gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1484/files#diff-66e6d923ac24b898cc4d8b405e107adfca86b017b7b63d31287a71549c1580bd">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Declare dsh bundle and whitelist patch file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Adds <code>dsh.bundle.patch</code> field pointing to <code>./cordis.patch.yml</code><br> <li> Adds <code>cordis.patch.yml</code> to the npm <code>files</code> whitelist<br> <li> Expands description to advertise the dsh bundle / MCP server <br>registration</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1484/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

