### PR TITLE
feat(gap): add gap→lesson lifecycle cleanup with BM25 matching

### DIFF
--- a/workers/gap-lifecycle.test.mjs
+++ b/workers/gap-lifecycle.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { cleanupCoveredGaps } from './register-proxy-sw.js';
+
+function createFakeKV(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    async get(key, opts) {
+      if (!store.has(key)) return null;
+      const raw = store.get(key);
+      const type = typeof opts === 'string' ? opts : opts?.type;
+      if (type === 'json') {
+        try { return JSON.parse(raw); } catch { return raw; }
+      }
+      return raw;
+    },
+    async put(key, value) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+// Minimal BM25 index with one doc matching "dco signoff" (via bm25Tokenize expansion)
+const MOCK_BM25_INDEX = {
+  version: 1,
+  docCount: 1,
+  avgDocLen: 10,
+  terms: {
+    dco: { idf: 1.5, docs: [{ doc: 0, tf: 2, len: 10 }] },
+    signoff: { idf: 1.2, docs: [{ doc: 0, tf: 1, len: 10 }] },
+    sign: { idf: 1.0, docs: [{ doc: 0, tf: 1, len: 10 }] },
+    off: { idf: 0.8, docs: [{ doc: 0, tf: 1, len: 10 }] },
+  },
+  docs: [{ id: 'dco-signoff-force-push-pitfall', title: 'DCO Signoff Force Push Pitfall', domain: 'git', path: 'lessons/core/dco-signoff-force-push-pitfall.md' }],
+};
+
+// Note: loadBM25Index has a 5-min global cache. Tests run sequentially; the first
+// test that loads the index will cache it. We test "no BM25 index" via empty gap
+// index (short-circuits before loadBM25Index), and test matching with a fresh KV
+// that has the index key.
+
+test('cleanupCoveredGaps does nothing when gap index is empty', async () => {
+  const kv = createFakeKV({
+    'gap:index': JSON.stringify([]),
+  });
+
+  const result = await cleanupCoveredGaps({ MISAKANET_KV: kv });
+  assert.equal(result.cleaned, 0);
+});
+
+test('cleanupCoveredGaps removes gaps that now have matching lessons', async () => {
+  const kv = createFakeKV({
+    'gap:index': JSON.stringify(['gap:dco sign-off', 'gap:unrelated topic']),
+    'gap:dco sign-off': JSON.stringify({ query: 'dco sign-off', count: 3 }),
+    'gap:unrelated topic': JSON.stringify({ query: 'unrelated topic', count: 1 }),
+    'worker_search_index': JSON.stringify(MOCK_BM25_INDEX),
+  });
+
+  const result = await cleanupCoveredGaps({ MISAKANET_KV: kv });
+  assert.equal(result.cleaned, 1);
+  assert.equal(result.remaining, 1);
+  assert.equal(result.details[0].query, 'dco sign-off');
+  // Gap key for matched query should be deleted
+  assert.equal(kv._store.has('gap:dco sign-off'), false);
+  // Gap key for unmatched query should remain
+  assert.equal(kv._store.has('gap:unrelated topic'), true);
+  // Index should be updated
+  const newIndex = JSON.parse(kv._store.get('gap:index'));
+  assert.deepEqual(newIndex, ['gap:unrelated topic']);
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -745,6 +745,16 @@ async function handleMcpToolCall(env, toolName, args, authToken, clientIp, ctx) 
         lastSeen: new Date().toISOString(),
       };
       await env.MISAKANET_KV.put(key, JSON.stringify(entry), { expirationTtl: 86400 * 90 });
+
+      // Track gap key in index for lifecycle management (Issue #1567)
+      if (!existing) {
+        const indexRaw = await env.MISAKANET_KV.get("gap:index", { type: "json" });
+        const index = Array.isArray(indexRaw) ? indexRaw : [];
+        if (!index.includes(key)) {
+          index.push(key);
+          await env.MISAKANET_KV.put("gap:index", JSON.stringify(index));
+        }
+      }
     } catch (_) {}
   }
 
@@ -2398,6 +2408,41 @@ async function aggregateDailyTraffic(env) {
   return { aggregated: totalAggregated, month, date: today };
 }
 
+// ── Gap Lifecycle (Issue #1567) ──
+async function cleanupCoveredGaps(env) {
+  const indexRaw = await env.MISAKANET_KV.get("gap:index", { type: "json" });
+  const index = Array.isArray(indexRaw) ? indexRaw : [];
+  if (index.length === 0) return { cleaned: 0 };
+
+  // Load BM25 index to check if lessons now cover gap queries
+  const bm25Index = await loadBM25Index(env);
+  if (!bm25Index) return { cleaned: 0, reason: "no BM25 index" };
+
+  const cleaned = [];
+  const remaining = [];
+
+  for (const gapKey of index) {
+    const query = gapKey.replace(/^gap:/, "");
+    // Search lessons for the gap query
+    const results = searchLessonsBM25(bm25Index, query, null, 3);
+    if (results.length > 0) {
+      // Lesson now covers this gap — delete the gap key
+      await env.MISAKANET_KV.delete(gapKey);
+      cleaned.push({ query, matchedLesson: results[0]?.title });
+    } else {
+      remaining.push(gapKey);
+    }
+  }
+
+  // Update index with remaining gaps
+  if (cleaned.length > 0) {
+    await env.MISAKANET_KV.put("gap:index", JSON.stringify(remaining));
+  }
+
+  console.log(`[gap-lifecycle] cleaned ${cleaned.length} covered gaps, ${remaining.length} remaining`);
+  return { cleaned: cleaned.length, remaining: remaining.length, details: cleaned };
+}
+
 async function runKeepaliveSweep(cron = "manual", env = null) {
   const results = await Promise.allSettled(KEEPALIVE_ENDPOINTS.map(probeKeepaliveEndpoint));
   const failures = results
@@ -3337,6 +3382,12 @@ async function getCode() {
         console.error("[traffic-aggregation] failed", e.message)
       ));
     }
+    // Gap lifecycle: clean up gap keys that now have covering lessons (Issue #1567)
+    if (env.MISAKANET_KV) {
+      ctx.waitUntil(cleanupCoveredGaps(env).catch(e =>
+        console.error("[gap-lifecycle] failed", e.message)
+      ));
+    }
   },
 };
 
@@ -3420,4 +3471,5 @@ export {
   findCoveringLesson,
   aggregateDailyTraffic,
   runKeepaliveSweep,
+  cleanupCoveredGaps,
 };


### PR DESCRIPTION
Closes #1567

## Changes
- Track gap keys in gap:index array for efficient scanning
- Add cleanupCoveredGaps() to scheduled handler
- Scan gap queries against BM25 index, delete covered gaps
- Idempotent: only updates index when gaps are cleaned
- Add 2 unit tests

## Testing
- Verified gap cleanup with matching lessons
- Verified empty gap index handling
- All tests pass