### PR TITLE
fix(ci): quality-gate label writes best-effort (fork PR 403 noise)

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -93,12 +93,15 @@ jobs:
               toAdd.push('needs-dco');
             }
 
-            // Apply
-            const uniqueAdd = toAdd.filter(l => !existing.includes(l));
-            const uniqueRemove = toRemove.filter(l => existing.includes(l));
-
+            // Apply — label writes can 403 on fork-PR check_run events where
+            // the token is read-only (issue "quality-labels 403"); treat as
+            // best-effort noise like removeLabel below, never fail the job.
             if (uniqueAdd.length > 0) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: uniqueAdd });
+              try {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: uniqueAdd });
+              } catch (e) {
+                console.log(`Skipping label add ${uniqueAdd.join(',')} (fork PR read-only run):`, e.message);
+              }
             }
             for (const label of uniqueRemove) {
               try {


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Fork PR check_run events run with a read-only GITHUB_TOKEN, so issues.addLabels 403s and turns quality-labels red on fork PRs (zsxh reports on #1400/#1411/#1505). addLabels now uses the same try/catch as removeLabel — label writes never fail the job. Resolves the quality-labels 403 column in zsxh's table.


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap `addLabels` in try/catch in `pr-quality-gate.yml`

- Treat label writes as best-effort on fork PRs

- Prevent 403 noise from failing the quality-labels check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["addLabels call (was hard fail)"] -- "wrap in try/catch" --> B["Best-effort label write"]
  B -- "log + continue on 403" --> C["Job stays green"]
  D["removeLabel (already safe)"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-quality-gate.yml</strong><dd><code>Wrap addLabels in best-effort try/catch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-quality-gate.yml

<ul><li>Wraps <code>github.rest.issues.addLabels</code> in a try/catch block<br> <li> Logs skipped label adds when fork PR token is read-only<br> <li> Adds explanatory comment referencing the quality-labels 403 issue</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1508/files#diff-4966fcd4151b7886920081583dfd552db8789c49d7e122ef2b9072b843d60edb">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

