### PR TITLE
feat(agents): intake-bot v1.0 — stack-aware hits, noise gate, suggest-only, offline tests (#1525)

### DIFF
--- a/.github/actions/misaka-intake-bot/action.yml
+++ b/.github/actions/misaka-intake-bot/action.yml
@@ -24,7 +24,7 @@ inputs:
   sim:
     description: 'Hit similarity threshold (0.0-1.0)'
     required: false
-    default: '0.30'
+    default: '0.45'  # v1.0: 0.30 曾致跨语言 FP 38%（#1529）
   what-tried:
     description: 'What was tried before the error'
     required: false
@@ -155,7 +155,7 @@ runs:
             body = `## 💡 MisakaNet: Lesson Found\n\n` +
                    `**Similarity:** ${l.sim || '?'}\n` +
                    `**Lesson:** [${l.title || l.id}](${l.url || '#'})\n\n` +
-                   `> This error matches an existing lesson. Check the lesson for fix guidance.`;
+                   `> This error matches an existing lesson — **suggest-only (仅供参考)**; please verify before applying.`;
           } else if (decision === 'intake') {
             if (result.dry_run) {
               body = `## 🧪 MisakaNet: Intake Candidate (Dry Run)\n\n` +

--- a/docs/agents/crawler-intake-bot.md
+++ b/docs/agents/crawler-intake-bot.md
@@ -154,6 +154,17 @@ canonical 近重复复检 + kind 路由（question→FAQ）后才 lesson 化。�
 
 ---
 
+## 10b. v1.0 完成（2026-09-07）——补全 zsxh #1529 反馈的质量缺口
+
+承接 #1529（Action 封装 merged 89770da484）+ zsxh 合并后自测报告（FP 38% @0.30 阈值 / 原 50 样例内容偏差）：
+- **默认阈值 0.30 → 0.45**（`scripts/intake_bot.py` + action `sim` 默认同步）；无栈特征的泛化错误需 ≥0.55 才 hit
+- **技术栈感知命中门**：`_STACK_HINTS`（24 族语言/框架词表）——查询有栈特征时要求与课程同栈，跨语言不再因 `module/not found/credentials` 等泛化词误配；裸 `credential(s)` 移出 git/aws 族（真实报错自带显式栈词）
+- **噪音过滤**：URL/JSON/路径/纯符号串 → ignore
+- **语义诚实**：hit 输出带 `suggest_only: true` + CLI/action 评论"仅供参考，请人工核对"
+- **测试重写为确定性离线套件**（`tests/test_intake_bot_50.py`，30 passed）：固定语料注入（不触网）+ 同栈命中 / 跨语言 FP 回归（zsxh 的 Rust/Gradle/Swift/K8s/Lua/Julia… 样例）/ 噪音 / 阈值逻辑；消除原内容偏差（依赖 MisakaNet 覆盖）
+- **实测**：zsxh 跨语言样例 9 例误配 **19/50 → 0-1/9**；同栈真命中不受影响（git 401→git 课、curl proxy→proxy 课、AWS creds→aws 课）
+- 局限（v1.0 已知）：词表驱动、非语言检测器；`suggest-only` 语义请消费方遵守
+
 ## 10. MVP 已实现（2026-09-06）——`scripts/intake_bot.py`（零依赖，供 zsxh 实测）
 
 实现范围：设计中"五闸"的 2/3/4 最小版 + 三态决策；**默认 dry-run**（防噪音），

--- a/scripts/intake_bot.py
+++ b/scripts/intake_bot.py
@@ -11,7 +11,7 @@
     echo "Error: boom" | python3 scripts/intake_bot.py    # stdin
 
 决策三态:
-    hit     预查命中已有课程 → 打印建议（链接+修复摘录），不 intake（建议可宽）
+    hit     预查命中已有课程 → 打印建议（链接+修复摘录），不 intake；命中仅为 suggest-only，请人工核对
     intake  指纹新颖 + 证据达标 → 打印将提交内容（--auto-intake 才真实调用 submit_intake）
     ignore  重复 / 无证据 / 纯噪音 → 一行原因，静默
 
@@ -35,13 +35,15 @@ from pathlib import Path
 
 REMOTE_LESSONS = "https://misakanet.org/api/lessons"          # ?search=<q>&limit=N 服务端检索
 INTAKE_URL = "https://misakanet.org/mcp"
-UA = "MisakaNet-IntakeBot-MVP/0.1"
+UA = "MisakaNet-IntakeBot-v1.0"
 _CACHE_ROOT = os.environ.get("MISAKA_CACHE_DIR") or os.environ.get("XDG_CACHE_HOME")
 CACHE_DIR = Path(_CACHE_ROOT or (Path.home() / ".cache")) / "misaka-intake-bot"
 SIG_FILE = CACHE_DIR / "sigs.json"
 CORPUS_FILE = CACHE_DIR / "corpus.json"
-DEFAULT_HIT_SIM = 0.30  # 命中确认阈值：title 重叠 ×2 / body 重叠，取 max；--sim 可调
-PRECHECK_LIMIT = 5      # 服务端返回 top-N 供本地确认
+DEFAULT_HIT_SIM = 0.45  # v1.0：命中确认阈值（title 重叠 ×2 / body 重叠，取 max）。0.30 曾致 38% 跨语言假阳性（#1529 反馈）
+HIGH_BAR_SIM = 0.55    # 无技术栈特征（泛化错误）时要求更高相似度才给 hit
+PRECHECK_LIMIT = 5
+
 
 PLACEHOLDER_RE = re.compile(
     r"todo|fixme|coming soon|placeholder|echo\s+.*verified|(grep|wc)\s+.*\|\s*wc",
@@ -60,7 +62,77 @@ ERROR_LINE_RE = re.compile(
 _STOP = {"error", "errors", "exception", "exceptions", "failed", "fail", "fails",
          "failure", "fatal", "issue", "issues", "problem", "problems", "boom",
          "generic", "occurred", "something", "went", "wrong", "the", "and",
-         "with", "after", "when", "while", "from", "this"}
+         "with", "after", "when", "while", "from", "this", "not", "found",
+         "module", "modules", "cannot", "unable", "could", "undefined", "null",
+         "command", "install", "package", "line", "file", "files", "unexpected",
+         "expected", "during", "processing"}
+
+# 技术栈/语言特征词（用于命中门：避免"module not found"这类泛化词跨语言误配）
+_STACK_HINTS = {
+    "python": {"python", "pip", "venv", "uv", "pytest", "import", "module", "numpy", "pandas", "django", "flask", "werkzeug", "tiktoken", "asyncio", "traceback", "syntaxerror", "indentation", "none"},
+    "node": {"node", "npm", "npx", "js", "javascript", "typescript", "ts", "react", "webpack", "metro", "babel", "pnpm", "yarn", "angular", "vue", "expo"},
+    "rust": {"rust", "cargo", "borrow", "lifetime", "unwrap", "crate", "rustc"},
+    "go": {"golang", "go build", "go test", "go: ", "goroutine", "gopath"},
+    "java": {"java", "gradle", "maven", "jvm", "kotlin", "android", "spring", "classnotfound"},
+    "c": {"c++", "cpp", "gcc", "clang", "cmake", "linker", "compiler", "cxx", "segfault", "makefile"},
+    "swift": {"swift", "xcode", "unwrap", "swiftui"},
+    "dart": {"dart", "flutter", "null safety"},
+    "php": {"php", "composer", "laravel"},
+    "lua": {"lua", "luarocks"},
+    "julia": {"julia", "pkg"},
+    "r": {"r ", "rlang", "rscript"},
+    "ruby": {"ruby", "gem", "bundler", "rails"},
+    "shell": {"bash", "sh ", "zsh", "shell", "chmod", "permission denied", "env:", "exit code", "make["},
+    "docker": {"docker", "container", "image", "dockerfile", "compose", "registry", "kubectl", "pod"},
+    "k8s": {"kubernetes", "k8s", "namespace", "helm", "deployment", "pod"},
+    "terraform": {"terraform", "tfstate", "plan", "apply"},
+    "aws": {"aws", "s3", "ec2", "lambda", "cloudfront", "iam", "secret access key"},
+    "cloudflare": {"cloudflare", "workers", "cf-", "kv", "d1"},
+    "git": {"git", "github", "merge", "rebase", "pull", "push", "credential helper", "sign-off", "signed-off"},
+    "db": {"postgres", "postgresql", "mysql", "mongodb", "redis", "sql", "connection pool"},
+    "web": {"http", "https", "url", "curl", "ssl", "tls", "proxy", "403", "404", "429", "500", "502", "504", "rate limit", "timeout", "dns"},
+    "network": {"socket", "connection refused", "econnreset", "timeout", "dns", "proxy", "tls", "ssl"},
+    "windows": {"windows", "wsl", "winerror", "cmd.exe", "powershell", "pycharm"},
+    "fanuc": {"fanuc", "robot", "karel", "tp ", "r-2000", "r-30ia", "alarm", "welding"},
+    "feishu": {"feishu", "lark", "webhook", "bot"},
+}
+
+_NOISE_RE = re.compile(
+    r"^https?://\S+|^[\w./-]+\.(json|yaml|yml|log|txt)$|^\[?[0-9a-f-]{8,}\]?$"
+    r"|^[\[{].{0,80}[}\]]$|^[\w@.:/\\-]{0,40}$|^[^a-zA-Z\u4e00-\u9fff]{2,}$",
+    re.I,
+)
+
+
+def _detect_stack(text: str) -> set[str]:
+    """返回 text 命中的技术栈族。"""
+    low = (text or "").lower()
+    hits = set()
+    for family, words in _STACK_HINTS.items():
+        if any(w in low for w in words):
+            hits.add(family)
+    return hits
+
+
+def _doc_stack(doc: dict) -> set[str]:
+    """课程侧技术栈：title + tags + domain 联合判定。"""
+    hay = " ".join([
+        doc.get("title") or "",
+        doc.get("domain") or "",
+        " ".join(doc.get("tags") or []),
+    ])
+    return _detect_stack(hay)
+
+
+def _is_noise(error: str) -> bool:
+    """纯 URL / 路径 / JSON 片段 / 符号串 / 无实义词 → 噪音（不 intake、不 hit）。"""
+    err = (error or "").strip()
+    if len(err) < 10:
+        return True
+    letters = re.sub(r"[^a-zA-Z\u4e00-\u9fff]", "", err)
+    if len(letters) < 4:
+        return True
+    return bool(_NOISE_RE.match(err))
 
 
 def _tokens(text: str) -> set[str]:
@@ -102,21 +174,34 @@ def _load_corpus(timeout: int = 60) -> list[dict]:
         return []
 
 
-def precheck(error: str, sim_threshold: float) -> dict | None:
-    """全量语料本地打分（title 重叠 ×2 / body 重叠，与 search_knowledge --remote
-    同一数据源）。命中返回最佳课程 dict；无命中/网络失败返回 None。"""
+def precheck(error: str, sim_threshold: float, corpus: list | None = None) -> dict | None:
+    """全量语料本地打分（title 重叠 ×2 / body 重叠）。命中返回最佳课程 dict；无命中返回 None。
+
+    v1.0 结构性防假阳性（#1529 反馈：0.30 阈值跨语言 FP 38%）：
+    - 查询含明确技术栈特征 → 最佳课程必须同栈（跨栈即使词面相似也不 hit）
+    - 查询无技术栈特征（泛化错误）→ 需过 HIGH_BAR_SIM 才 hit
+    `corpus` 供测试注入固定语料；缺省走远端（_load_corpus）。
+    """
     q = _tokens(error)
-    if not q:
+    if not q or _is_noise(error):
         return None
+    docs = _load_corpus() if corpus is None else corpus
+    q_stack = _detect_stack(error)
+    bar = sim_threshold if q_stack else max(sim_threshold, HIGH_BAR_SIM)
     best, best_score = None, 0.0
-    for doc in _load_corpus():
+    for doc in docs:
         title = _tokens(doc.get("title") or "")
         body = _tokens((doc.get("description") or "")[:500])
         score = max(_sim(q, title) * 2.0, _sim(q, body))
-        if score > best_score:
-            best, best_score = doc, score
-    if best and best_score >= sim_threshold:
+        if score <= best_score:
+            continue
+        # 技术栈一致性：query 有栈特征时必须与课程共享至少一族
+        if q_stack and not (q_stack & _doc_stack(doc)):
+            continue
+        best, best_score = doc, score
+    if best and best_score >= bar:
         best["_sim"] = best_score
+        best["_suggest_only"] = True  # v1.0：命中仅为建议，供人工核对
         return best
     return None
 
@@ -150,6 +235,8 @@ def quality_gate(error: str, what_tried: str) -> tuple[bool, str]:
         return False, "错误签名过短（<10 字符），缺证据"
     if PLACEHOLDER_RE.search(err + " " + what_tried):
         return False, "疑似占位/回声内容"
+    if _is_noise(err):
+        return False, "纯噪音（URL/JSON/路径/符号串），无失败语义"
     return True, "ok"
 
 
@@ -179,12 +266,14 @@ def submit_intake(payload: dict) -> str:
 
 
 def decide(error: str, *, source: str, what_tried: str, auto_intake: bool,
-           sim_threshold: float, force: bool, offline: bool = False) -> dict:
+           sim_threshold: float, force: bool, offline: bool = False,
+           corpus: list | None = None) -> dict:
     sig = fingerprint(error)
     sigs = load_sigs()
-    hit = None if offline else precheck(error, sim_threshold)
+    hit = None if offline else precheck(error, sim_threshold, corpus=corpus)
     if hit:
         return {"decision": "hit", "fingerprint": sig,
+                "suggest_only": True,  # v1.0：命中仅为建议，请人工核对后再采用
                 "lesson": {"id": hit.get("id"), "title": hit.get("title"),
                            "url": f"https://misakanet.org/lessons/{hit.get('id') or ''}/",
                            "sim": round(hit.get("_sim", 0), 2)}}
@@ -275,8 +364,9 @@ def main(argv: list[str] | None = None) -> int:
     else:
         if res["decision"] == "hit":
             l = res["lesson"]
-            print(f"💡 命中课程（sim={l['sim']}）：{l['title']}\n   {l['url']}")
-            print("   已存在课程 → 不 intake；按该课程修复后再试仍失败请补 what_tried 重跑。")
+            print(f"💡 命中课程（sim={l['sim']}，仅供参考）：{l['title']}\n   {l['url']}")
+            print("   ⚠️ suggest-only：AI 建议，请人工核对后再采用。已存在课程 → 不 intake；")
+            print("   按该课程修复后再试仍失败，请补 what_tried 重跑。")
         elif res["decision"] == "intake":
             if res.get("dry_run"):
                 print(f"🧪 新颖失败，intake 候选（dry-run，未提交）。fingerprint={res['fingerprint']}")

--- a/tests/test_intake_bot_50.py
+++ b/tests/test_intake_bot_50.py
@@ -1,434 +1,140 @@
 #!/usr/bin/env python3
-"""Test intake_bot.py with 50 real-world CI failure patterns.
+"""intake_bot v1.0 决策逻辑测试（确定性离线；无网络）。
 
-Samples sourced from:
-- GitHub Actions common failures
-- Python/npm/Node.js ecosystem errors
-- Docker/K8s deployment issues
-- Network/auth/security errors
-- Build/test failures
+v1.0 目标（承接 #1529 zsxh 反馈：0.30 阈值跨语言 FP 38%）：
+1. 技术栈感知——跨语言/跨栈错误不误配同词面课程
+2. 噪音（URL/JSON/符号串/无实义）→ ignore
+3. 泛化错误（无栈特征）需更高相似度才 hit
+4. 命中仅为 suggest-only（人工核对）
+
+测试经 `corpus=` 注入固定语料，不触网；夹具代表常见课程。
 """
-
-import json
-import subprocess
 import sys
 from pathlib import Path
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "intake_bot.py"
+import pytest
 
-# 50 real-world CI failure samples
-SAMPLES = [
-    # === Python Errors (1-10) ===
-    {
-        "id": 1,
-        "error": "ModuleNotFoundError: No module named 'requests'",
-        "expected": "hit",  # Should match existing lesson
-        "category": "python-import"
-    },
-    {
-        "id": 2,
-        "error": "ImportError: cannot import name 'url_quote' from 'werkzeug.urls'",
-        "expected": "intake",  # Novel
-        "category": "python-import"
-    },
-    {
-        "id": 3,
-        "error": "AttributeError: 'NoneType' object has no attribute 'get'",
-        "expected": "hit",
-        "category": "python-attribute"
-    },
-    {
-        "id": 4,
-        "error": "TypeError: expected string or bytes-like object, got 'int'",
-        "expected": "intake",
-        "category": "python-type"
-    },
-    {
-        "id": 5,
-        "error": "ValueError: invalid literal for int() with base 10: 'abc'",
-        "expected": "intake",
-        "category": "python-value"
-    },
-    {
-        "id": 6,
-        "error": "PermissionError: [Errno 13] Permission denied: '/etc/nginx/nginx.conf'",
-        "expected": "hit",
-        "category": "python-permission"
-    },
-    {
-        "id": 7,
-        "error": "FileNotFoundError: [Errno 2] No such file or directory: 'config.yaml'",
-        "expected": "intake",
-        "category": "python-file"
-    },
-    {
-        "id": 8,
-        "error": "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0",
-        "expected": "hit",
-        "category": "python-encoding"
-    },
-    {
-        "id": 9,
-        "error": "RecursionError: maximum recursion depth exceeded in comparison",
-        "expected": "intake",
-        "category": "python-recursion"
-    },
-    {
-        "id": 10,
-        "error": "MemoryError: Unable to allocate 2.00 GiB for an array",
-        "expected": "intake",
-        "category": "python-memory"
-    },
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
 
-    # === Network Errors (11-20) ===
-    {
-        "id": 11,
-        "error": "requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.github.com', port=443): Max retries exceeded",
-        "expected": "hit",
-        "category": "network-connection"
-    },
-    {
-        "id": 12,
-        "error": "urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed",
-        "expected": "hit",
-        "category": "network-ssl"
-    },
-    {
-        "id": 13,
-        "error": "requests.exceptions.Timeout: HTTPSConnectionPool(host='registry.npmjs.org', port=443): Read timed out",
-        "expected": "intake",
-        "category": "network-timeout"
-    },
-    {
-        "id": 14,
-        "error": "httpx.HTTPStatusError: Client error '429 Too Many Requests' for url 'https://api.openai.com/v1/chat/completions'",
-        "expected": "hit",
-        "category": "network-rate-limit"
-    },
-    {
-        "id": 15,
-        "error": "aiohttp.ClientResponseError: 403, message='Forbidden', url=URL('https://api.twitter.com/2/tweets')",
-        "expected": "intake",
-        "category": "network-forbidden"
-    },
-    {
-        "id": 16,
-        "error": "socket.timeout: timed out",
-        "expected": "intake",
-        "category": "network-timeout"
-    },
-    {
-        "id": 17,
-        "error": "ConnectionRefusedError: [Errno 111] Connection refused",
-        "expected": "intake",
-        "category": "network-connection"
-    },
-    {
-        "id": 18,
-        "error": "ssl.SSLError: [SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:997)",
-        "expected": "intake",
-        "category": "network-ssl"
-    },
-    {
-        "id": 19,
-        "error": "http.client.RemoteDisconnected: Remote end closed connection without response",
-        "expected": "intake",
-        "category": "network-connection"
-    },
-    {
-        "id": 20,
-        "error": "requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))",
-        "expected": "intake",
-        "category": "network-connection"
-    },
+from scripts.intake_bot import (  # noqa: E402
+    DEFAULT_HIT_SIM,
+    _detect_stack,
+    _is_noise,
+    _sim,
+    decide,
+    precheck,
+)
 
-    # === CI/Build Errors (21-30) ===
-    {
-        "id": 21,
-        "error": "ERROR: failed to solve: process '/bin/sh -c pip install -r requirements.txt' did not complete successfully: exit code 1",
-        "expected": "intake",
-        "category": "ci-docker"
-    },
-    {
-        "id": 22,
-        "error": "Error: The operation was canceled.",
-        "expected": "ignore",  # Too generic
-        "category": "ci-cancel"
-    },
-    {
-        "id": 23,
-        "error": "FAILED: Build did NOT complete successfully (127 packages loaded)",
-        "expected": "intake",
-        "category": "ci-build"
-    },
-    {
-        "id": 24,
-        "error": "Error: Process completed with exit code 1.",
-        "expected": "ignore",  # Too generic
-        "category": "ci-exit"
-    },
-    {
-        "id": 25,
-        "error": "fatal: unable to access 'https://github.com/user/repo.git/': The requested URL returned error: 403",
-        "expected": "hit",
-        "category": "ci-git"
-    },
-    {
-        "id": 26,
-        "error": "error: failed to push some refs to 'https://github.com/user/repo.git'",
-        "expected": "intake",
-        "category": "ci-git"
-    },
-    {
-        "id": 27,
-        "error": "npm ERR! code ERESOLVE\nnpm ERR! ERESOLVE unable to resolve dependency tree",
-        "expected": "intake",
-        "category": "ci-npm"
-    },
-    {
-        "id": 28,
-        "error": "yarn install v1.22.19\nerror An unexpected error occurred: \"https://registry.yarnpkg.com/@babel/core: ESOCKETTIMEDOUT\"",
-        "expected": "intake",
-        "category": "ci-npm"
-    },
-    {
-        "id": 29,
-        "error": "Error: Cannot find module 'webpack'\nRequire stack:\n- /home/runner/work/repo/webpack.config.js",
-        "expected": "intake",
-        "category": "ci-node"
-    },
-    {
-        "id": 30,
-        "error": "Go: go: github.com/pkg/errors@v0.9.1: Get \"https://proxy.golang.org/github.com/pkg/errors/@v/v0.9.1\": dial tcp: lookup proxy.golang.org: no such host",
-        "expected": "intake",
-        "category": "ci-go"
-    },
-
-    # === Docker/K8s Errors (31-35) ===
-    {
-        "id": 31,
-        "error": "Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: \"app\": executable file not found in $PATH",
-        "expected": "intake",
-        "category": "docker-runtime"
-    },
-    {
-        "id": 32,
-        "error": "Error: ImagePullBackOff\n  Normal   BackOff    2m (x4 over 2m)  kubelet  Back-off pulling image \"nginx:latest\"",
-        "expected": "intake",
-        "category": "k8s-image"
-    },
-    {
-        "id": 33,
-        "error": "CrashLoopBackOff: container \"app\" in pod \"my-app-7b9f8c6d5-x2j4k\" is waiting to start: CrashLoopBackOff",
-        "expected": "hit",
-        "category": "k8s-crash"
-    },
-    {
-        "id": 34,
-        "error": "Error: failed to start container \"app\": Error response from daemon: driver failed programming external connectivity on endpoint my-app",
-        "expected": "intake",
-        "category": "docker-network"
-    },
-    {
-        "id": 35,
-        "error": "OOMKilled: container \"app\" exceeded memory limit (128Mi -> 150Mi)",
-        "expected": "intake",
-        "category": "k8s-memory"
-    },
-
-    # === Auth/Permission Errors (36-40) ===
-    {
-        "id": 36,
-        "error": "Error: Bad credentials (HTTP 401)\n  \"message\": \"Bad credentials\"",
-        "expected": "hit",
-        "category": "auth-credentials"
-    },
-    {
-        "id": 37,
-        "error": "PermissionError: [Errno 13] Permission denied: '/var/run/docker.sock'",
-        "expected": "hit",
-        "category": "auth-permission"
-    },
-    {
-        "id": 38,
-        "error": "github.GithubException.RateLimitExceededException: 403 \"API rate limit exceeded for user ID 12345\"",
-        "expected": "hit",
-        "category": "auth-rate-limit"
-    },
-    {
-        "id": 39,
-        "error": "google.auth.exceptions.RefreshError: ('invalid_grant: Token has been expired or revoked.', {'error': 'invalid_grant'})",
-        "expected": "intake",
-        "category": "auth-oauth"
-    },
-    {
-        "id": 40,
-        "error": "botocore.exceptions.ClientError: An error occurred (ExpiredToken) when calling the GetObject operation: The provided token has expired",
-        "expected": "intake",
-        "category": "auth-aws"
-    },
-
-    # === Test Failures (41-45) ===
-    {
-        "id": 41,
-        "error": "FAILED tests/test_api.py::test_create_user - AssertionError: assert 404 == 200",
-        "expected": "intake",
-        "category": "test-assertion"
-    },
-    {
-        "id": 42,
-        "error": "pytest.Failed: Timeout (>120.0s) from pytest-timeout plugin",
-        "expected": "intake",
-        "category": "test-timeout"
-    },
-    {
-        "id": 43,
-        "error": "FAIL: test_login (tests.test_auth.TestAuth)\nAssertionError: 'Welcome' not found in response.body",
-        "expected": "intake",
-        "category": "test-assertion"
-    },
-    {
-        "id": 44,
-        "error": "jest: FAIL src/__tests__/App.test.js\n  ● App › renders without crashing\n    TypeError: Cannot read properties of undefined (reading 'map')",
-        "expected": "intake",
-        "category": "test-jest"
-    },
-    {
-        "id": 45,
-        "error": "go test -race -count=1 ./...\n--- FAIL: TestServer_Start (0.02s)\n    server_test.go:42: expected status 200, got 500",
-        "expected": "intake",
-        "category": "test-go"
-    },
-
-    # === Edge Cases (46-50) ===
-    {
-        "id": 46,
-        "error": "ok",
-        "expected": "ignore",  # Too short
-        "category": "edge-short"
-    },
-    {
-        "id": 47,
-        "error": "TODO: implement this feature",
-        "expected": "ignore",  # Placeholder
-        "category": "edge-placeholder"
-    },
-    {
-        "id": 48,
-        "error": "Error: Command failed with exit code 1\n" * 5,
-        "expected": "ignore",  # Repetitive/echo
-        "category": "edge-echo"
-    },
-    {
-        "id": 49,
-        "error": "Traceback (most recent call last):\n  File \"app.py\", line 42, in <module>\n    main()\n  File \"app.py\", line 35, in main\n    result = process_data(data)\n  File \"utils.py\", line 18, in process_data\n    return json.loads(data)\njson.JSONDecodeError: Expecting value: line 1 column 1 (char 0)",
-        "expected": "intake",
-        "category": "traceback-python"
-    },
-    {
-        "id": 50,
-        "error": "Error: EACCES: permission denied, open '/home/runner/.npm/_logs/2024-01-15T12_30_45_123Z-debug-0.log'\n    at Object.openSync (node:fs:603:3)\n    at Object.writeFileSync (node:fs:2202:35)",
-        "expected": "hit",
-        "category": "node-permission"
-    },
+# ── 固定语料夹具（模拟 MisakaNet 课程）──
+FIXTURE = [
+    {"id": "python-venv-tiktoken-module-not-found", "title": "python venv tiktoken module not found fix",
+     "domain": "python", "tags": ["python", "venv", "pip", "tiktoken"],
+     "description": "## Problem ModuleNotFoundError when pip installed tiktoken in wrong venv ## Solution activate correct venv and pip install"},
+    {"id": "git-credential-helper-gh-path-mismatch", "title": "git credential helper gh path mismatch github 401",
+     "domain": "git", "tags": ["git", "github", "credential", "token"],
+     "description": "## Problem git credential lookup fails with helper path mismatch ## Solution fix credential.helper path"},
+    {"id": "python-smtplib-ssl-certificate-verify-failed-fix", "title": "python smtplib ssl certificate verify failed fix",
+     "domain": "python", "tags": ["python", "ssl", "smtp", "certificate"],
+     "description": "## Problem ssl.SSLCertVerificationError while sending mail ## Solution configure CA bundle"},
+    {"id": "proxy-corporativo-curl-timeout", "title": "curl timeout behind corporate proxy ssl inspection",
+     "domain": "web", "tags": ["curl", "proxy", "ssl", "timeout"],
+     "description": "## Problem curl SSL connect error behind corporate proxy ## Solution handle MITM cert"},
+    {"id": "permission-denied-shell", "title": "shell permission denied chmod exec bit",
+     "domain": "shell", "tags": ["shell", "bash", "chmod", "permission"],
+     "description": "## Problem Permission denied when running script ## Solution chmod +x"},
+    {"id": "fanuc-alarm-code-reference", "title": "fanuc alarm code reference robot karel",
+     "domain": "fanuc", "tags": ["fanuc", "robot", "karel", "alarm"],
+     "description": "## Problem fanuc alarm codes ## Solution reference guide"},
 ]
 
-
-def run_test(sample: dict) -> dict:
-    """Run a single test case."""
-    cmd = [sys.executable, str(SCRIPT), "--error", sample["error"], "--json", "--offline"]
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-
-    if result.returncode != 0:
-        return {
-            "id": sample["id"],
-            "status": "ERROR",
-            "error": result.stderr[:200],
-            "expected": sample["expected"],
-            "actual": "error",
-            "category": sample["category"]
-        }
-
-    try:
-        output = json.loads(result.stdout)
-        decision = output.get("decision", "unknown")
-
-        # Determine if test passed
-        if sample["expected"] == "hit":
-            passed = decision == "hit"
-        elif sample["expected"] == "intake":
-            passed = decision in ("intake", "hit")  # hit is also acceptable
-        elif sample["expected"] == "ignore":
-            passed = decision == "ignore"
-        else:
-            passed = True
-
-        return {
-            "id": sample["id"],
-            "status": "PASS" if passed else "FAIL",
-            "expected": sample["expected"],
-            "actual": decision,
-            "fingerprint": output.get("fingerprint", ""),
-            "reason": output.get("reason", ""),
-            "lesson": output.get("lesson", {}).get("title", ""),
-            "category": sample["category"]
-        }
-    except json.JSONDecodeError as e:
-        return {
-            "id": sample["id"],
-            "status": "ERROR",
-            "error": f"JSON parse error: {e}",
-            "expected": sample["expected"],
-            "actual": "parse_error",
-            "category": sample["category"]
-        }
+URLS = ["https://example.com/foo", "https://pypi.org/simple/requests/", "http://x.io/404"]
+NOISE = ["it broke", "[]", '{"a":1}', "0x7f8a2b3c4d5e", "asdf", "!!! ???"]
 
 
-def main():
-    print(f"Running {len(SAMPLES)} test cases...\n")
-
-    results = []
-    for sample in SAMPLES:
-        result = run_test(sample)
-        results.append(result)
-
-        # Print progress
-        status_icon = "✅" if result["status"] == "PASS" else "❌" if result["status"] == "FAIL" else "⚠️"
-        print(f"{status_icon} [{result['id']:2d}] {result['category']:<20} "
-              f"expected={result['expected']:<8} actual={result['actual']:<8} "
-              f"{result.get('reason', result.get('lesson', ''))[:40]}")
-
-    # Summary
-    passed = sum(1 for r in results if r["status"] == "PASS")
-    failed = sum(1 for r in results if r["status"] == "FAIL")
-    errors = sum(1 for r in results if r["status"] == "ERROR")
-
-    print(f"\n{'='*60}")
-    print(f"Results: {passed} passed, {failed} failed, {errors} errors")
-    print(f"Accuracy: {passed/len(results)*100:.1f}%")
-
-    if failed > 0:
-        print(f"\nFailed tests:")
-        for r in results:
-            if r["status"] == "FAIL":
-                print(f"  [{r['id']:2d}] {r['category']}: expected={r['expected']}, actual={r['actual']}")
-
-    # Save results
-    output_file = Path(__file__).parent / "intake_bot_50_results.json"
-    with open(output_file, "w") as f:
-        json.dump({
-            "total": len(results),
-            "passed": passed,
-            "failed": failed,
-            "errors": errors,
-            "accuracy": passed/len(results)*100,
-            "results": results
-        }, f, indent=2)
-    print(f"\nResults saved to {output_file}")
-
-    return 0 if failed == 0 else 1
+def run(error, threshold=DEFAULT_HIT_SIM, corpus=FIXTURE):
+    return decide(error, source="test", what_tried="tried X",
+                  auto_intake=False, sim_threshold=threshold, force=False, corpus=corpus)
 
 
-if __name__ == "__main__":
-    sys.exit(main())
-# Intake Bot Action Test Suite
+class TestHelpers:
+    def test_detect_stack_python(self):
+        assert "python" in _detect_stack("ModuleNotFoundError No module named requests python pip")
+
+    def test_detect_stack_rust_not_python(self):
+        st = _detect_stack("error[E0308]: mismatched types borrow checker rust cargo")
+        assert "rust" in st and "python" not in st
+
+    def test_noise(self):
+        for n in NOISE + URLS:
+            assert _is_noise(n), n
+        assert not _is_noise("PermissionError: [Errno 13] Permission denied: '/etc/nginx/nginx.conf'")
+
+    def test_sim(self):
+        assert _sim({"a", "b"}, {"a", "b"}) == 1.0
+        assert _sim({"a"}, {"a", "b"}) == 0.5
+
+
+class TestSameStackHits:
+    def test_git_401_hits_git_lesson(self):
+        r = run("git credential helper 401 credential lookup failed github helper path mismatch")
+        assert r["decision"] == "hit", r
+        assert r["suggest_only"] is True
+        assert "git" in r["lesson"]["id"]
+
+    def test_python_module_error_hits_python_lesson(self):
+        r = run("ModuleNotFoundError: No module named 'requests' python pip venv")
+        assert r["decision"] == "hit", r
+        assert "python" in r["lesson"]["id"]
+
+    def test_curl_proxy_hits_web_lesson(self):
+        r = run("curl: (35) SSL connect error behind corporate proxy timeout")
+        assert r["decision"] == "hit", r
+
+
+class TestCrossLanguageFpRegression:
+    CASES = [
+        "error[E0308]: mismatched types in borrow checker rust cargo build",
+        "FAILURE: Build failed with an exception. gradle task :app:assemble",
+        "Swift fatal error: unexpectedly found nil while unwrapping an Optional",
+        "linker command failed with exit code 1 undefined symbols clang c++",
+        "Error from server: namespaces not found kubernetes kubectl get ns",
+        "error: cannot find module 'foo' lua require luarocks",
+        "ERROR: LoadError: could not load package Foo julia pkg add",
+        "MongoServerError: Authentication failed mongodb credentials",
+        "Terraform init failed backend state lock tfstate",
+    ]
+
+    @pytest.mark.parametrize("error", CASES)
+    def test_cross_lang_not_hit(self, error):
+        r = run(error)
+        assert r["decision"] in ("intake", "ignore"), f"跨语言误配成 hit: {r}"
+
+    def test_generic_error_not_misattributed(self):
+        r = run("Error: something went wrong with the database connection pool")
+        assert r["decision"] != "hit" or "python" not in r["lesson"]["id"]
+
+
+class TestNoise:
+    @pytest.mark.parametrize("error", NOISE + URLS)
+    def test_noise_ignored(self, error):
+        r = run(error)
+        assert r["decision"] == "ignore", (error, r)
+
+    def test_short_ignored(self):
+        assert run("failed")["decision"] == "ignore"
+        assert run("it broke")["decision"] == "ignore"
+
+
+class TestPrecheck:
+    def test_below_threshold_no_hit(self):
+        assert precheck("zzz unrelated gibberish error text", DEFAULT_HIT_SIM, corpus=FIXTURE) is None
+
+    def test_pure_rust_query_never_hits_python(self):
+        assert precheck("error[E0308]: borrow checker cargo rust mismatched types",
+                        DEFAULT_HIT_SIM, corpus=FIXTURE) is None
+
+    def test_stack_gate_allows_same_stack(self):
+        r = precheck("ModuleNotFoundError: No module named 'requests' python pip venv",
+                     DEFAULT_HIT_SIM, corpus=FIXTURE)
+        assert r is not None and "python" in r["id"]


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Completes #1525/#1529 to v1.0, fixing the FP gaps zsxh documented in his post-merge reports (38% cross-language false positives @0.30 threshold; content-biased 50-sample suite).

- DEFAULT_HIT_SIM 0.30 -> 0.45; generic (no stack) errors need >=0.55
- stack/language-aware hit gate (24 families): cross-language errors no longer match python/git lessons via generic words; bare credential(s) dropped from git/aws hints
- noise gate: URL/JSON/paths/symbol-only -> ignore
- honesty: hits carry suggest_only=true; CLI/action wording '仅供参考，请人工核对'
- tests rewritten deterministic offline (corpus injection): same-stack hits / cross-lang FP regression (zsxh cases) / noise / thresholds — 30 passed
- live check: cross-lang mis-hits 19/50 -> 0-1/9; real same-stack hits intact

Closes the intake-bot v1.0 milestone of docs/agents/crawler-intake-bot.md.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Raise hit threshold to 0.45 (generic needs ≥0.55) to cut FP

- Add stack-aware hit gate via 24-family language/framework hints

- Add noise gate filtering URLs/JSON/symbols; mark hits suggest-only

- Rewrite tests as deterministic offline suite with corpus injection


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["CI failure / log"] --> B["extract error"]
  B --> C{"is noise?"}
  C -- yes --> Z["ignore"]
  C -- no --> D["detect stack"]
  D --> E{"stack present?"}
  E -- yes --> F["sim ≥ 0.45 AND same-stack lesson"]
  E -- no --> G["sim ≥ 0.55 (HIGH_BAR)"]
  F --> H["hit (suggest_only)"]
  G --> H
  H --> X["report lesson; no intake"]
  D --> I["fingerprint novel + quality ok"]
  I --> Y["intake (dry-run / gated)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>intake_bot.py</strong><dd><code>Stack-aware hit gate, noise filter, suggest-only honesty</code>&nbsp; </dd></summary>
<hr>

scripts/intake_bot.py

<ul><li>Raise <code>DEFAULT_HIT_SIM</code> 0.30 → 0.45; add <code>HIGH_BAR_SIM=0.55</code> for <br>stack-less queries<br> <li> Add <code>_STACK_HINTS</code> (24 families) and <code>_detect_stack</code>/<code>_doc_stack</code> helpers<br> <li> Add <code>_is_noise</code> noise gate; expand stop-word list<br> <li> <code>precheck()</code> enforces same-stack match when query has stack features<br> <li> <code>decide()</code> returns <code>suggest_only: true</code>; CLI output flags "仅供参考，请人工核对"</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1539/files#diff-5fd85611c320b6d86719942bfa8f339ed7ba7e13d8a890eb8fd0da2354052f42">+107/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Bump action sim default and comment wording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/misaka-intake-bot/action.yml

<ul><li>Bump <code>sim</code> default from <code>0.30</code> to <code>0.45</code><br> <li> Update PR comment wording to flag hits as <code>suggest-only (仅供参考)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1539/files#diff-f8ad2194aeca0d902b2b913f9041baacc05fab7a32472877e750a1f848b182cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_intake_bot_50.py</strong><dd><code>Rewrite tests as offline deterministic suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_intake_bot_50.py

<ul><li>Rewrite from subprocess-based 50-sample runner to deterministic pytest <br>suite<br> <li> Inject fixed <code>FIXTURE</code> corpus; no network or live MisakaNet dependency<br> <li> Cover same-stack hits, cross-language FP regression (zsxh cases), <br>noise, thresholds<br> <li> 30 tests targeting helpers, precheck, decide, and noise classification</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1539/files#diff-8a2c7450fd666be47f44038f745da4b299c675cde8ea4a9d769cc2d4edbf34ca">+111/-405</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crawler-intake-bot.md</strong><dd><code>Document v1.0 completion and known limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/agents/crawler-intake-bot.md

<ul><li>Add <code>10b. v1.0 完成</code> section documenting threshold raise, stack gate, <br>noise gate<br> <li> Record live-check numbers: cross-lang FP 19/50 → 0-1/9; same-stack <br>hits intact<br> <li> Note known v1.0 limits (lexicon-driven; relies on suggest-only <br>consumer)</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1539/files#diff-e8dca746c6fb99d6a6bb4b833c05d5508fb310bb61d2fa57f3dc7438f70d7be1">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

