### PR TITLE
docs(dsh): npm vs git+ guidance + remote MCP example patch (B2-doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ cp -r skills/misakanet ~/.dsh/skills/
 python3 scripts/mcp_deepseek_adapter.py
 ```
 
+> **DSH bundle tools (`mcp__misakanet__*`)** are served by the repo's python MCP
+> server, which ships only with a **git+ install** (the npm bundle provides the
+> skill/CLI surfaces only). For live tools from an npm install, either switch to
+> git+ (above) or point a `dsh-mcp-client` row at the remote endpoint
+> `https://misakanet.org/mcp` — example patch: `docs/maintenance.md` → dsh bundle.
+
 ### Try it now
 
 | Method | Command | Time |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,6 +101,11 @@ mkdir -p ~/.dsh/skills
 cp -r skills/misakanet ~/.dsh/skills/
 ```
 
+> **DSH bundle 工具（`mcp__misakanet__*`）** 由仓库自带 python MCP 服务器提供，
+> 仅在 **git+ 安装**时随包存在（npm 包只含 skill/CLI 面）。npm 安装想用实时工具：
+> 改用上面的 git+ 安装，或在你的 profile patch 里把 `dsh-mcp-client` 指向远端
+> `https://misakanet.org/mcp`（示例见 `docs/maintenance.md` → dsh bundle 章节）。
+
 ```python
 # Python 库方式
 from misakanet.search import search_lessons

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -141,4 +141,4 @@ MisakaNet 现已声明 `dsh.bundle`（`package.json` + `cordis.patch.yml`），�
 
 > 命名空间提示：`serverName` 唯一（`misakanet` 已被默认本地行占用，远端用
 > `misakanet-remote`），工具名会以 `mcp__misakanet-remote__*` 出现。
-> 契约测试：`tests/test_dsh_bundle.py`（patch 声明/单行/字段/全局唯一 id）。
+> 契约测试：`tests/test_dsh_bundle.py`（随 PR #1484 合入 main；patch 声明/单行/字段/全局唯一 id）。

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -109,3 +109,36 @@ GHSA-2wm9（高, 租户越权）、GHSA-36p7（严重, 代码注入）、GHSA-f4
 GHSA-xph7（高, RBAC 范围）。`last_affected = 1.5.9` 即 PyPI 最新版，上游无修复。
 本仓库零 chromadb import（仅 pyproject hub extras 遗留声明）→ 已从 `hub` extras 移除并 `uv lock`
 （lock -1806/+37 行），4 条告警在推送后自动关闭；外部 hub 包如确需 chromadb 由其自身清单声明。
+
+## 7. dsh bundle（插件/工具集成，2026-09-05）
+
+MisakaNet 现已声明 `dsh.bundle`（`package.json` + `cordis.patch.yml`），作为 dsh 插件的
+默认行为：
+
+- **git+ 安装**（`dsh plugin add git+https://github.com/Ikalus1988/MisakaNet.git`）：
+  patch 行 `misakanet-mcp` 以 stdio 启动仓库自带 `scripts/mcp_server.py`，向 profile 提供
+  `mcp__misakanet__misakanet_search / get_lesson / …` 工具（本地、无限额）。
+- **npm 安装**（skill-only，不含 python）：该行 `failOnStartupError: false` 静默断开，
+  仅提供 skill/CLI 面——要实时工具请改用 git+ 安装。
+
+### 远端接入示例（npm 用户可选）
+
+把下面行追加到你 profile 的用户 patch（如 `~/.dsh/profiles/web/cordis.patch.yml`），
+让 `dsh-mcp-client` 直连远端（无需本地 python；token 需在 https://misakanet.org 注册）：
+
+```yaml
+- insert:
+    - id: misakanet-remote
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        transport: streamable-http
+        serverName: misakanet-remote
+        url: https://misakanet.org/mcp
+        headers:
+          Authorization: 'Bearer YOUR_MISAKANET_TOKEN'
+        failOnStartupError: false
+```
+
+> 命名空间提示：`serverName` 唯一（`misakanet` 已被默认本地行占用，远端用
+> `misakanet-remote`），工具名会以 `mcp__misakanet-remote__*` 出现。
+> 契约测试：`tests/test_dsh_bundle.py`（patch 声明/单行/字段/全局唯一 id）。


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
B2 closed as documentation per recommendation:
- README.md / README.zh-CN.md: DSH Option sections now state live mcp__misakanet__* tools require a git+ install (npm bundle = skill/CLI only), with pointer to the remote-endpoint alternative
- docs/maintenance.md §7: dsh bundle behavior (git+ local stdio row vs npm silent-degrade) + streamable-http remote example patch for npm users (serverName misakanet-remote, Bearer token placeholder)

## Summary

<!-- What does this PR do? One sentence is fine. -->

## Type of Change

- [ ] 📚 New lesson submission
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] Other (please describe)

## Lessons Added (if applicable)

<!-- List lesson filenames if adding new lessons -->

## Checklist

- [ ] My commit has `Signed-off-by:` (DCO required)
- [ ] I have tested that the changes work correctly
- [ ] I have NOT modified generated files (data/lessons.json, docs/data/*, feeds) — maintainer will regenerate after merge

## Before submitting — check related lessons

<!-- If your PR fixes a known issue, check if a lesson already covers it: -->

- [DCO sign-off fix](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/dco-auto-fix-workflow.md)
- [Secret scan / token fix](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/codeql-alert-dismissal-false-positive.md)
- [pip install timeout/SSL](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/contrib/pip-install-timeout-ssl.md)
- [GitHub API 401](https://github.com/Ikalus1988/MisakaNet/blob/main/lessons/core/github-401-credential-lookup.md)
- [🔍 Search all lessons](https://ikalus1988.github.io/MisakaNet/search/)

<!-- Don't worry about perfection. Small fixes are welcome too. -->


___

### **PR Type**
Documentation


___

### **Description**
- README (en/zh) note: `mcp__misakanet__*` tools require git+ install

- npm bundle clarified as skill/CLI-only (silent-degrade for tools)

- docs/maintenance.md §7: dsh bundle behavior + remote streamable-http patch

- Remote example uses `serverName: misakanet-remote` with Bearer token


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["git+ install"] -- "stdio local" --> B["mcp__misakanet__* tools"]
  C["npm install"] -- "skill/CLI only" --> D["no live tools (silent degrade)"]
  D -- "add remote patch" --> E["https://misakanet.org/mcp"]
  E -- "streamable-http" --> F["mcp__misakanet-remote__* tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>README notes npm vs git+ for DSH MCP tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds callout above "Try it now": live <code>mcp__misakanet__*</code> tools need <br>git+ install<br> <li> Notes npm bundle ships skill/CLI only (silent-degrade for python MCP <br>server)<br> <li> Points readers to remote endpoint <code>https://misakanet.org/mcp</code> and <br><code>docs/maintenance.md</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1486/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh-CN.md</strong><dd><code>中文 README 增加 DSH bundle 安装说明</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh-CN.md

<ul><li>Chinese mirror of the new DSH bundle callout<br> <li> States npm package only includes skill/CLI surfaces<br> <li> Suggests git+ install or remote <code>dsh-mcp-client</code> row pointing to <br><code>misakanet.org/mcp</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1486/files#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>maintenance.md</strong><dd><code>maintenance §7 documents dsh bundle + remote MCP patch</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/maintenance.md

<ul><li>New §7 "dsh bundle": explains git+ stdio row vs npm silent-degrade <br>behavior<br> <li> Provides streamable-http remote MCP patch for npm users (serverName <br><code>misakanet-remote</code>)<br> <li> Uses Bearer token placeholder and notes <code>tests/test_dsh_bundle.py</code> for <br>contract checks</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1486/files#diff-0541ee302f10469f3b0290ea7585f45ff9652bc6de7131548819836586da0eb3">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

