### PR TITLE
fix(api): wire ?search= filter to /api/lessons endpoint

### DIFF
--- a/scripts/intake_bot.py
+++ b/scripts/intake_bot.py
@@ -78,8 +78,7 @@ _CORPUS_TTL = 300  # seconds
 
 
 def _load_corpus(timeout: int = 60) -> list[dict]:
-    """拉全量语料（limit=5000，~360 lessons）本地打分——服务端 ?search= 过滤器当前
-    未生效（2026-09-06 探明，待修）。缓存 300s 吸收冷启动延迟。失败返回 []（降级）。"""
+    """拉全量语料（limit=5000，~360 lessons）本地打分。缓存 300s 吸收冷启动延迟。失败返回 []（降级）。"""
     if CORPUS_FILE.exists() and time.time() - CORPUS_FILE.stat().st_mtime < _CORPUS_TTL:
         try:
             return json.loads(CORPUS_FILE.read_text(encoding="utf-8"))

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -2409,7 +2409,7 @@ export default {
         const qTag = url.searchParams.get("tag");
         const qId = url.searchParams.get("id");
         const qLimit = url.searchParams.get("limit");
-        const qSearch = url.searchParams.get("q");
+        const qSearch = url.searchParams.get("q") || url.searchParams.get("search");
         if (qDomain) filters.domain = qDomain.slice(0, 50);
         if (qStatus) filters.status = qStatus.slice(0, 20);
         if (qTag) filters.tag = qTag.slice(0, 50);
@@ -2420,8 +2420,17 @@ export default {
         // PRD ④ #1356: FTS5 full-text search via ?q=term (ranked).
         if (qSearch) {
           const d1 = d1Binding(env);
-          if (!d1) return jsonResponse({ error: "Full-text search requires the D1 service", filtered: true, filters });
           const limit = Math.min(Math.max(parseInt(qLimit, 10) || 20, 1), 50);
+          if (!d1) {
+            // Client-side fallback when D1 is not bound
+            const allLessons = await loadLessons(env, {});
+            const terms = qSearch.toLowerCase().split(/\s+/).filter(Boolean);
+            const filtered = allLessons.filter(l => {
+              const haystack = [l.title || "", l.summary || "", l.domain || "", ...(l.tags || [])].join(" ").toLowerCase();
+              return terms.every(t => haystack.includes(t));
+            }).slice(0, limit);
+            return jsonResponse({ query: qSearch, results: filtered, source: "client-side" });
+          }
           // FTS5 MATCH with sanitized query; join lessons for full metadata.
           const safeQ = qSearch.replace(/["']/g, " ").trim().slice(0, 100);
           let sql =

--- a/workers/register-proxy.js
+++ b/workers/register-proxy.js
@@ -247,6 +247,29 @@ async function getWithCache(env, cacheKey, fetchFn) {
   return data;
 }
 
+// ── Lessons 搜索过滤 ──
+function filterLessons(lessons, query, limit) {
+  if (!query) return lessons.slice(0, limit);
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  const scored = [];
+  for (const lesson of lessons) {
+    const haystack = [
+      lesson.title || "",
+      lesson.summary || "",
+      lesson.domain || "",
+      ...(lesson.tags || []),
+    ]
+      .join(" ")
+      .toLowerCase();
+    let matched = true;
+    for (const t of terms) {
+      if (!haystack.includes(t)) { matched = false; break; }
+    }
+    if (matched) scored.push(lesson);
+  }
+  return scored.slice(0, limit);
+}
+
 // ── API 路由处理 ──
 async function handleApiRequest(pathWithQuery, env, request) {
   // 分离路径与查询参数
@@ -291,7 +314,11 @@ async function handleApiRequest(pathWithQuery, env, request) {
       const data = await getWithCache(env, "proxy:lessons", () =>
         fetchFromGitHub(token, "lessons.json", "data")
       );
-      return jsonResponse(data);
+      const params = new URLSearchParams(search);
+      const q = (params.get("search") || "").trim();
+      const limit = Math.min(parseInt(params.get("limit") || "50", 10) || 50, 500);
+      const results = filterLessons(data, q, limit);
+      return jsonResponse(results);
     }
 
     case "/api/health":
@@ -368,7 +395,7 @@ function serveLandingPage() {
       <dt>GET /api/counter</dt>
       <dd>获取节点计数器 (GitHub Token 代理 + KV 缓存 30s)</dd>
       <dt>GET /api/lessons</dt>
-      <dd>获取 lessons 索引 (GitHub Token 代理 + KV 缓存 30s)</dd>
+      <dd>获取 lessons 索引 (支持 <code>?search=&lt;q&gt;&limit=N</code> 过滤)</dd>
       <dt>GET /api/health</dt>
       <dd>健康检查 (返回 Token / KV 配置状态)</dd>
     </dl>
@@ -627,4 +654,5 @@ export {
   handleDemandBoard,
   handleDemandMap,
   handlePrGeniusStats,
+  filterLessons,
 };

--- a/workers/register-proxy.test.mjs
+++ b/workers/register-proxy.test.mjs
@@ -9,6 +9,7 @@ import {
   buildDemandMapBuckets,
   handleDemandBoard,
   handleDemandMap,
+  filterLessons,
 } from './register-proxy.js';
 
 function createFakeKV(seed = {}) {
@@ -159,4 +160,64 @@ test('handleDemandMap requires a maintainer key and rejects mismatches', async (
   assert.equal(body.buckets[0].unsolvedReason, 'too_basic');
   assert.equal(body.buckets[0].unsolvedCount, 1);
   assert.equal(body.buckets[0].distinctSourceCount, 1);
+});
+
+// ── filterLessons tests ──
+
+const SAMPLE_LESSONS = [
+  { id: 'pip-proxy', title: 'pip proxy timeout', domain: 'devops', tags: ['pip', 'proxy'], summary: 'pip install fails behind corporate proxy' },
+  { id: 'docker-build', title: 'docker build cache', domain: 'devops', tags: ['docker'], summary: 'Docker layer caching strategies' },
+  { id: 'github-auth', title: 'GitHub token 401', domain: 'devops', tags: ['github', 'token'], summary: 'GitHub PAT authentication failure' },
+  { id: 'python-import', title: 'Python import error', domain: 'python', tags: ['import'], summary: 'ModuleNotFoundError resolution' },
+];
+
+test('filterLessons returns all when query is empty', () => {
+  const result = filterLessons(SAMPLE_LESSONS, '', 50);
+  assert.equal(result.length, 4);
+});
+
+test('filterLessons matches single term in title', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'docker', 50);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'docker-build');
+});
+
+test('filterLessons matches single term in summary', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'corporate', 50);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'pip-proxy');
+});
+
+test('filterLessons matches single term in tags', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'token', 50);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'github-auth');
+});
+
+test('filterLessons matches multiple terms (AND logic)', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'pip proxy', 50);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'pip-proxy');
+});
+
+test('filterLessons returns empty when no match', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'kubernetes', 50);
+  assert.equal(result.length, 0);
+});
+
+test('filterLessons applies limit', () => {
+  const result = filterLessons(SAMPLE_LESSONS, '', 2);
+  assert.equal(result.length, 2);
+});
+
+test('filterLessons is case-insensitive', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'Docker', 50);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'docker-build');
+});
+
+test('filterLessons matches domain field', () => {
+  const result = filterLessons(SAMPLE_LESSONS, 'python', 50);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'python-import');
 });


### PR DESCRIPTION
## Problem

`GET /api/lessons?search=pip+proxy&limit=5` returns the full unfiltered `lessons.json` — the `?search=` parameter is silently ignored.

Root cause: the `/api/lessons` handler in `register-proxy.js` fetches from GitHub and returns the raw array without any filtering logic.

## Fix

### register-proxy.js (deployed worker)
- Added `filterLessons(lessons, query, limit)` — client-side AND-match on title, summary, domain, tags (case-insensitive)
- Wired `?search=` and `?limit=` params from the URL query string
- Exported `filterLessons` for testability
- Updated landing page docs to mention search support

### register-proxy-sw.js (D1-capable worker)
- Accept `?search=` as alias for `?q=` (both now work)
- Added client-side filtering fallback when D1 is not bound (instead of returning an error)

### Tests
- 9 new test cases in `register-proxy.test.mjs`: empty query, single term in title/summary/tags, multi-term AND, case-insensitive, limit, no match, domain match
- All 20 tests pass

### Cleanup
- `intake_bot.py`: removed stale comment about broken search filter

## Verification

```bash
# Before: returns all 363 lessons regardless of query
curl "https://misakanet.org/api/lessons?search=docker&limit=5"

# After: returns only matching lessons (up to limit)
curl "https://misakanet.org/api/lessons?search=docker&limit=5"
```

Closes #1524