### PR TITLE
fix(ci): align bot DCO messages with auto-clear + audit manual-run robustness

### DIFF
--- a/.github/actions/dco-audit/action.yml
+++ b/.github/actions/dco-audit/action.yml
@@ -76,7 +76,7 @@ runs:
         printf 'failed_commits_log<<DCO_EOF\n%s\nDCO_EOF\n' "$FAILED_LOG" >> "$GITHUB_OUTPUT"
         echo "failed_count=$FAILED_COUNT" >> "$GITHUB_OUTPUT"
 
-    - name: Post DCO Failure Comment
+    - name: Post DCO Failure Comment (marker upsert)
       if: steps.scan.outputs.dco_passed == 'false' && inputs.pr-number != ''
       shell: bash
       env:
@@ -88,20 +88,12 @@ runs:
         ${{ steps.scan.outputs.failed-commits-log }}
         DCO_EOF
         )
-        BASE_REF="${{ inputs.base-sha }}"
-        HEAD_REF="${{ inputs.head-sha }}"
 
         cat > /tmp/dco_comment.md << 'CMTEOF'
-        ### 🤖 AUTOMATED AUDIT SYSTEM: REGULATORY BLOCK
+        <!-- misakanet-dco-block -->
+        ### 🔏 DCO Check — some commits need sign-off
 
-        **[STATUS]** AUTO-MERGE: PINNED (BLOCKED)
-        **[REASON]** Developer Certificate of Origin (DCO) validation failed.
-
-        ---
-
-        #### 1. COMMIT SIGN-OFF SNAPSHOT
-
-        The following commits in this Pull Request are missing the required `Signed-off-by` line:
+        The following commits in this Pull Request are missing the required `Signed-off-by:` trailer (Developer Certificate of Origin):
 
         ```text
         CMTEOF
@@ -109,24 +101,36 @@ runs:
         cat >> /tmp/dco_comment.md << 'CMTEOF'
         ```
 
-        #### 2. REMEDIATION PROTOCOL FOR AGENT / CONTRIBUTOR
-
-        Execute the following commands locally within your repository to re-sign and update the branch:
+        **How to fix (about 2 minutes):**
 
         ```bash
-        # Step 1: Rebase to add sign-off to all commits in this PR
-        git rebase -i origin/$BASE_REF --exec "git commit --amend --no-edit --signoff"
+        # sign the latest commit
+        git commit --amend --signoff --no-edit
+        git push --force-with-lease
 
-        # Step 2: Force-push the corrected history back to the remote branch
-        git push --force origin $HEAD_REF
+        # or sign the last N commits
+        git rebase --signoff HEAD~N
+        git push --force-with-lease
         ```
 
-        *Note: This is an automated gate. Once all commits conform to the DCO specification, the Auto-Merge controller will resume execution immediately.*
+        Same-repo PRs can also comment `/fix-dco` to auto-apply the sign-off.
+
+        > Merge commits are exempt from sign-off. CI re-scans on **every push**
+        > (including force-pushes): once all commits are signed, the `needs-dco`
+        > label **auto-clears** and this comment is removed — do NOT push an empty
+        > commit. Full guide: CONTRIBUTING.md → *Developer Certificate of Origin*.
         CMTEOF
 
-        # Replace variables inside the comment body
-        sed -i "s/\$BASE_REF/${{ inputs.base-sha }}/g" /tmp/dco_comment.md
-        sed -i "s/\$HEAD_REF/${{ inputs.head-sha }}/g" /tmp/dco_comment.md
-
-        gh pr comment "$PR" --repo "$REPO" --body-file /tmp/dco_comment.md
-        echo "Posted DCO failure comment to PR #$PR"
+        # Upsert: update an existing block comment instead of stacking (issue #1498)
+        EXISTING_ID=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+          --jq '.[] | select(.body | contains("misakanet-dco-block")) | .id' 2>/dev/null | tail -n1)
+        if [ -n "$EXISTING_ID" ]; then
+          gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" \
+            -f "body=@/tmp/dco_comment.md" >/dev/null 2>&1 \
+            && echo "Updated DCO block comment on PR #$PR" \
+            || gh pr comment "$PR" --repo "$REPO" --body-file /tmp/dco_comment.md 2>/dev/null \
+            || echo "::warning::Could not update/post DCO comment on PR #$PR (read-only fork run?)"
+        else
+          gh pr comment "$PR" --repo "$REPO" --body-file /tmp/dco_comment.md 2>/dev/null \
+            || echo "::warning::Could not post DCO comment on PR #$PR (read-only fork run?)"
+        fi

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -105,6 +105,9 @@ jobs:
                 ? '✅ **DCO Check Passed** — All commits include `Signed-off-by:`. Thank you for respecting code origin!'
                 : '❌ **DCO Check Failed** — Some commits are missing `Signed-off-by:`. Please amend with `--signoff`.';
               const conclusion = dcoPass ? 'success' : 'action_required';
+              const detail = dcoPass
+                ? 'All commits include a Signed-off-by trailer. This certifies that the contributor has the right to submit the code under the project license.'
+                : 'One or more commits are missing the Signed-off-by trailer (merge commits are exempt). Fix:\n\n```bash\n# latest commit\ngit commit --amend --signoff --no-edit\ngit push --force-with-lease\n\n# last N commits\ngit rebase --signoff HEAD~N\ngit push --force-with-lease\n```\n\nCI re-scans on every push (including force-pushes) and the `needs-dco` label **auto-clears** once all commits are signed — do not push an empty commit. Same-repo PRs can also comment `/fix-dco` to auto-apply.';
 
               await github.rest.checks.create({
                 owner: context.repo.owner,
@@ -116,9 +119,7 @@ jobs:
                 output: {
                   title: 'Developer Certificate of Origin',
                   summary: body,
-                  text: dcoPass
-                    ? 'All commits include a Signed-off-by trailer. This certifies that the contributor has the right to submit the code under the project license.'
-                    : 'One or more commits are missing the Signed-off-by trailer. Use `git commit --amend --signoff` or `git rebase --signoff` to fix.'
+                  text: detail
                 }
               });
             } catch (e) {

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,9 +118,11 @@ jobs:
           exit 1
 
       # ── DCO Audit Gate (all PRs) ──
+      # Uses the local copy of the dco-audit action so the comment wording is
+      # versioned in-repo (issue #1498). Scan semantics: --no-merges.
       - name: DCO Audit
         id: dco
-        uses: Ikalus1988/dco-audit@v1
+        uses: ./.github/actions/dco-audit
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}
           head-sha: ${{ github.event.pull_request.head.sha }}
@@ -134,8 +136,9 @@ jobs:
           echo "DCO check failed: ${{ steps.dco.outputs.failed-count }} commit(s) without sign-off."
           exit 1
 
-      # Clean stale REGULATORY BLOCK comments once DCO passes so the PR thread
-      # no longer contradicts the green checks (issue #1498).
+      # Clean stale DCO block comments once DCO passes so the PR thread
+      # no longer contradicts the green checks (issue #1498). Matches both
+      # the current marker and legacy REGULATORY BLOCK comments.
       - name: Remove stale DCO block comments
         if: steps.dco.outputs.dco-passed == 'true'
         env:
@@ -144,7 +147,7 @@ jobs:
           PR_NUM="${{ github.event.pull_request.number || '' }}"
           [ -z "$PR_NUM" ] && exit 0
           for cid in $(gh api "repos/Ikalus1988/MisakaNet/issues/$PR_NUM/comments?per_page=100" \
-            --jq '.[] | select(.body | contains("AUTOMATED AUDIT SYSTEM: REGULATORY BLOCK")) | .id' 2>/dev/null); do
+            --jq '.[] | select((.body | contains("misakanet-dco-block")) or (.body | contains("AUTOMATED AUDIT SYSTEM: REGULATORY BLOCK"))) | .id' 2>/dev/null); do
             gh api -X DELETE "repos/Ikalus1988/MisakaNet/issues/comments/$cid" >/dev/null 2>&1 || true
           done
           echo "Stale DCO block comments cleaned."
@@ -244,6 +247,14 @@ jobs:
           # Only audit ecosystems whose dependency files changed
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # workflow_dispatch runs have no base/head PR SHAs — nothing to diff
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "Manual (workflow_dispatch) run — no PR diff; dependency audit skipped"
+            echo "depaudit_result=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           PY_DEPS_CHANGED=false
           JS_DEPS_CHANGED=false
@@ -522,11 +533,13 @@ jobs:
             REPORT+=$'\n\n'
             if [ "$OUTCOME" = "success" ]; then
               REPORT+="✅ **PASS** — ${COVERAGE}% coverage"
-            else
+            elif [ -n "$OUTCOME" ]; then
               REPORT+="❌ **FAIL** — tests have failures"
               if [ -n "$COVERAGE" ]; then
                 REPORT+=" (${COVERAGE}% coverage)"
               fi
+            else
+              REPORT+="⏭️ Skipped (manual run without PR context)."
             fi
             REPORT+=$'\n\n'
           fi
@@ -571,7 +584,7 @@ jobs:
               REPORT+="❌ Dependency audit found vulnerabilities."$'\n'
               VERDICT_PASS=false
             fi
-            if [ "$OUTCOME" != "success" ]; then
+            if [ -n "$OUTCOME" ] && [ "$OUTCOME" != "success" ]; then
               REPORT+="❌ Test suite failed."$'\n'
               VERDICT_PASS=false
             fi
@@ -623,7 +636,7 @@ jobs:
           fi
           # Note: dep audit blocking is handled in the dep audit step itself
           # (only blocks when dependency files actually changed)
-          if [ "$SCOPE" = "full" ] && [ "$OUTCOME" != "success" ]; then
+          if [ "$SCOPE" = "full" ] && [ -n "$OUTCOME" ] && [ "$OUTCOME" != "success" ]; then
             echo "Audit failed: test suite has issues."
             exit 1
           fi

--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -16,18 +16,43 @@ jobs:
       - uses: actions/github-script@v9
         with:
           script: |
-            const body = [
-              "## Welcome to MisakaNet!",
-              "",
-              "Thanks for your first PR!",
-              "",
-              "### Fix DCO First",
-              "",
-              "Every commit needs `Signed-off-by:`. If DCO fails:",
-              "```bash",
-              "git commit --amend --signoff --no-edit",
-              "git push --force-with-lease",
-              "```",
+            const body = [];
+            body.push("## Welcome to MisakaNet!");
+            body.push("");
+            body.push("Thanks for your first PR!");
+
+            // Only show DCO remediation when it is actually needed — don't nag
+            // contributors whose commits are already signed (issue #1498).
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              { owner: context.repo.owner, repo: context.repo.repo,
+                pull_number: context.issue.number, per_page: 100 }
+            );
+            const unsigned = commits
+              .filter(c => (c.parents || []).length <= 1) // merge commits exempt
+              .filter(c => !(c.commit.message || '').includes('Signed-off-by:'));
+
+            if (unsigned.length > 0) {
+              body.push(
+                "",
+                "### 🔏 Fix DCO First",
+                "",
+                "Some commits are missing `Signed-off-by:`. Fix and force-push:",
+                "",
+                "```bash",
+                "git commit --amend --signoff --no-edit   # latest commit",
+                "git push --force-with-lease",
+                "```",
+                "",
+                "For several commits: `git rebase --signoff HEAD~N && git push --force-with-lease`",
+                "",
+                "> CI re-scans on **every push** (including force-pushes). Once all commits are signed, the `needs-dco` label **auto-clears** — do NOT push an empty commit."
+              );
+            } else {
+              body.push("", "### 🔏 DCO: all commits signed ✅");
+            }
+
+            body.push(
               "",
               "### Quick Links",
               "",
@@ -53,12 +78,12 @@ jobs:
               "  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"misakanet_submit_intake\",\"arguments\":{\"problem\":\"YOUR PROBLEM\",\"source\":\"your-agent\"}}}'",
               "```",
               "",
-              "CI runs automatically once DCO passes."
-            ].join("\n");
+              "CI checks run automatically on every push."
+            );
 
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              body: body.join("\n")
             });


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Follow-up to [#1502](https://github.com/Ikalus1988/MisakaNet/pull/1502) / [#1498](https://github.com/Ikalus1988/MisakaNet/issues/1498): the label/merge-gate state machine was fixed, but the **bot messages contributors actually read still carried the old story** ("Fix DCO First" on every first PR, alarmist `REGULATORY BLOCK / AUTO-MERGE: PINNED`, no mention of auto-clear). This PR aligns all bot copy with the new semantics.

## Changes

| File | Change |
|---|---|
| `.github/workflows/pr-welcome.yml` | "Fix DCO First" now **conditional** — only when the PR has unsigned commits (verified via commits API); wording documents auto-clear on next push (no empty commit needed); signed PRs get "DCO: all commits signed ✅" instead |
| `.github/workflows/dco-check.yml` | failure check output includes fix commands, merge-commit exemption, and the auto-clear promise |
| `.github/actions/dco-audit/action.yml` | friendly remediation comment (fix commands + `/fix-dco` hint + auto-clear note) replacing the alarmist REGULATORY BLOCK; **marker-based upsert** (no comment stacking) |
| `.github/workflows/pr-checks.yml` | use the **local** dco-audit action (external `Ikalus1988/dco-audit@v1` was stale); cleanup matches new marker + legacy REGULATORY BLOCK; **Dependency Audit skips gracefully on workflow_dispatch** (empty base/head SHAs used to fail); Test Suite report/gate treat empty OUTCOME (manual run) as skipped, not failed |

## Why the audit robustness bits (found while triaging #1430)

A `workflow_dispatch` audit run had no PR base/head SHAs → Dependency Audit failed → the always-run report posted a bogus "❌ Test suite failed" on a docs-only PR (misleading a contributor). Guarded now.

## Verification

- YAML validated locally; DCO sign-off on the commit
- Will verify live: welcome comment on a new first PR, and re-run manual audit on an open PR to confirm it no longer emits a false failure


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Align bot DCO comments with auto-clear semantics from #1502

- Make "Fix DCO First" welcome copy conditional on real unsigned commits

- Upsert DCO failure comments via marker (no stacking) using local action

- Skip dependency audit + test suite on empty manual `workflow_dispatch` runs


___

### Diagram Walkthrough


```mermaid
  flowchart LR
    A["New first-time PR"] --> B{"Commits signed?"}
    B -- "no" --> C["Welcome: 🔏 Fix DCO First + auto-clear note"]
    B -- "yes" --> D["Welcome: DCO all commits signed ✅"]
    E["DCO failure"] --> F["dco-audit posts marker comment"]
    F -- "next push, still failing" --> G["PATCH existing comment (upsert)"]
    F -- "next push, all signed" --> H["pr-checks deletes marker + legacy REGULATORY BLOCK"]
    I["workflow_dispatch audit"] --> J{"base/head SHAs empty?"}
    J -- "yes" --> K["Dependency audit skipped; test OUTCOME treated as skipped"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Friendly DCO failure comment with marker upsert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/dco-audit/action.yml

<ul><li>Replaced alarmist "REGULATORY BLOCK / AUTO-MERGE: PINNED" with <br>friendly 🔏 remediation comment<br> <li> Added <code>misakanet-dco-block</code> marker and PATCH-then-POST upsert logic to <br>avoid stacked comments<br> <li> Documented merge-commit exemption, <code>/fix-dco</code> hint, and auto-clear <br>promise in comment body</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1503/files#diff-6e990e949807c25fb47739c18826876b8d7b86a26f2b29513711f8f619e32542">+30/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dco-check.yml</strong><dd><code>Richer DCO check run output on failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dco-check.yml

<ul><li>Failure check output now includes fix commands, merge-commit <br>exemption, and auto-clear promise<br> <li> Success branch detail unchanged but moved into a dedicated <code>detail</code> <br>field<br> <li> Output <code>text</code> field now uses the new richer <code>detail</code> instead of inline <br>ternary</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1503/files#diff-f5037a8b55ec9dd64e578bd528931937ceb9e33dc9f5ea3a644d1855227beae9">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-checks.yml</strong><dd><code>Local dco-audit + robust manual-run audit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-checks.yml

<ul><li>Switched DCO Audit step from external <code>Ikalus1988/dco-audit@v1</code> to local <br><code>./.github/actions/dco-audit</code><br> <li> Stale-comment cleanup now matches both new <code>misakanet-dco-block</code> marker <br>and legacy REGULATORY BLOCK text<br> <li> Dependency Audit skips gracefully with <code>depaudit_result=skipped</code> when <br>base/head SHAs are empty (manual <code>workflow_dispatch</code>)<br> <li> Test Suite report/gate treat empty <code>OUTCOME</code> as skipped instead of <br>emitting a bogus failure</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1503/files#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcb">+20/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-welcome.yml</strong><dd><code>Conditional DCO nag in first-PR welcome</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-welcome.yml

<ul><li>"Fix DCO First" section is now conditional — fetched via <br><code>pulls.listCommits</code>, only shown when unsigned (non-merge) commits exist<br> <li> Wording documents auto-clear on next push; removes the misleading "CI <br>runs automatically once DCO passes"<br> <li> Signed PRs now get a brief "DCO: all commits signed ✅" confirmation <br>instead of being nagged</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1503/files#diff-e3facf2449312950312e64afa07f9ee65526a40bc84a994aa80f4be5f95d2047">+40/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

