### PR TITLE
ci(pypi): add workflow_dispatch to release-pypi (unblocks 2.28.0 publish)

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 2.28.0). Builds from current main."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -27,6 +33,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT_TAG="${{ github.ref_name }}"
+          # workflow_dispatch carries the version as input; tag pushes use the tag name
+          VERSION_INPUT="${{ github.event.inputs.version || '' }}"
+          if [ -n "$VERSION_INPUT" ]; then
+            CURRENT_TAG="v$VERSION_INPUT"
+          fi
           PREV_TAG=$(git describe --tags --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
           if [ -n "$PREV_TAG" ]; then
             SINCE=$(echo "$PREV_TAG" | sed 's/v//')


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
PyPI publish is stuck at 2.18.0: release-pypi.yml used Trusted Publishing (environment: pypi) but that environment never existed on this repo, so the publish job could never run. The `pypi` environment is now created (repo settings via API). This adds workflow_dispatch with a version input so we can publish 2.28.0 without tag delete/recreate, and makes the changelog step honor the input version. After PyPI has 2.28.0, the MCP registry publish (currently blocked with "version 2.28.0 was not found") will succeed.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `workflow_dispatch` trigger with `version` input

- Make CHANGELOG step honor input version for manual runs

- Unblock PyPI publish stuck at 2.18.0 due to missing env


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["push tag v*"] --> C["Build & Test"]
  B["workflow_dispatch with version"] --> C
  C --> D{"Use input version?"}
  D -- "yes" --> E["CURRENT_TAG = v<input>"]
  D -- "no" --> F["CURRENT_TAG = github.ref_name"]
  E --> G["Generate CHANGELOG"]
  F --> G
  G --> H["Publish to PyPI (env: pypi)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-pypi.yml</strong><dd><code>Add manual dispatch trigger with version input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-pypi.yml

<ul><li>Added <code>workflow_dispatch</code> trigger with a <code>version</code> string input<br> <li> Defaults <code>version</code> to optional so existing tag pushes still work<br> <li> Updated CHANGELOG generation step to use the input version when <br>supplied<br> <li> Falls back to <code>github.ref_name</code> when no input is provided (tag pushes)</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1511/files#diff-b66cdf1c2ec3851a39891c3db9e84217fb9918b12c6d83bd387b4c0a1cea2fae">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

