### PR TITLE
fix(email): switch rate limit from interval to count-based window (5/day)

### DIFF
--- a/workers/email-register/src/index.js
+++ b/workers/email-register/src/index.js
@@ -48,12 +48,14 @@ export default {
       return;
     }
 
-    const lastReg = await env.MISAKANET_KV.get(`rate:email:${sender}`, 'text');
-    if (lastReg && (Date.now() - parseInt(lastReg)) < 86400000) {
-      console.log(`Rate limited email: ${sender}`);
+    const MAX_EMAILS_PER_DAY = 5;
+    const rateCount = await env.MISAKANET_KV.get(`rate:email:${sender}`, 'text');
+    const currentCount = parseInt(rateCount) || 0;
+    if (currentCount >= MAX_EMAILS_PER_DAY) {
+      console.log(`Rate limited email (${currentCount}/${MAX_EMAILS_PER_DAY}): ${sender}`);
       return;
     }
-    await env.MISAKANET_KV.put(`rate:email:${sender}`, String(Date.now()), { expirationTtl: 86400 });
+    await env.MISAKANET_KV.put(`rate:email:${sender}`, String(currentCount + 1), { expirationTtl: 86400 });
 
     // Consume the raw stream before forwarding and retain only bounded, plain text.
     const rawEmail = await new Response(message.raw).text();


### PR DESCRIPTION
Closes #1564

## Changes
- Replace timestamp-based interval check with count-based window
- Track email count per sender with 24h TTL expiration
- Allow up to 5 emails per sender per day before dropping

## Testing
- Verified rate limiting logic with count-based approach
- Weekly senders now properly limited after 5 emails