### PR TITLE
feat(agents): internal dogfood (ci-lesson-search→v1.0) + server intake dedupe gate (#1526)

### DIFF
--- a/.github/workflows/ci-lesson-search.yml
+++ b/.github/workflows/ci-lesson-search.yml
@@ -70,69 +70,59 @@ jobs:
             core.setOutput('run_url', run.html_url);
             core.setOutput('run_name', run.name || 'CI');
 
-      - name: Search MisakaNet
+      # v1.0 (PR #1539): 决策交给 intake-bot（stack-aware + noise gate +
+      # suggest-only）。hit → 评论建议；intake 候选 / ignore → 静默（避免 CI
+      # 失败刷屏；候选可通过本地跑 intake_bot 查看）。
+      - name: Run intake-bot v1.0 decision
         if: steps.context.outputs.error_signatures != ''
-        id: search
+        id: intake
         run: |
-          # Use environment variable to avoid shell escaping issues
-          export ERROR_SIG="$ERROR_SIGNATURES"
-          # Take first 3 error lines, strip special chars, use as search query
-          QUERY=$(echo "$ERROR_SIG" | head -3 | tr -cd '[:alnum:][:space:].,-' | tr '\n' ' ' | head -c 200)
-
-          if [ -z "$QUERY" ]; then
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Searching MisakaNet for: $QUERY"
-
-          # Use search_knowledge.py
-          RESULT=$(python3 search_knowledge.py "$QUERY" --json --top 3 2>/dev/null || echo "[]")
-
-          # Check if we got results
-          COUNT=$(echo "$RESULT" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
-
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-          echo "results<<EOF" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$ERROR_SIG" > /tmp/ci_error.log
+          RESULT=$(python3 scripts/intake_bot.py --log /tmp/ci_error.log --json \
+            --source ci-lesson-search 2>/dev/null || echo '{"decision":"error","reason":"bot failed"}')
+          DECISION=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('decision','unknown'))")
+          echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
+          echo "result<<EOF" >> "$GITHUB_OUTPUT"
           echo "$RESULT" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
         env:
           ERROR_SIGNATURES: ${{ steps.context.outputs.error_signatures }}
 
-      - name: Comment on PR
-        if: steps.context.outputs.pr_number != '' && steps.search.outputs.count != '0'
+      # 只在 hit 时评论（dogfood：观察 v1.0 建议质量；ignore/intake 静默防噪音）
+      - name: Comment lesson suggestion on PR
+        if: steps.context.outputs.pr_number != '' && steps.intake.outputs.decision == 'hit'
         uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.context.outputs.pr_number }}
-          RESULTS: ${{ steps.search.outputs.results }}
+          INTAKE_RESULT: ${{ steps.intake.outputs.result }}
           RUN_URL: ${{ steps.context.outputs.run_url }}
           RUN_NAME: ${{ steps.context.outputs.run_name }}
         with:
           script: |
-            const results = JSON.parse(process.env.RESULTS || '[]');
+            const res = JSON.parse(process.env.INTAKE_RESULT || '{}');
             const prNumber = parseInt(process.env.PR_NUMBER);
+            const lesson = res.lesson || {};
 
-            if (!results.length) return;
+            if (res.decision !== 'hit' || !lesson.id) return;
 
-            let body = `## 💡 MisakaNet: Related lessons found\n\n`;
-            body += `CI failed in [${process.env.RUN_NAME}](${process.env.RUN_URL}). `;
-            body += `Here are potentially relevant lessons:\n\n`;
-
-            for (const r of results.slice(0, 3)) {
-              body += `### ${r.title}\n`;
-              body += `> ${r.preview || 'No preview'}\n\n`;
-              body += `- **Domain**: ${r.domain || 'general'}\n`;
-              body += `- **Score**: ${(r.score * 100).toFixed(0)}%\n`;
-              body += `- **Path**: \`${r.path}\`\n\n`;
-            }
-
-            body += `---\n`;
-            body += `_To search manually: \`python3 search_knowledge.py "your error"\`_\n`;
-            body += `_To disable: remove or comment out ci-lesson-search.yml_\n`;
+            const body = [
+              `## 💡 MisakaNet: possible related lesson (suggest-only)`,
+              ``,
+              `CI failed in [${process.env.RUN_NAME}](${process.env.RUN_URL}). A MisakaNet lesson may match this error:`,
+              ``,
+              `### ${lesson.title || lesson.id}`,
+              `- **Similarity**: ${lesson.sim || '?'}`,
+              `- **Lesson**: [${lesson.id}](${lesson.url || '#'})`,
+              ``,
+              `> ⚠️ 仅供参考（suggest-only）——请人工核对后决定是否采用该修复思路。`,
+              ``,
+              `---`,
+              `_Powered by intake-bot v1.0 (stack-aware hit gate). To disable, remove ci-lesson-search.yml._`
+            ].join('\n');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: body
+              body
             });

--- a/workers/intake-canonical.test.mjs
+++ b/workers/intake-canonical.test.mjs
@@ -1,0 +1,45 @@
+// #1526 tests: canonical "already have lesson" gate (server backstop).
+// Run: node --test workers/intake-canonical.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { findCoveringLesson } from './register-proxy-sw.js';
+
+const LESSONS = [
+  { id: 'pip-install-proxy-timeout', title: 'pip install timeout behind corporate proxy', domain: 'devops',
+    tags: ['pip', 'proxy', 'timeout'],
+    description: '## Problem pip install ReadTimeoutError behind corporate proxy ## Solution fix cert & timeout config' },
+  { id: 'git-credential-helper-gh-path-mismatch', title: 'git credential helper gh path mismatch github 401', domain: 'git',
+    tags: ['git', 'github', 'credential'], description: '## Problem git credential lookup fails ## Solution fix helper path' },
+  { id: 'python-venv-tiktoken', title: 'python venv tiktoken module not found', domain: 'python',
+    tags: ['python', 'venv'], description: '## Problem ModuleNotFoundError tiktoken wrong venv ## Solution activate venv' },
+];
+
+test('near-verbatim failure covered by lesson → returns lesson', () => {
+  const r = findCoveringLesson(
+    'pip install times out behind corporate proxy ReadTimeoutError',
+    'ReadTimeoutError while reading from pypi', LESSONS);
+  assert.ok(r, 'expected a covering lesson');
+  assert.equal(r.lesson.id, 'pip-install-proxy-timeout');
+  assert.ok(r.ratio >= 0.5);
+});
+
+test('different stack / generic words do not match', () => {
+  const r = findCoveringLesson(
+    'error[E0308] mismatched types borrow checker rust cargo',
+    'cargo build failed', LESSONS);
+  assert.equal(r, null, 'cross-language must not be suppressed');
+});
+
+test('too few real tokens → no suppression (fall through to issue)', () => {
+  assert.equal(findCoveringLesson('it broke', '', LESSONS), null);
+  assert.equal(findCoveringLesson('error not found', '', LESSONS), null);
+});
+
+test('unrelated but wordy failure not suppressed', () => {
+  const r = findCoveringLesson('terraform state lock backend initialization failed', 'tfstate locked', LESSONS);
+  assert.equal(r, null);
+});
+
+test('empty lessons list → null', () => {
+  assert.equal(findCoveringLesson('pip proxy timeout', 'ReadTimeoutError', []), null);
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -1100,10 +1100,40 @@ async function handleMcpToolCall(env, toolName, args, authToken, clientIp, ctx) 
         return {
           submitted: false,
           duplicate: true,
-          previous_issue: existingDedup,
-          error: "Duplicate intake — this problem was already submitted. See the linked issue.",
+          previous_issue: existingDedup,          error: "Duplicate intake — this problem was already submitted. See the linked issue.",
         };
       }
+    }
+
+    // #1526 backstop: failure intakes already covered near-verbatim by an
+    // active lesson return already_have instead of opening a triage issue
+    // (client-side gates are best-effort; this guards every source). Best-effort:
+    // corpus failure falls through to the normal intake path.
+    if (kind === "missing_lesson") {
+      try {
+        const lessons = await loadLessons(env, {});
+        const cover = findCoveringLesson(safeProblem, safeError || "", lessons || []);
+        if (cover) {
+          if (args.source && env.MISAKANET_KV) {
+            try {
+              const ck = `intake_source_count:${String(args.source).slice(0, 40)}`;
+              const cn = parseInt((await env.MISAKANET_KV.get(ck, "text")) || "0", 10) || 0;
+              await env.MISAKANET_KV.put(ck, String(cn + 1), { expirationTtl: 86400 * 30 });
+            } catch (_) { /* best-effort ledger (feeds #1528) */ }
+          }
+          return {
+            submitted: false,
+            already_have: true,
+            lesson: {
+              id: cover.lesson.id,
+              url: `https://misakanet.org/lessons/${cover.lesson.id}/`,
+              title: cover.lesson.title || cover.lesson.id,
+              similarity: Number(cover.ratio.toFixed(2)),
+            },
+            note: "This failure appears already covered by an existing lesson — no new intake issue was created. If that lesson does not solve your case, re-submit with what_tried.",
+          };
+        }
+      } catch (_) { /* corpus unavailable → normal intake */ }
     }
 
     const bodyParts = [
@@ -3246,6 +3276,41 @@ async function handlePrGeniusStats(env) {
     return jsonResponse({ error: "Failed to load PR Genius statistics: " + err.message }, 502);
   }
 }
+// #1526 server backstop — canonical "already have a lesson" gate for failure
+// intakes. Conservative: only near-verbatim coverage suppresses the issue;
+// anything ambiguous still opens a triage issue (never silently swallow a
+// novel failure). Pure function so it is unit-testable without an env.
+const _GENERIC_TOKENS = new Set(["error", "errors", "failed", "fail", "failure", "fatal",
+  "issue", "issues", "problem", "problems", "not", "found", "cannot", "unable", "when",
+  "with", "after", "this", "the", "and", "module", "modules", "command", "during",
+  "line", "file", "files"]);
+
+function _tok(text) {
+  return new Set((String(text || "").toLowerCase()
+    .match(/[a-z][a-z0-9_]{2,}|[\u4e00-\u9fff]{2,}/g) || []));
+}
+
+function findCoveringLesson(problemText, errorText, lessons) {
+  const qReal = new Set([..._tok(`${problemText} ${errorText}`)].filter(w => !_GENERIC_TOKENS.has(w)));
+  if (qReal.size < 3) return null;
+  let best = null;
+  let bestRatio = 0;
+  for (const doc of lessons || []) {
+    const hay = `${doc.title || ""} ${doc.description || doc.summary || ""} ${doc.domain || ""} ${(doc.tags || []).join(" ")}`;
+    const dTok = _tok(hay);
+    if (dTok.size === 0) continue;
+    let hit = 0;
+    for (const w of qReal) if (dTok.has(w)) hit += 1;
+    const ratio = hit / qReal.size;
+    if (ratio > bestRatio) { bestRatio = ratio; best = doc; }
+  }
+  if (best && bestRatio >= 0.5) {
+    return { lesson: best, ratio: bestRatio };
+  }
+  return null;
+}
+
+
 
 export {
   IDENTITY_AURA,
@@ -3268,4 +3333,5 @@ export {
   recordUnsolvedSearch,
   sanitizeReasonKey,
   hashString,
+  findCoveringLesson,
 };


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Two tasks from the intake-bot v1.0 follow-up plan (user-approved):

**1. Internal dogfood** — ci-lesson-search.yml now runs intake-bot v1.0 decision (stack-aware, noise gate, suggest-only) and comments only on hit (intake candidates / ignore stay silent) instead of raw top-3 + unconditional comment.

**2. #1526 server backstop** — submit_intake gains a canonical 'already have lesson' gate: failure intakes whose real tokens are ≥50% covered by one active lesson return {submitted:false, already_have:{lesson_id,url,title}} instead of opening a triage issue; best-effort source counter (KV intake_source_count:*) feeds the #1528 ledger. Conservative: corpus failure or ambiguous matches fall through to normal intake (novel failures never silently swallowed). Pure fn findCoveringLesson + 5 node tests (canonical 5 ✓, intake-kind 18 ✓, intake_bot pytest 30 ✓).

Deploys to the live worker on merge to main.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Internal dogfood: ci-lesson-search uses intake-bot v1.0

- Server dedupe gate: returns existing lesson on near-duplicate

- Best-effort source counter feeds #1528 conversion ledger

- Pure findCoveringLesson fn with 5 node tests


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["submit_intake failure"] --> B{"kind == missing_lesson?"}
  B -- no --> X["open triage issue"]
  B -- yes --> C["loadLessons + findCoveringLesson"]
  C --> D{"ratio >= 0.5?"}
  D -- no --> X
  D -- yes --> E["return already_have + bump intake_source_count"]
  E --> F["silence (no issue)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register-proxy-sw.js</strong><dd><code>Add server intake dedupe gate for missing_lesson</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workers/register-proxy-sw.js

<ul><li>Added <code>findCoveringLesson</code> pure fn (token-overlap, ≥50% real-token <br>coverage)<br> <li> In <code>handleMcpToolCall</code>, for <code>missing_lesson</code> intakes, gate on covering <br>lesson<br> <li> On hit: return <code>already_have</code> payload + bump <code>intake_source_count:*</code> <br>(best-effort)<br> <li> Exported the new fn; corpus errors fall through to normal intake</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1540/files#diff-55537d922a19e93e77ddd38c37d845f1af9382db11e13c42aa33e5394ca92195">+68/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-lesson-search.yml</strong><dd><code>Switch CI lesson search to intake-bot v1.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-lesson-search.yml

<ul><li>Replaced raw <code>search_knowledge.py</code> top-3 with <code>intake_bot.py</code> v1.0 <br>decision<br> <li> Comments only when <code>decision == hit</code> (intake candidates / ignore stay <br>silent)<br> <li> Suggest-only body with similarity + lesson link + Chinese disclaimer</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1540/files#diff-c23ea45164264abe2e047e3af285b87c674b57013f4beab0ff663c782bd0c1c9">+35/-45</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>intake-canonical.test.mjs</strong><dd><code>Add node tests for findCoveringLesson</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workers/intake-canonical.test.mjs

<ul><li>5 node:test cases covering hit, cross-language miss, too-few-tokens, <br>unrelated, empty list<br> <li> Imports <code>findCoveringLesson</code> from <code>register-proxy-sw.js</code><br> <li> Asserts canonical lesson match and ratio threshold</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1540/files#diff-dda8aac1f16594fe7b925f7dc220bb488730b22f182a5d3cc0d0b9c62d949a87">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

