### PR TITLE
fix: replace broken Smithery badge with auto-updating dynamic badge

### DIFF
--- a/.github/workflows/update-smithery-badge.yml
+++ b/.github/workflows/update-smithery-badge.yml
@@ -1,0 +1,40 @@
+name: Update Smithery Badge (daily)
+
+on:
+  schedule:
+    # Daily: 06:00 UTC — catches Kin score updates within ~24h
+    - cron: '0 6 * * *'
+  workflow_dispatch:          # manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: data
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Fetch Smithery Kin score and write badge JSON
+        run: |
+          python3 scripts/update-smithery-badge.py --output badges/smithery.json
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "misakanet-bot"
+          git config user.email "bot@misakanet.org"
+          git add badges/smithery.json
+          if git diff --cached --quiet; then
+            echo "No change — score is the same"
+          else
+            git commit -m "chore(badge): update Smithery Kin score [skip ci]"
+            git pull --rebase origin data 2>&1 || true
+            git push || { echo "push conflict, retrying..."; sleep 5; git pull --rebase origin data 2>&1 || true; git push || echo "push skipped"; }
+          fi

--- a/.github/workflows/update-smithery-badge.yml
+++ b/.github/workflows/update-smithery-badge.yml
@@ -7,6 +7,11 @@ on:
   workflow_dispatch:          # manual trigger
 
 permissions:
+  # GITHUB_TOKEN (auto-provisioned by GitHub Actions): granted 'contents: write'
+  # scope so this job can commit the updated badge JSON to the 'data' branch
+  # and push it. No other scopes are required — the token is scoped to this
+  # repository only and expires when the workflow run ends. Do not add broader
+  # permissions (e.g. packages, issues) unless a future step needs them.
   contents: write
 
 jobs:

--- a/.github/workflows/update-smithery-badge.yml
+++ b/.github/workflows/update-smithery-badge.yml
@@ -13,9 +13,10 @@ jobs:
   update-badge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout main (for script)
+        uses: actions/checkout@v7
         with:
-          ref: data
+          ref: main
           fetch-depth: 1
 
       - uses: actions/setup-python@v7
@@ -24,7 +25,13 @@ jobs:
 
       - name: Fetch Smithery Kin score and write badge JSON
         run: |
-          python3 scripts/update-smithery-badge.py --output badges/smithery.json
+          python3 scripts/update-smithery-badge.py --output /tmp/smithery.json
+
+      - name: Checkout data branch for commit
+        run: |
+          git checkout data
+          mkdir -p badges
+          cp /tmp/smithery.json badges/smithery.json
 
       - name: Commit and push if changed
         run: |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mcp-name: io.github.Ikalus1988/misakanet
   &nbsp;&nbsp;
   <a href="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/score"><img src="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badges/score.svg" alt="Glama score"></a>
   <a href="https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet"><img src="https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg" alt="MCP Toplist"></a>
-  <a href="https://smithery.ai/servers/misakanet/misakanet"><img src="https://smithery.ai/badge/misakanet/misakanet" alt="Smithery"></a>
+  <a href="https://smithery.ai/servers/misakanet/misakanet"><img src="https://img.shields.io/badge/Smithery-82%2F100-orange" alt="Smithery"></a>
   <a href="https://hol.org/registry/plugins/Ikalus1988%2FMisakaNet"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3DIkalus1988%252FMisakaNet%26metric%3Dtrust%26style%3Dfor-the-badge%26label%3DMisakaNet" alt="MisakaNet on HOL Registry"></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/tree/main/docs/benchmarks"><img src="https://img.shields.io/badge/Benchmark-Weekly%20Workers%20AI-blue" alt="Benchmark"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mcp-name: io.github.Ikalus1988/misakanet
   &nbsp;&nbsp;
   <a href="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/score"><img src="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badges/score.svg" alt="Glama score"></a>
   <a href="https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet"><img src="https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg" alt="MCP Toplist"></a>
-  <a href="https://smithery.ai/servers/misakanet/misakanet"><img src="https://img.shields.io/badge/Smithery-82%2F100-orange" alt="Smithery"></a>
+  <a href="https://smithery.ai/servers/misakanet/misakanet"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Ikalus1988/MisakaNet/data/badges/smithery.json" alt="Smithery"></a>
   <a href="https://hol.org/registry/plugins/Ikalus1988%2FMisakaNet"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3DIkalus1988%252FMisakaNet%26metric%3Dtrust%26style%3Dfor-the-badge%26label%3DMisakaNet" alt="MisakaNet on HOL Registry"></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/tree/main/docs/benchmarks"><img src="https://img.shields.io/badge/Benchmark-Weekly%20Workers%20AI-blue" alt="Benchmark"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ mcp-name: io.github.Ikalus1988/misakanet
   &nbsp;&nbsp;
   <a href="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/score"><img src="https://glama.ai/mcp/servers/Ikalus1988/MisakaNet/badges/score.svg" alt="Glama score"></a>
   <a href="https://mcptoplist.com/server/io.github.Ikalus1988%2Fmisakanet"><img src="https://mcptoplist.com/badge/io.github.Ikalus1988%2Fmisakanet.svg" alt="MCP Toplist"></a>
+  <!-- Smithery badge uses a shields.io 'endpoint' badge that dynamically reads the Kin
+       score from data/badges/smithery.json -- updated daily by the update-smithery-badge
+       workflow, so it stays in sync without manual PRs. -->
   <a href="https://smithery.ai/servers/misakanet/misakanet"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Ikalus1988/MisakaNet/data/badges/smithery.json" alt="Smithery"></a>
   <a href="https://hol.org/registry/plugins/Ikalus1988%2FMisakaNet"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3DIkalus1988%252FMisakaNet%26metric%3Dtrust%26style%3Dfor-the-badge%26label%3DMisakaNet" alt="MisakaNet on HOL Registry"></a>
   <a href="https://github.com/Ikalus1988/MisakaNet/tree/main/docs/benchmarks"><img src="https://img.shields.io/badge/Benchmark-Weekly%20Workers%20AI-blue" alt="Benchmark"></a>

--- a/scripts/update-smithery-badge.py
+++ b/scripts/update-smithery-badge.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fetch the Smithery Kin score for MisakaNet and write a shields.io-compatible badge JSON file.
+
+Usage:
+    python3 scripts/update-smithery-badge.py [--output data/badges/smithery.json]
+
+The JSON output follows the shields.io endpoint schema:
+    {"schemaVersion": 1, "label": "Smithery", "message": "82/100", "color": "orange"}
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+SMITHERY_SERVER_URL = "https://smithery.ai/servers/misakanet/misakanet"
+DEFAULT_OUTPUT = "data/badges/smithery.json"
+
+
+def fetch_score(url: str) -> str | None:
+    """Fetch the Smithery server page and extract the Kin score.
+
+    The score is rendered as: <span>N<!-- -->/100</span> in the HTML.
+    Returns the score string like "82/100" or None if not found.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"Error fetching {url}: {e}", file=sys.stderr)
+        return None
+
+    # Pattern: <span>N<!-- -->/100</span>
+    m = re.search(r"<span>(\d+)<!-- -->/100</span>", html)
+    if m:
+        return f"{m.group(1)}/100"
+
+    print(f"Score pattern not found in HTML", file=sys.stderr)
+    return None
+
+
+def write_badge(message: str, output_path: str) -> bool:
+    """Write a shields.io-compatible badge JSON file."""
+    badge = {
+        "schemaVersion": 1,
+        "label": "Smithery",
+        "message": message,
+        "color": "orange",
+    }
+    try:
+        with open(output_path, "w") as f:
+            json.dump(badge, f, indent=2)
+        print(f"Written: {output_path}")
+        return True
+    except OSError as e:
+        print(f"Error writing {output_path}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update Smithery Kin score badge")
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT,
+        help=f"Output JSON file path (default: {DEFAULT_OUTPUT})",
+    )
+    args = parser.parse_args()
+
+    score = fetch_score(SMITHERY_SERVER_URL)
+    if score is None:
+        print("Failed to fetch Smithery score", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Smithery Kin score: {score}")
+    if not write_badge(score, args.output):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The Smithery badge in the README is serving **HTTP 500**, so it renders as a broken image:

```
https://smithery.ai/badge/misakanet/misakanet → 500
```

This isn't specific to this repo — Smithery's badge endpoint is failing across the ecosystem (confirmed by testing multiple servers, all return 500).

## Fix

Replaced the broken badge with a **self-updating dynamic badge** that stays in sync with the actual Smithery Kin score.

### How it works

| Component | Purpose |
|-----------|---------|
| `scripts/update-smithery-badge.py` | Fetches `https://smithery.ai/servers/misakanet/misakanet`, extracts the Kin score from HTML (`<span>N<!-- -->/100</span>`), writes a shields.io-compatible JSON file |
| `.github/workflows/update-smithery-badge.yml` | Runs daily at 06:00 UTC on the `data` branch, executes the script, commits/pushes the updated JSON to `data/badges/smithery.json` |
| README.md | Uses shields.io's `/endpoint` badge to dynamically render the score from `data/badges/smithery.json` |

### Badge URL (dynamic)

```markdown
<img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Ikalus1988/MisakaNet/data/badges/smithery.json" alt="Smithery">
```

The badge now updates automatically — no manual PR needed when the Kin score changes.

### Files changed

- `README.md` — badge image src updated to use shields.io endpoint
- `scripts/update-smithery-badge.py` — new: score extractor script
- `.github/workflows/update-smithery-badge.yml` — new: daily update workflow

### Verification

- [x] Script correctly extracts score: `82/100`
- [x] shields.io endpoint badge renders from the JSON file
- [x] Initial badge JSON pushed to `data/badges/smithery.json` on the `data` branch
- [x] Bug report filed upstream: https://github.com/clavia-labs/.github/issues/15

### Reverting (when Smithery fixes their endpoint)

Once `https://smithery.ai/badge/misakanet/misakanet` returns 200 with an SVG, revert to:

```markdown
<img src="https://smithery.ai/badge/misakanet/misakanet" alt="Smithery">
```

And remove:
- `scripts/update-smithery-badge.py`
- `.github/workflows/update-smithery-badge.yml`
