### PR TITLE
fix(ci): register workflow skips [Onboarding] issues — stop auto-close loop

### DIFF
--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -21,16 +21,20 @@ jobs:
     # 处理 "join"、"register" 相关 Issue 或 workflow_dispatch 手动触发
     # 支持中英文：join / Join / register / Register / 加入 / 注册 / Registration
     # 还处理邮件注册 Worker 创建的 Issue（email-register: 前缀）
+    # 排除 "[Onboarding]" 聚合入口（如 #1258 "always open" 指引 issue）——
+    # 此类 issue 标题历史含 "Register"，reopen 会误触发注册-关闭循环（2026-09-08 复现）。
     if: |
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.issue.title, 'join') ||
-      contains(github.event.issue.title, 'Join') ||
-      contains(github.event.issue.title, 'register') ||
-      contains(github.event.issue.title, 'Register') ||
-      contains(github.event.issue.title, '加入') ||
-      contains(github.event.issue.title, '注册') ||
-      contains(github.event.issue.title, 'Registration') ||
-      contains(github.event.issue.title, 'email-register')
+      (github.event.issue.title != null &&
+       !startsWith(github.event.issue.title, '[Onboarding]') &&
+       (contains(github.event.issue.title, 'join') ||
+        contains(github.event.issue.title, 'Join') ||
+        contains(github.event.issue.title, 'register') ||
+        contains(github.event.issue.title, 'Register') ||
+        contains(github.event.issue.title, '加入') ||
+        contains(github.event.issue.title, '注册') ||
+        contains(github.event.issue.title, 'Registration') ||
+        contains(github.event.issue.title, 'email-register')))
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 背景

Pinned onboarding 入口 **#1258**（body 首句 "This issue is always open"）反复被误关：其标题含 "Register"，每次 reopen 触发 `register.yml`（issues reopened）→ 注册流程在完成时打 `registered` 标签并 **close** 该 issue。2026-09-08 复现两次（reopen 后 13 秒被 github-actions[bot] 关闭）。

## 修复

`register.yml` 的 register job `if` 排除标题以 `[Onboarding]` 开头的聚合入口 issue（#1258 已改名去触发词作为即时止血；本修复是通用防御，防未来 onboarding 类 issue 再被误关）。

- `workflow_dispatch` 仍可手动触发
- 普通 join/register/加入/注册/email-register issue 的注册-关闭流程不变

## 验证

- YAML 解析通过
- #1258 改名后 reopen 保持 open（20s+ 验证）

Signed-off-by: Ikalus1988 <136884451+Ikalus1988@users.noreply.github.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude `[Onboarding]` issues from register workflow trigger

- Add null safety check for issue title in `if` condition

- Prevent auto-close loop on pinned onboarding issue #1258


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue reopened"] --> B{"Title starts with [Onboarding]?"}
  B -- Yes --> C["Skip register job — keep open"]
  B -- No --> D{"Title contains join/register/加入/注册/email-register?"}
  D -- Yes --> E["Run register job — apply 'registered' + close"]
  D -- No --> F["Skip register job"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register.yml</strong><dd><code>Skip [Onboarding] issues from register trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/register.yml

<ul><li>Wrapped the title-matching conditions inside a parenthesized group <br>guarded by <code>!startsWith(title, '[Onboarding]')</code> and a null check<br> <li> Added inline comment explaining the exclusion and the 2026-09-08 repro<br> <li> Preserved <code>workflow_dispatch</code> and all existing trigger keywords <br>(join/Join/register/Register/加入/注册/Registration/email-register)</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1561/files#diff-bc5c828df9b4d0ab95b021910dac8ca634696460eba760bb8ca810bb7aa14e34">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

