### PR TITLE
feat(agents): failure_harvest P0 — batch failure clustering to lesson drafts

### DIFF
--- a/docs/maintainer/handoff-2026-09-06.md
+++ b/docs/maintainer/handoff-2026-09-06.md
@@ -378,3 +378,26 @@ zsxh 反馈闭环后，继续实施 #1506（lesson 质量门差异化）——**
 
 ---
 *Wave 12 附记于 2026-09-07。*
+
+---
+*Wave 13 附记于 2026-09-07。*
+
+# Wave 13（2026-09-07 failure_harvest P0——失败→lesson 批量转化的最小实现）
+
+- 前置：用户批准 P0（评审通过后），并要求实现前核对开放 PR 是否已有打样。
+- **PR 打样核对结论**：开放 PR（#1538/#1542/#1544/#1541/#1535 等）无 failure→lesson 管线；
+  #1526 已于 #1540 合入（#1535 重复，应 triage 关）；#1538/#1542 是 #1527 error-signature 竞品
+  （改 intake_bot.py，与 v1.0 会冲突，留意）；真正"打样"是已合入的 tombstone_to_draft.py 生命周期。
+- **P0 分支 `feat/failure-harvest-p0`（`924c3384d`，已推未合）**：
+  - `scripts/failure_harvest.py`：失败事件→指纹簇→lesson 骨架草稿（落 `lessons/drafts/`）。
+  - 防过窄修复（demo 复现 8 簇全拆 → 3 簇 3 草稿）：
+    1. `classify()` 取**最后/最内层**异常类名并剥模块路径（pip 3 措辞 → ReadTimeoutError 一簇）；
+    2. 401/fatal/HTTP 码 = **弱信号**（进 failure_patterns），不作聚类键（git "401"+"fatal:" 两措辞一簇）；
+    3. `norm_stack()` 检测前剥 URL（防 https→web 误报）+ 剔除 R 栈 `"r "` 单字符误报（"error " 尾 r 误命中）；
+    4. 聚类键：specific kind → `K:<class>`（忽略栈差异）；generic → `G:generic|<栈>`。
+  - 防噪音：occ≥min_occ(默认2) 才写草稿；what_tried 不豁免 occ=1；文件名跨平台安全。
+  - `tests/test_failure_harvest.py` 10 用例锁定（40 pytest 全过）。
+  - `lessons/drafts/README.md`：纳入 failure-harvest 第二来源 frontmatter 规范（harvest_ref/failure_patterns/E0）。
+  - `docs/reviews/2026-09-07-intake-lesson-network-vs-ecosystem.md`：第一性原理评审记录（通过，有条件）。
+- 待办：#1527 error-signature 索引（警惕 #1538/#1542 竞品 merge 冲突）、#1528 转换回执、
+  failure_harvest 真实事件源接入（ci-lesson-search 失败事件 → harvest）、#1535 triage 关闭。

--- a/docs/reviews/2026-09-07-intake-lesson-network-vs-ecosystem.md
+++ b/docs/reviews/2026-09-07-intake-lesson-network-vs-ecosystem.md
@@ -1,0 +1,40 @@
+# Review: failure→lesson 网络 vs 生态 / PR-Agent / pr-genius（2026-09-07）
+
+> 目的：P0（failure_harvest）实现前的第一性原理竞品评审。
+> 结论：**通过（有条件）**——整体不与现有开源方案/PR-Agent/pr-genius 重复；组件层明确"借鉴不重造"；范围裁剪见 §6。
+
+## 1. 需求还原
+把"每次失败的修复知识"变成：**可检索、带证据分级、跨项目共享、agent 自己在生产中采集与消费的开放课程网络**。
+
+## 2. 生态对照（引用）
+| 方案 | 做什么 | 重叠 | 差异 |
+|---|---|---|---|
+| Sentry ([grouping/fingerprints](https://docs.sentry.dev/product/issues/grouping-and-fingerprints/)) | 错误指纹/聚类/去重 → 工单给人 | 聚类/指纹语义 | 产出 bug 工单给人；我们产出给 agent 的修复课程 |
+| runbook-copilot ([repo](https://github.com/weihong363/runbook-copilot)) | RAG 查已有 runbook | 检索已有知识给建议 | 不累积；不产课程；面向人 |
+| HolmesGPT ([CNCF](https://github.com/cncf/sandbox/issues/392)) | AI 排查告警 → 诊断 | 诊断失败 | 单域诊断；无跨项目课程库 |
+| Junto / agent-external-memory ([repo](https://github.com/tlemmons/junto-memory), [issue](https://github.com/openclaw/openclaw/issues/75611)) | 多 agent 通用记忆共享 | "共享记忆" | 无质量策展（不去重/验证据/防噪音/分级） |
+| 社区失败记忆模板（CLAUDE.md 等） | 单项目私有失败笔记 | 记录失败 | 私有、无共享、无批量转化、命中差（过窄根源） |
+| PR-Agent / Qodo ([解析](https://blog.csdn.net/sinat_28461591/article/details/147914402), [AutoFix](https://dev.to/priyanshu123coder/building-autofix-agent-autonomous-cicd-failure-remediation-with-trueforge-qodo-5735)) | 代码审查 + CI 失败自动修复 | 都在 CI 失败处出声 | 单仓库私有改代码；我们跨项目知识不改码 |
+
+## 3. 与 PR-Agent：补集，需划评论位
+- PR-Agent：单仓库、审代码、提/实施修复（专家审你）。
+- 我们：跨项目、检索"别人已验证"的失败课程（同行经验库），不改码。
+- 划界：MisakaNet 评论仅 hit/新颖两类、低频、suggest-only；与 PR-Agent 审查评论信息不同源，可共存。
+
+## 4. 与自家 pr-genius：评审层 vs 知识层（补集 + 协同）
+- pr-genius（zsxh1990/pr-genius v1.7.2，PR opened/synchronize）：规则+证据审计 **PR 形态**（issue 链接/规模/pattern），产出审计评论，缩短 review ~50%。
+- MisakaNet：**失败知识**（谁踩过/怎么修/是否值得沉淀）。
+- 协同：课程转正 PR 本就走 pr-genius + lesson-gate 审；历史 lesson（pr-genius-issue-evaluator-for-intake）表明 pr-genius 可做 intake/候选质量初筛 → 与 harvest 聚类互补（harvest 归堆、pr-genius 挑优）。
+- 不重复：pr-genius 无跨项目失败知识面；MisakaNet 不审 PR 形态。
+
+## 5. 区分度
+① 面向 agent 语义的失败课程 + 人可读；② 生产闭环（agent 采→机转→机查）；③ 可靠性工程化（噪音/栈感知/去重/证据分级/基准护栏）；④ 跨项目开放 intake + 节点。边界：闭环仍人在环批量审；词表驱动；单维护者节点起步。
+
+## 6. 范围裁剪（实现守则）
+- 采集层：只做 intake/CI 事件接入，不自研事件平台（对齐 Sentry fingerprint 语义即可）。
+- 检索层：沿用现成 BM25/RRF；增量只在 failure_patterns 签名索引（#1527）。
+- 不做：时序事件库/通用 LLM 记忆/代码自动修复（分别留给 Sentry/Junto/Qodo）。
+- 评论位：MisakaNet = 低频 suggest-only 知识链接，与 pr-genius/PR-Agent 文案分工。
+
+## 7. 结论
+通过（有条件）。P0 最小实现 = `scripts/failure_harvest.py`（失败事件→指纹簇→lesson 骨架草稿，落 `lessons/drafts/`，与 fatal-guard 草稿生命周期一致），组件注明借鉴来源、不做轮子。

--- a/lessons/drafts/README.md
+++ b/lessons/drafts/README.md
@@ -11,9 +11,10 @@ verification: "metadata-normalized"
 ## 生命周期
 
 ```
-崩溃 → fatal-guard 截获墓碑 JSON
+来源 A：崩溃 → fatal-guard 截获墓碑 JSON
+来源 B：批量失败事件（intake/CI/agent 日志）→ failure_harvest.py 聚簇
            ↓
-    tombstone_to_draft.py 自动生成 draft lesson
+    tombstone_to_draft.py / failure_harvest.py 自动生成 draft lesson
            ↓
     lessons/drafts/lesson-XXXX.md（draft 标签）
            ↓
@@ -34,15 +35,21 @@ verification: "metadata-normalized"
 
 ```yaml
 ---
-title: "Fix: <错误摘要>"
+title: "Fix: <错误摘要>"        # failure_harvest 用 "Harvest: <类名> (<栈>)"
 domain: "<领域>"
 tags: ["draft", "auto-generated", "bounty"]
 status: "draft"
-source: "fatal-guard"
-tombstone_ref: "<原始墓碑 JSON 的 SHA256 或文件路径>"
+source: "fatal-guard | failure-harvest"   # 来源 A / 来源 B
 created: "2026-06-22T00:00:00Z"
 ---
 ```
+
+按来源追加溯源字段：
+
+| source | 溯源字段 | 说明 |
+|---|---|---|
+| `fatal-guard` | `tombstone_ref` + `tombstone_hash` | 原始墓碑 JSON 的 SHA256/路径 |
+| `failure-harvest` | `harvest_ref` + `failure_patterns` + `evidence_level` | 失败簇 id；错误类名/弱信号/栈词（供 #1527 签名索引）；E0=未验证 |
 
 ## 与正式 lesson 的区别
 

--- a/scripts/failure_harvest.py
+++ b/scripts/failure_harvest.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""failure_harvest — P0: 失败养料 → 指纹簇 → lesson 骨架草稿（批量、防过窄）。
+
+Review 通过后最小实现（docs/reviews/2026-09-07-intake-lesson-network-vs-ecosystem.md）：
+- 借鉴不重造：指纹/聚类语义对齐 Sentry grouping；复用本仓 intake_bot 的
+  fingerprint/_detect_stack/_is_noise/_tokens；产出落 lessons/drafts/（与
+  fatal-guard 草稿同一生命周期：自动生成 → PR → 维护者审 → 升格 contrib）。
+- 防"过窄"：同失败族多变体 → 一篇草稿。聚类键 = 具体异常类名（specific kind）
+  或 generic+归一化技术栈；401/fatal/HTTP 码为弱信号，只进 failure_patterns，
+  不因措辞差异拆簇（git credential 的 "401" 与 "fatal:" 属同一族）。
+- 防"过宽"：specific kind 才按类名聚类；generic 必配技术栈，避免不同栈同并。
+- 栈噪声处理：检测前剥 URL（防 https→web 误报）；剔除 "r " 单字符误报
+  （"error " 尾字母 r+空格 会命中 intake_bot 的 R 词表，采收场景弃用 R 栈）。
+- 草稿带 failure_patterns（类名+弱信号+栈词）→ 为 #1527 签名索引铺路。
+
+用法:
+  python3 scripts/failure_harvest.py --demo
+  python3 scripts/failure_harvest.py --events events.json [--out lessons/drafts] [--json]
+  cat events.json | python3 scripts/failure_harvest.py --json
+事件格式: [{"error": "...", "source": "...", "what_tried": "...", "occurred_at": "..."}]
+"""
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts.intake_bot import _detect_stack, _is_noise, fingerprint as ib_fingerprint  # noqa: E402
+
+DRAFT_DIR = REPO / "lessons" / "drafts"
+MIN_OCCURRENCES = 2          # 高频门槛：同簇出现 ≥2 才默认生成草稿
+# 类名（可带模块路径）优先；HTTP 状态码 / 裸 4xx/5xx / fatal 为弱信号
+_CLASS_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Failure|Fault)")
+_HTTP_CODE_RE = re.compile(r"\b(?:HTTP\s*)?(?<!\w)(?:4\d\d|5\d\d)(?!\w)", re.I)
+_FATAL_RE = re.compile(r"\bfatal\b", re.I)
+_URL_RE = re.compile(r"https?://\S+", re.I)
+# intake_bot._STACK_HINTS["r"] = {"r ", ...}：任意 "r"+空格（如 "error "、"for "）都命中，
+# 采收聚类里误报率远高于真实 R 语境 → 直接剔除（不动共享词表，避免影响 intake 命中门）。
+_STACK_DROPS = {"r"}
+STACK_DOMAIN = {
+    "python": "python", "node": "node", "git": "git", "web": "web", "network": "network",
+    "shell": "shell", "docker": "docker", "k8s": "kubernetes", "aws": "aws",
+    "cloudflare": "cloudflare", "db": "database", "fanuc": "fanuc", "feishu": "feishu",
+}
+
+
+def classify(error: str) -> tuple[str, bool, list[str]]:
+    """返回 (kind_label, specific, signals)。
+
+    - kind_label：specific=True 时为最内层异常类短名（剥模块路径，如 ReadTimeoutError）；
+      specific=False 时为弱信号词（http-401 / fatal）或 generic-failure。
+    - specific：以 Error/Exception/Failure/Fault 结尾的类名才可作聚类键；
+      401/fatal 语义上可能是同族不同措辞（如 git credential），不可作键。
+    - signals：捕获到的全部弱信号（HTTP 码 / fatal），供 failure_patterns。
+    """
+    err = error or ""
+    classes = list(_CLASS_RE.finditer(err))
+    if classes:
+        raw = classes[-1].group(0)          # 取最后一个（最内层）异常
+        return raw.rsplit(".", 1)[-1], True, []
+    code = _HTTP_CODE_RE.search(err)
+    if code:
+        m = code.group(0)
+        digits = re.sub(r"\D", "", m)
+        return f"http-{digits}", False, [m.strip()]
+    if _FATAL_RE.search(err):
+        return "fatal", False, ["fatal"]
+    return "generic-failure", False, []
+
+
+def error_kind(error: str) -> str:
+    """向后兼容：仅返回 kind_label。"""
+    return classify(error)[0]
+
+
+def norm_stack(text: str) -> tuple[str, ...]:
+    """归一化技术栈：剥 URL → 检测 → 剔除弱/误报栈。返回排序 tuple。
+
+    - https://github.com 会命中 web（词表含 http/https）→ 先剥 URL。
+    - "r " 词表命中任意 r+空格 → 剔除 r（见 _STACK_DROPS）。
+    """
+    cleaned = _URL_RE.sub("", text or "")
+    hits = _detect_stack(cleaned)
+    hits -= _STACK_DROPS
+    return tuple(sorted(hits))
+
+
+def norm_variant(error: str) -> str:
+    return re.sub(r"\s+", " ", (error or "").strip())[:200]
+
+
+def cluster_key(stack: tuple, kind: str, specific: bool) -> str:
+    """聚类键：specific kind → 仅 kind（同族措辞/栈差异不拆簇）；
+    generic → generic + 归一栈（栈承担区分，防不同栈并入同簇）。"""
+    if specific:
+        return f"K:{kind}"
+    return f"G:generic|{','.join(stack)}"
+
+
+def safe_filename(cid: str) -> str:
+    """cid → 跨平台安全文件名（去掉 : | 等文件系统不友好字符）。"""
+    safe = re.sub(r"[^A-Za-z0-9]+", "-", cid).strip("-")
+    return safe or "cluster"
+
+
+def build_draft(cluster: dict) -> str:
+    """生成 lesson 骨架草稿（合并多措辞变体 → 泛化；签名 → failure_patterns）。"""
+    now = datetime.now(timezone.utc)
+    stack = cluster["stack"]
+    kind = cluster["kind"]
+    signals = cluster.get("signals", [])
+    top = cluster["top_error"]
+    slug_kind = re.sub(r"[^A-Za-z0-9]+", "-", kind)[:40].lower()
+    slug = f"harvest-{now.strftime('%Y%m%d')}-{cluster['cid']}-{slug_kind}"
+    domain = STACK_DOMAIN.get(stack[0] if stack else "", "general")
+    tags = ["draft", "auto-generated", "failure-harvest"]
+    tags += list(stack)[:3]
+    tags += [kind[:30]] if len(kind) <= 30 else []
+    patterns = [kind] + signals + list(stack)[:3]
+    fm = {
+        "title": f"Harvest: {kind} ({', '.join(stack) or 'general'})",
+        "domain": domain,
+        "tags": tags,
+        "status": "draft",
+        "source": "failure-harvest",
+        "harvest_ref": cluster["cid"],
+        "failure_patterns": patterns,
+        "created": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "evidence_level": "E0",  # draft 未验证；升格前须补真实证据
+    }
+    lines = ["---", json.dumps(fm, ensure_ascii=False, indent=2), "---", "", "## Problem", "",
+             f"同一失败族 `{kind}` 在 {cluster['occurrences']} 次事件中出现"
+             f"（{len(cluster['variants'])} 种措辞变体）。代表性报错：", "",
+             "```text", top[:300], "```", ""]
+    if len(cluster["variants"]) > 1:
+        lines += ["变体（防过窄：本课应覆盖族内所有形态）：", ""]
+        for v in cluster["variants"][:5]:
+            lines += [f"- `{v[:150]}`", ""]
+    if cluster.get("sources"):
+        lines += ["来源计数：", ""]
+        for src, n in sorted(cluster["sources"].items(), key=lambda x: -x[1])[:8]:
+            lines += [f"- {src}: {n}", ""]
+    tried = cluster.get("what_tried", [])
+    if tried:
+        lines += ["## What was tried（合并去重）", ""]
+        for t in tried[:5]:
+            lines += [f"- {t[:200]}", ""]
+    lines += ["## 待补全（草稿生命周期）", "",
+              "- [ ] Root cause 归因", "- [ ] 可验证 Solution", "- [ ] 人工/实证 Verification 后升格 lessons/contrib/（通过 lesson_gate）", ""]
+    return "\n".join(lines)
+
+
+def harvest(events: list[dict], out_dir: Path, min_occ: int) -> dict:
+    """events → 簇 → 草稿。返回摘要。"""
+    cleaned = 0
+    clusters: dict[str, dict] = {}
+    for ev in events:
+        err = (ev.get("error") or "").strip()
+        if not err or _is_noise(err):
+            cleaned += 1
+            continue
+        fp = ib_fingerprint(err)
+        kind, specific, signals = classify(err)
+        stack = norm_stack(err)
+        cid = cluster_key(stack, kind, specific)
+        c = clusters.setdefault(cid, {"cid": cid, "stack": stack, "kind": kind, "specific": specific,
+                                      "signals": [], "fingerprints": set(), "variants": [],
+                                      "sources": {}, "what_tried": []})
+        c["signals"] = sorted(set(c["signals"]) | set(signals))
+        c["fingerprints"].add(fp)
+        c["occurrences"] = c.get("occurrences", 0) + 1
+        v = norm_variant(err)
+        if v not in c["variants"]:
+            c["variants"].append(v)
+        src = ev.get("source") or "unknown"
+        c["sources"][src] = c["sources"].get(src, 0) + 1
+        wt = (ev.get("what_tried") or "").strip()
+        if wt and wt not in c["what_tried"]:
+            c["what_tried"].append(wt)
+
+    written, skipped = [], []
+    for c in clusters.values():
+        c["variants"] = c["variants"][:10]
+        c["top_error"] = c["variants"][0] if c["variants"] else ""
+        # 只按频次门槛写；what_tried 只是草稿内容，不豁免 occ=1（防噪音草稿）。
+        if c["occurrences"] >= min_occ:
+            try:
+                out_dir.mkdir(parents=True, exist_ok=True)
+                p = out_dir / f"{safe_filename(c['cid'])}.md"
+                p.write_text(build_draft(c), encoding="utf-8")
+                written.append({"cid": c["cid"], "kind": c["kind"],
+                                "stack": list(c["stack"]), "occurrences": c["occurrences"],
+                                "file": str(p)})
+            except OSError as e:
+                skipped.append({"cid": c["cid"], "reason": f"write failed: {e}"})
+        else:
+            skipped.append({"cid": c["cid"], "kind": c["kind"],
+                            "reason": f"low signal (occ={c['occurrences']} < {min_occ})"})
+    return {"events": len(events), "cleaned_noise": cleaned,
+            "clusters": len(clusters), "drafts": written, "skipped": skipped}
+
+
+def demo() -> int:
+    events = []
+    # 同族多变体（防过窄：应聚成一簇生成一篇草稿）
+    pip_variants = [
+        "pip install ReadTimeoutError behind corporate proxy while reading from pypi",
+        "ERROR: Could not install packages due to an OSError ReadTimeoutError proxy pypi pip",
+        "pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool proxy timeout pip",
+    ]
+    git_variants = [
+        "git credential helper 401 credential lookup failed github helper path mismatch",
+        "fatal: could not read Username for 'https://github.com': credential helper misconfigured git",
+    ]
+    cf_variants = [
+        "ReferenceError: env.MISAKANET_KV is undefined cloudflare worker kv binding",
+        "ReferenceError: KV namespace binding missing in cloudflare workers env",
+    ]
+    for e in pip_variants:
+        events.append({"error": e, "source": "pilot-a"})
+    for e in git_variants:
+        events.append({"error": e, "source": "pilot-b", "what_tried": "checked credential.helper path"})
+    for e in cf_variants:
+        events.append({"error": e, "source": "pilot-a"})
+    # 噪音 + 弱信号（应被跳过）
+    events.append({"error": "https://example.com/foo", "source": "pilot-a"})
+    events.append({"error": "it broke", "source": "pilot-b"})
+    events.append({"error": "error[E0308] borrow checker rust cargo", "source": "pilot-c"})
+    summary = harvest(events, DRAFT_DIR, MIN_OCCURRENCES)
+    print(json.dumps(summary, ensure_ascii=False, indent=1)[:2000])
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--events", help="events JSON 文件")
+    ap.add_argument("--demo", action="store_true")
+    ap.add_argument("--out", default=str(DRAFT_DIR))
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--min-occ", type=int, default=MIN_OCCURRENCES)
+    a = ap.parse_args()
+    if a.demo:
+        return demo()
+    if a.events:
+        events = json.loads(Path(a.events).read_text(encoding="utf-8"))
+    elif not sys.stdin.isatty():
+        events = json.load(sys.stdin)
+    else:
+        print("need --events / --demo / stdin"); return 2
+    summary = harvest(events, Path(a.out), a.min_occ)
+    if a.json:
+        print(json.dumps(summary, ensure_ascii=False))
+    else:
+        print(json.dumps(summary, ensure_ascii=False, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_failure_harvest.py
+++ b/tests/test_failure_harvest.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Tests for failure_harvest P0 clustering (failure → draft lesson skeleton).
+
+Locks the fixes from the P0 demo regression:
+- specific error-class kind clusters by class only (pip 3 phrasings → 1 draft);
+- 401/fatal are *weak* signals, not cluster keys (git "401" + "fatal:" → 1 draft);
+- URL-stripping + R-stack drop keep stack sets stable across phrasings;
+- noise / low-signal events never produce drafts.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.failure_harvest import (  # noqa: E402
+    classify,
+    cluster_key,
+    harvest,
+    norm_stack,
+    safe_filename,
+)
+
+PIP_VARIANTS = [
+    "pip install ReadTimeoutError behind corporate proxy while reading from pypi",
+    "ERROR: Could not install packages due to an OSError ReadTimeoutError proxy pypi pip",
+    "pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool proxy timeout pip",
+]
+GIT_VARIANTS = [
+    "git credential helper 401 credential lookup failed github helper path mismatch",
+    "fatal: could not read Username for 'https://github.com': credential helper misconfigured git",
+]
+CF_VARIANTS = [
+    "ReferenceError: env.MISAKANET_KV is undefined cloudflare worker kv binding",
+    "ReferenceError: KV namespace binding missing in cloudflare workers env",
+]
+
+
+# ── classify ─────────────────────────────────────────────
+def test_classify_takes_last_inner_class_and_strips_module_path():
+    # 3 phrasings of the same family must land on the same specific class
+    kinds = {classify(e)[0] for e in PIP_VARIANTS}
+    assert kinds == {"ReadTimeoutError"}
+    for e in PIP_VARIANTS:
+        assert classify(e)[1] is True  # specific → clusterable by class
+
+
+def test_classify_http_code_and_fatal_are_weak_signals():
+    kind, specific, signals = classify(GIT_VARIANTS[0])
+    assert kind == "http-401" and specific is False and "401" in signals
+    kind2, spec2, sig2 = classify(GIT_VARIANTS[1])
+    assert kind2 == "fatal" and spec2 is False and "fatal" in sig2
+
+
+def test_classify_generic_failure_for_rust_borrow():
+    kind, specific, signals = classify("error[E0308] borrow checker rust cargo")
+    assert kind == "generic-failure" and specific is False and signals == []
+
+
+# ── norm_stack ───────────────────────────────────────────
+def test_norm_stack_strips_url_and_drops_r_false_positive():
+    # "https://github.com" would hit web via http; "helper "/"for " would hit R
+    assert norm_stack(GIT_VARIANTS[1]) == ("git",)
+    assert norm_stack("git rebase conflict on branch main") == ("git",)
+    assert "r" not in norm_stack("credential helper 401 github")
+
+
+def test_norm_stack_python_for_pip():
+    assert "python" in norm_stack(PIP_VARIANTS[0])
+
+
+# ── cluster_key ──────────────────────────────────────────
+def test_cluster_key_specific_ignores_stack():
+    assert cluster_key(("git",), "ReadTimeoutError", True) == "K:ReadTimeoutError"
+    assert cluster_key(("python", "web"), "ReadTimeoutError", True) == "K:ReadTimeoutError"
+
+
+def test_cluster_key_generic_uses_stack():
+    assert cluster_key(("git",), "http-401", False) == "G:generic|git"
+    assert cluster_key(("git",), "fatal", False) == "G:generic|git"
+    assert cluster_key(("rust",), "generic-failure", False) == "G:generic|rust"
+
+
+# ── safe_filename ────────────────────────────────────────
+def test_safe_filename_removes_colon_pipe():
+    assert safe_filename("K:ReadTimeoutError") == "K-ReadTimeoutError"
+    assert safe_filename("G:generic|git") == "G-generic-git"
+
+
+# ── harvest end-to-end ───────────────────────────────────
+def _demo_events():
+    events = []
+    for e in PIP_VARIANTS:
+        events.append({"error": e, "source": "pilot-a"})
+    for e in GIT_VARIANTS:
+        events.append({"error": e, "source": "pilot-b", "what_tried": "checked credential.helper path"})
+    for e in CF_VARIANTS:
+        events.append({"error": e, "source": "pilot-a"})
+    events += [
+        {"error": "https://example.com/foo", "source": "pilot-a"},          # noise
+        {"error": "it broke", "source": "pilot-b"},                          # noise
+        {"error": "error[E0308] borrow checker rust cargo", "source": "pilot-c"},  # low signal
+    ]
+    return events
+
+
+def test_harvest_three_families_one_draft_each(tmp_path):
+    s = harvest(_demo_events(), tmp_path, min_occ=2)
+    assert s["events"] == 10 and s["cleaned_noise"] == 2
+    kinds = {d["kind"] for d in s["drafts"]}
+    assert kinds == {"ReadTimeoutError", "http-401", "ReferenceError"}
+    by_kind = {d["kind"]: d for d in s["drafts"]}
+    assert by_kind["ReadTimeoutError"]["occurrences"] == 3   # 3 phrasings merged
+    assert by_kind["http-401"]["occurrences"] == 2           # 401 + fatal merged
+    # only rust singleton skipped as low signal
+    assert [x["reason"] for x in s["skipped"]] == ["low signal (occ=1 < 2)"]
+
+
+def test_harvest_writes_drafts_with_weak_signals_in_patterns(tmp_path):
+    s = harvest(_demo_events(), tmp_path, min_occ=2)
+    git_file = tmp_path / "G-generic-git.md"
+    assert git_file.exists()
+    body = git_file.read_text(encoding="utf-8")
+    fm = json.loads(body.split("---")[1])
+    assert fm["failure_patterns"] == ["http-401", "401", "fatal", "git"]
+    assert "fatal: could not read Username" in body       # variant preserved
+    assert "checked credential.helper path" in body       # what_tried preserved


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

失败事件 → 指纹簇 → lesson 骨架草稿（落 `lessons/drafts/`），与 fatal-guard 草稿同一生命周期（自动生成 → PR → 维护者审 → 升格 contrib）。Review 通过后最小实现（`docs/reviews/2026-09-07-intake-lesson-network-vs-ecosystem.md`）。

### 防过窄（demo 复现 8 簇全拆 → 3 簇 3 草稿）
1. `classify()` 取**最后/最内层**异常类名并剥模块路径：pip 3 措辞变体（`ReadTimeoutError` / `OSError ReadTimeoutError` / `pip._vendor...ReadTimeoutError`）→ 1 簇
2. **401/fatal/HTTP 码 = 弱信号**（进 `failure_patterns`，不作聚类键）：git credential 的 `401` 与 `fatal:` 两措辞 → 1 簇
3. `norm_stack()` 剥 URL（防 `https://` → web 误报）+ 剔除 R 栈 `"r "` 单字符误报（"error " 尾字母误命中）
4. 聚类键：specific kind → `K:<class>`；generic → `G:generic|<栈>`

### 防噪音
- occ ≥ min_occ（默认 2）才写草稿；what_tried 不豁免 occ=1
- 文件名跨平台安全（去 `:`/`|`）

### 测试与文档
- `tests/test_failure_harvest.py` 10 用例（40 pytest 全过）
- `lessons/drafts/README.md`：纳入 failure-harvest 第二来源 frontmatter 规范
- `docs/maintainer/handoff-2026-09-06.md`：Wave 13 附记

## Demo 验证
```
events:10 | cleaned_noise:2 | clusters:4 | drafts:3 (ReadTimeoutError×3, http-401×2, ReferenceError×2) | skipped:1 (rust occ=1)
```


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `failure_harvest.py` to cluster failure events into lesson drafts

- Cluster by specific class kind; treat 401/fatal as weak signals

- Strip URLs and drop false-positive `r` stack before detection

- Require `occ ≥ min_occ` (default 2) to write drafts

- Add 10 pytest cases locking the anti-narrow clustering fixes

- Document Wave 13 handoff and failure→lesson ecosystem review


___

### Diagram Walkthrough


```mermaid
flowchart TD
  E["Failure Events"] --> CL["classify()"]
  CL --> NS["norm_stack()"]
  CL --> CK["cluster_key()"]
  NS --> CK
  CK --> H["harvest()"]
  H --> D["lessons/drafts/*.md"]
  H --> S["Summary (drafts/skipped)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>failure_harvest.py</strong><dd><code>Add failure_harvest clustering and draft generation script</code></dd></summary>
<hr>

scripts/failure_harvest.py

<ul><li>Reuse <code>intake_bot._detect_stack/_is_noise/fingerprint</code> for <br>stack/fingerprint<br> <li> <code>classify()</code> picks last/innermost exception class; HTTP codes/fatal are <br>weak signals<br> <li> <code>norm_stack()</code> strips URLs and drops <code>r</code> stack to avoid false positives<br> <li> <code>cluster_key()</code> uses specific kind alone or generic+stack; <br><code>MIN_OCCURRENCES=2</code><br> <li> Builds draft frontmatter with <code>harvest_ref</code>, <code>failure_patterns</code>, <br><code>evidence_level: E0</code><br> <li> CLI: <code>--demo</code>, <code>--events</code>, <code>--stdin</code>, <code>--out</code>, <code>--min-occ</code>, <code>--json</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1545/files#diff-d48f2887cb969102a03c38def0ea0008bc5fe218f56efab3d18ad3dcbaeba5cb">+264/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_failure_harvest.py</strong><dd><code>Add tests locking failure_harvest anti-narrow clustering</code>&nbsp; </dd></summary>
<hr>

tests/test_failure_harvest.py

<ul><li>10 pytest cases covering <br>classify/norm_stack/cluster_key/safe_filename/harvest<br> <li> Locks pip 3 phrasings → 1 cluster; git 401+fatal → 1 cluster<br> <li> Asserts URL-strip + R-stack drop and low-signal skip behavior<br> <li> Verifies draft frontmatter <code>failure_patterns</code> and variant preservation</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1545/files#diff-017bfc18a165ed8d4f9f413c3360fd397902ba4ebb9b6546d904fdb25fd1bbd8">+130/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handoff-2026-09-06.md</strong><dd><code>Append Wave 13 handoff note for failure_harvest P0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/maintainer/handoff-2026-09-06.md

<ul><li>Adds Wave 13 note documenting failure_harvest P0 implementation<br> <li> Records PR打样核对结论 and open-PR竞品 triage<br> <li> Lists防过窄 fixes (classify/norm_stack/cluster_key/MIN_OCCURRENCES)<br> <li> Captures pending follow-ups (#1527, #1528, real event source, #1535 <br>triage)</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1545/files#diff-7f42e3eed23ac077b1526d5ada631cd6bb1ae0d4feaa349e16ae2be7491ee031">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>2026-09-07-intake-lesson-network-vs-ecosystem.md</strong><dd><code>Add P0 ecosystem review and scope cuts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reviews/2026-09-07-intake-lesson-network-vs-ecosystem.md

<ul><li>First-principles review of failure→lesson network vs <br>Sentry/PR-Agent/pr-genius<br> <li> Defines scope cuts: no in-house event platform, no code auto-fix, no <br>LLM memory<br> <li> Distinguishes MisakaNet (cross-project failure lessons) from PR-Agent <br>(code review)<br> <li> Approves P0 minimum implementation with component-level "borrow not <br>rebuild"</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1545/files#diff-27813da203d792aec45411ab911c36ab8967537ab488d551fde26f87f5324ed1">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document failure-harvest as second draft source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lessons/drafts/README.md

<ul><li>Adds source B (failure-harvest) alongside source A (fatal-guard) <br>lifecycle<br> <li> Extends frontmatter table with <br><code>harvest_ref</code>/<code>failure_patterns</code>/<code>evidence_level</code><br> <li> Notes <code>failure_harvest</code> title format differs from fatal-guard<br> <li> Keeps verification/draft→contrib promotion flow intact</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1545/files#diff-85d1ca6e07335ba9a7758609f0e3b25047c10ddbb83aff23850cc36a5949d68c">+12/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

