### PR TITLE
fix(search): expand hyphenated tokens in BM25 tokenizer for better recall

### DIFF
--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -523,10 +523,18 @@ const BM25_STOPWORDS = new Set([
 ]);
 
 function bm25Tokenize(text) {
-  return text.toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .split(/\s+/)
+  const lower = text.toLowerCase();
+  // Split on non-alphanumeric, get base tokens
+  const baseTokens = lower.replace(/[^a-z0-9]+/g, " ").split(/\s+/)
     .filter(t => t.length >= 2 && !BM25_STOPWORDS.has(t));
+  // Also extract compound tokens from hyphenated words (e.g. "dco-signoff" → "dco-signoff")
+  const compoundTokens = lower.match(/[a-z0-9]+-[a-z0-9]+/g) || [];
+  const expanded = [];
+  for (const compound of compoundTokens) {
+    const joined = compound.replace(/-/g, "");
+    if (joined.length >= 2) expanded.push(joined);
+  }
+  return [...new Set([...baseTokens, ...expanded])];
 }
 
 function searchLessonsBM25(index, query, domain, top = 5) {


### PR DESCRIPTION
Closes #1562

## Root Cause
BM25 tokenizer splits on non-alphanumeric characters, so:
- Index: 'dco-signoff' → tokens ['dco', 'signoff']
- Query: 'dco sign-off' → tokens ['dco', 'sign', 'off']
- No match because 'sign' ≠ 'signoff'

## Fix
bm25Tokenize now emits both split tokens AND concatenated compound tokens:
- 'dco-signoff' → ['dco', 'signoff', 'dcosignoff']
- 'sign-off' → ['sign', 'off', 'signoff']
- Now 'dco sign-off' query produces ['dco', 'sign', 'off', 'signoff'] which matches index

## Testing
- Verified tokenizer produces expected tokens for hyphenated terms
- Both index and query paths use the same bm25Tokenize function