### PR TITLE
feat(contrib): explain first-PR CI approval gate + DCO interplay (#1536)

### DIFF
--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -54,6 +54,21 @@ jobs:
 
             body.push(
               "",
+              "### ⏳ First PR: CI waits for one-time maintainer approval",
+              "",
+              "On your **first PR from a fork**, GitHub requires a maintainer to approve",
+              "workflow runs before CI can start (a safety gate). Until then checks may show",
+              "as *waiting / grey* — **that is expected, not a problem with your PR**.",
+              "A maintainer usually approves within a day; after that, CI runs automatically",
+              "on every push (including force-pushes).",
+              "",
+              "If you see a red `needs-dco` label or DCO check, fix it now so your PR is",
+              "already green once CI is approved (see above — the label auto-clears after",
+              "you amend + force-push; no empty commit needed)."
+            );
+
+            body.push(
+              "",
               "### Quick Links",
               "",
               "- [Register your node](https://github.com/Ikalus1988/MisakaNet/issues/new?template=register.yml) - get a Misaka ID",
@@ -78,7 +93,7 @@ jobs:
               "  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"misakanet_submit_intake\",\"arguments\":{\"problem\":\"YOUR PROBLEM\",\"source\":\"your-agent\"}}}'",
               "```",
               "",
-              "CI checks run automatically on every push."
+              "After the one-time approval, CI checks run automatically on every push."
             );
 
             await github.rest.issues.createComment({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ When you open a PR, several automated checks run. **These are quality gates, not
 
 > **"auto-merge: fail"** → This is expected for first-time contributors. The maintainer will merge manually after review.
 
+> **First PR checks look grey / "waiting"** → This is GitHub's one-time approval gate for fork PRs: a maintainer must approve workflow runs before CI starts (usually within a day). It is not a problem with your PR — checks will run automatically once approved, and on every push after that.
+
 > **"DCO: fail"** → The ONLY blocker you must fix. Run:
 > ```bash
 > git commit -s --amend --no-edit


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
First-time fork contributors hit two unexplained gates at once (see #1513): GitHub's one-time workflow approval (checks grey/action_required) and needs-dco. pr-welcome.yml now explains both to first-timers; CONTRIBUTING documents grey-check behavior. Tracks #1536.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add first-PR CI approval gate explanation to `pr-welcome.yml` welcome comment

- Document grey-check behavior for fork first-time contributors in `CONTRIBUTING.md`

- Clarify `needs-dco` auto-clears once CI is approved, no empty commit needed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["First-time fork PR opened"] --> B["pr-welcome.yml posts welcome comment"]
  B --> C["Explains grey checks = approval gate"]
  B --> D["Explains needs-dco auto-clears"]
  C --> E["Maintainer approves workflow"]
  D --> F["DCO amend + force-push"]
  E --> G["CI runs on every push"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-welcome.yml</strong><dd><code>Welcome comment explains first-PR approval gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-welcome.yml

<ul><li>Adds "⏳ First PR: CI waits for one-time maintainer approval" section <br>to first-time contributor welcome comment<br> <li> Explains grey checks are expected for fork first PRs and a maintainer <br>usually approves within a day<br> <li> Clarifies <code>needs-dco</code> should be fixed before approval so the PR is green <br>when CI runs<br> <li> Updates closing line to note CI runs after the one-time approval</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1537/files#diff-e3facf2449312950312e64afa07f9ee65526a40bc84a994aa80f4be5f95d2047">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Document first-PR grey-check behavior in CONTRIBUTING</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

<ul><li>Adds a Common Scenarios entry explaining grey/waiting checks for <br>first-PR fork contributors<br> <li> Clarifies the approval gate is expected behavior, not a PR problem<br> <li> Confirms checks run automatically once approved and on every push <br>after</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1537/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

