### PR TITLE
docs: DSH Directory badge + failure-knowledge benchmark swap + failure_harvest smoke guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ mcp-name: io.github.Ikalus1988/misakanet
   <a href="https://pypi.org/project/misakanet/"><img src="https://img.shields.io/pypi/v/misakanet" alt="PyPI"></a>
   <a href="https://www.npmjs.com/package/misakanet"><img src="https://img.shields.io/npm/v/misakanet" alt="npm"></a>
   <a href="https://dsh-plugin.org/plugins/ikalus1988/misakanet"><img src="https://dsh-plugin.org/badges/listed.svg" alt="Listed on dsh-plugin.org"></a>
+  <a href="https://dsh.directory/plugins/ikalus1988/misakanet"><img src="https://dsh.directory/badges/listed.svg" alt="Listed on DSH Directory"></a>
   <a href="https://www.dsh.so/artifact/misakanet/"><img src="https://www.dsh.so/badge/install/misakanet.svg" alt="dsh.so install"></a>
 </p>
 
@@ -467,25 +468,34 @@ Use skills when you want an agent to do something. Use MisakaNet when you want a
 
 ## How is this different?
 
-| Project | ⭐ | Active | Sharing model | Infrastructure | Entry cost |
-|---------|-----|--------|---------------|----------------|------------|
-| **MisakaNet** | ![stars](https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social) | ✅ Active | Public Git-backed failure-memory | `git` + `python3` *(zero-dep)* | `git clone` (5s) |
-| [agentmemory](https://github.com/rohitg00/agentmemory) | ![stars](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social) | ✅ Active | Local/team memory depending on backend | Python + SQLite | `pip install` |
-| [Memorix](https://github.com/AVIDS2/memorix) | ![stars](https://img.shields.io/github/stars/AVIDS2/memorix?style=social) | ✅ Active | MCP shared memory | Python | `pip install` |
-| [Memoria](https://github.com/matrixorigin/Memoria) | ![stars](https://img.shields.io/github/stars/matrixorigin/Memoria?style=social) | ✅ Active | Cloud / app-level shared memory | Infra-backed | Docker |
-| [claude-memory-compiler](https://github.com/coleam00/claude-memory-compiler) | ![stars](https://img.shields.io/github/stars/coleam00/claude-memory-compiler?style=social) | 🟡 Warm | Personal memory | Python | `pip install` |
-| [SwarmClaw](https://github.com/swarmclawai/swarmclaw) | ![stars](https://img.shields.io/github/stars/swarmclawai/swarmclaw?style=social) | 🟡 Warm | Runtime federation | Python | `pip install` |
-| [Agent-KB](https://github.com/OPPO-PersonalAI/Agent-KB) | ![stars](https://img.shields.io/github/stars/OPPO-PersonalAI/Agent-KB?style=social) | 🔬 Research | Shared experience pool / research prototype | Docker + PostgreSQL | Docker (~15min) |
-| [MemoryCustodian](https://github.com/waittim/MemoryCustodian) | ![stars](https://img.shields.io/github/stars/waittim/MemoryCustodian?style=social) | 🟡 Warm | Personal memory | Python | `pip install` |
-| [GoodMemory](https://github.com/hjqcan/GoodMemory) | ![stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=social) | ✅ Active | Local / app-level memory | TypeScript + Bun/SQLite | `npm install` |
+MisakaNet is **not** a general memory system (Mem0 / agentmemory / Memorix etc. are
+a different category — see [What this is NOT](#what-this-is-not) above). The closest
+relatives are *failure/experience knowledge* MCP servers for AI agents (Glama-listed):
 
-> **MisakaNet is not the only shared memory system.** Its edge is:
+| Project | ⭐ | 定位（shared model） | 与 MisakaNet 差异 |
+|---------|-----|---------------------|-------------------|
+| **MisakaNet** | ![stars](https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social) | Public Git-backed failure memory — verified debugging lessons, searchable by agents & humans | — |
+| [deadends.dev](https://github.com/dbwls99706/deadends.dev) | ![stars](https://img.shields.io/github/stars/dbwls99706/deadends.dev?style=social) | Structured failure knowledge — dead ends, workarounds, error chains | 同类最接近：同样存"失败→解法"；差异：我们的 lesson 走 DCO 审校 + 证据分级 + 可全文搜索/基准护栏，且零依赖本地可查 |
+| [Prior](https://github.com/cg3inc/prior_mcp) (io.cg3) | ![stars](https://img.shields.io/github/stars/cg3inc/prior_mcp?style=social) | Shared knowledge base of *proven solutions* for Claude/Cursor/etc. | 偏"已验证方案"经验交换，非专门失败记忆；我们按失败原语组织、命中可量化 |
+| [Kira](https://github.com/aibenyclaude-coder/Kira) | ![stars](https://img.shields.io/github/stars/aibenyclaude-coder/Kira?style=social) | Auto-manages Skills & Scars (persistent failure warnings) for agents | Scars 偏"本次会话/项目级警告"；我们是跨项目、公开、可审计的失败课程库 |
+| [Casebook-MCP](https://github.com/AgentPostmortem/Casebook-MCP) | ![stars](https://img.shields.io/github/stars/AgentPostmortem/Casebook-MCP?style=social) | Remote MCP over AgentPostmortem — registry of documented AI-agent failures | 同为 agent 故障复盘库；差异：我们带 intake 闭环 + 证据分级 + 课程可升格 contrib |
+| [knownissue](https://github.com/gong8/knownissue) | ![stars](https://img.shields.io/github/stars/gong8/knownissue?style=social) | Shared debugging memory — search/report/patch/verify issues | 同为调试记忆共享；我们侧重"已审校 lesson 可检索复用"，非 issue 工单闭环 |
+| [fix-memory-mcp](https://github.com/l111403717-cloud/fix-memory-mcp) | ![stars](https://img.shields.io/github/stars/l111403717-cloud/fix-memory-mcp?style=social) | Local-first coding fix memory for agents | 本地私有 fix 记忆；我们是公开共享 + 网络化检索 |
+| [cogmem](https://github.com/dcondrey/cogmem) | ![stars](https://img.shields.io/github/stars/dcondrey/cogmem?style=social) | Self-improving, verifiable memory layer for coding agents | 通用 agent 记忆层；我们是失败知识专库，非会话/状态记忆 |
+
+> Glama 目录上还可见 AskAgent（错误原文→根因→修复档案）、Civis（结构化方案/构建日志检索）、
+> FixFlow 等条目，但未发现公开 GitHub 仓库，未列入上表（避免引用无法核验的链接）。
+> 上表仅收录可核验仓库；⭐ 为写时快照。
+
+> **MisakaNet is not the only shared failure-memory system.** Its edge is:
 > - **Git-backed** — every lesson is a Markdown file, fully auditable, version-controlled
 > - **Zero-dependency** — pure Python stdlib, no vector DB, no embedding model, no server
 > - **Purpose-built** — failure-recovery knowledge, not general memory
 > - **Public by default** — lessons are open, contributions are DCO-gated
 >
-> Other systems (Mem0, Agent-KB, agentmemory) offer stronger semantic recall / state management, but require heavier deployment. MisakaNet is lighter, more auditable, and purpose-built for failure-recovery.
+> General-memory systems (Mem0, Agent-KB, agentmemory) offer stronger semantic recall /
+> state management, but require heavier deployment. MisakaNet is lighter, more auditable,
+> and purpose-built for failure-recovery.
 
 > 📦 Core engine is **zero-dep** (pure Python stdlib). Optional extras: `pip install misakanet[semantic|hub|feishu]`.
 > → [Architecture details](ARCHITECTURE.md) · [Benchmark: LessonReuseBench](docs/lesson-reuse-benchmark.md)

--- a/docs/agents/failure-harvest-smoke.md
+++ b/docs/agents/failure-harvest-smoke.md
@@ -1,0 +1,82 @@
+# failure_harvest 全流程 Smoke 验证
+
+> 目标：验证"失败事件 → 指纹簇 → lesson 骨架草稿"全流程可复现地跑通，
+> 且草稿满足升格前置（lesson_gate 结构门可通过）。
+> 适用：`scripts/failure_harvest.py`（P0，#1545 合入后）。
+
+## 触发方式
+
+### 方式 A：内置 demo（3 族合成事件，快速自检）
+
+```bash
+python3 scripts/failure_harvest.py --demo
+```
+
+预期（断言见 `tests/test_failure_harvest.py`）：
+
+```
+events:10 | cleaned_noise:2 | clusters:4 | drafts:3 | skipped:1
+  drafts: K:ReadTimeoutError(3) / G:generic|git(2) / K:ReferenceError(2)
+  skipped: G:generic|rust — low signal (occ=1 < 2)
+```
+
+验证点：
+- pip 3 措辞变体（ReadTimeoutError / OSError ReadTimeoutError / 模块全路径）→ **1 簇**（防过窄）
+- git credential "401" 与 "fatal:" 两措辞 → **1 簇**（弱信号不拆族）
+- cloudflare KV 两措辞 → **1 簇**
+- 纯 URL / 短文本噪音 → 跳过（cleaned_noise=2）
+- 单事件 rust → 跳过（occ 门槛）
+
+### 方式 B：真实形态事件文件（端到端，推荐）
+
+构造 `events.json`（真实失败事件，同族可多变体、可带 source/what_tried）：
+
+```json
+[
+  {"error": "/home/hp/.local/bin/gh auth git-credential get: ... gh: not found",
+   "source": "agent-a", "what_tried": "checked gh install path"},
+  {"error": "fatal: could not read Username for 'https://github.com': credential helper ...",
+   "source": "agent-b", "what_tried": "reinstalled gh"}
+]
+```
+
+```bash
+python3 scripts/failure_harvest.py --events events.json --out lessons/drafts
+# 或管道
+cat events.json | python3 scripts/failure_harvest.py --json
+```
+
+产物落 `lessons/drafts/<safe-cid>.md`（如 `G-generic-git.md`），
+frontmatter 含 `source: failure-harvest`、`harvest_ref`、`failure_patterns`、
+`evidence_level: E0` —— 与 fatal-guard 草稿同生命周期。
+
+### 方式 C：升格前置验证（草稿 → contrib 门槛）
+
+草稿在 `lessons/drafts/` 隔离区不受 lesson_lint/lesson_gate 硬卡；
+升格前人工补全 Root Cause / Solution / Verification 后移入 `lessons/contrib/`，
+届时由 `lesson-gate.yml` 硬门校验。本地预检：
+
+```bash
+python3 scripts/failure_harvest.py --demo          # 生成草稿
+python3 scripts/lesson_gate.py lessons/drafts/G-generic-git.md   # 结构预检
+```
+
+实测：harvest 草稿 frontmatter（title/domain/tags/status/evidence_level）
++ content ≥100 字符已满足 lesson_gate 结构要求（demo 草稿直接通过）。
+
+## 单测护栏
+
+```bash
+python3 -m pytest tests/test_failure_harvest.py -q   # 10 用例
+python3 -m pytest tests/test_failure_harvest.py tests/test_intake_bot_50.py -q  # 40 全过
+```
+
+锁定防回归点：specific kind 按类聚类 / generic 按栈聚类 / URL 剥除 / R 栈剔除 /
+401+fatal 同簇 / occ 门槛 / 文件名跨平台安全。
+
+## 已知边界
+
+- 草稿 = 骨架（E0，无 Root Cause/验证）——升格需维护者审 + 补全（草稿生命周期）
+- 跨异常类型的同根因（如 TypeError vs ReferenceError 同因）不合并——确定性规则
+  不臆测语义，留给 #1527 failure_patterns 签名索引
+- 真实事件源接入（ci-lesson-search 失败事件 → harvest）尚未自动化，属后续工作


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

### 1. DSH Directory badge
MisakaNet 已上线 alexchenzl 的 [DSH Directory](https://dsh.directory/plugins/ikalus1988/misakanet)（issue #47 已 close，维护者提供 badge）。README 此前只有 dsh-plugin.org（另一目录），补上 dsh.directory。

### 2. README 对标修正
原 "How is this different?" 对标以**通用记忆系统**（agentmemory/Memorix/Memoria/GoodMemory…）为主——用户指出这与其说是对标不如说是反例，真正的同类是 Glama 推荐的**失败/经验知识类 MCP**。已换表：
- 收录可核验仓库：deadends.dev、Prior(io.cg3)、Kira、Casebook-MCP、knownissue、fix-memory-mcp、cogmem（逐项 GitHub API 核验存在）
- 明确差异列（共享模型 vs MisakaNet 定位）
- 无公开仓库的条目（AskAgent/Civis/FixFlow）注明不列，避免引用无法核验的链接
- 通用记忆系统移到表外，cross-ref "What this is NOT"

### 3. failure_harvest 全流程 smoke 指南
`docs/agents/failure-harvest-smoke.md`：三种触发方式（demo / 真实事件文件 / 升格预检）+ 预期输出 + 单测护栏 + 边界。实测：demo 3 簇 3 草稿、噪音跳过、草稿过 lesson_gate 结构门。

## 验证
- README 全部 badge URL 可达（dsh.directory/dsh-plugin.org 200）
- lesson_gate 对 harvest 草稿预检通过
- pytest 40 全过（含 test_failure_harvest 10 新用例）


___

### **PR Type**
Documentation


___

### **Description**
- Added DSH Directory badge alongside existing dsh-plugin.org badge

- Replaced README "How is this different?" peer table with verified failure/experience knowledge MCPs

- Moved general memory systems to "What this is NOT" cross-reference

- Added `failure-harvest-smoke.md` full-flow verification guide


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] --> B["+ DSH Directory badge"]
  A --> C["Swap peer table"]
  C --> D["Failure/experience MCPs"]
  C --> E["Move general memory to NOT-list"]
  F["docs/agents/failure-harvest-smoke.md"] --> G["Demo trigger"]
  F --> H["Real events file trigger"]
  F --> I["Promotion pre-check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>DSH badge + failure-memory peer benchmark swap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added DSH Directory (<code>dsh.directory</code>) badge next to existing <br><code>dsh-plugin.org</code> badge<br> <li> Replaced "How is this different?" table to benchmark against verified <br>failure/experience knowledge MCP servers (deadends.dev, Prior, Kira, <br>Casebook-MCP, knownissue, fix-memory-mcp, cogmem)<br> <li> Removed unverifiable entries (AskAgent/Civis/FixFlow) from table, <br>noted as Glama-visible without public repo<br> <li> Moved general memory systems (Mem0/agentmemory/Memorix/...) into "What <br>this is NOT" cross-reference</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1546/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+24/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>failure-harvest-smoke.md</strong><dd><code>failure_harvest full-flow smoke verification guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/agents/failure-harvest-smoke.md

<ul><li>Documents three trigger modes: <code>--demo</code>, real <code>events.json</code> file, and <br>promotion pre-check<br> <li> Specifies expected cluster counts (4 clusters / 3 drafts / 1 skipped) <br>and assertion points<br> <li> Details draft frontmatter contract (<code>source: failure-harvest</code>, <br><code>harvest_ref</code>, <code>evidence_level: E0</code>) and lesson_gate structural pre-check <br>workflow<br> <li> Lists known boundaries (E0 skeleton drafts, no cross-type clustering, <br>manual event ingestion)</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1546/files#diff-eccf40ef4d6bb99e1b683890dcd56d5033aaa0bc6b96f407998af7f786c32b5c">+82/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

