### PR TITLE
fix(guard): add deprecation warning + CI schema check for lessons.json generator

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -413,6 +413,25 @@ jobs:
           fi
           echo "✅ Lesson count: $ACTUAL files, $JSON_COUNT indexed"
 
+      - name: Validate lessons.json schema
+        run: |
+          echo "=== lessons.json Schema Validation (Issue #1374) ==="
+          python3 -c "
+          import json, sys
+          REQUIRED = {'id','title','domain','tags','summary','preview','url','triggers','verified','evidence_level','trust_score'}
+          data = json.load(open('data/lessons.json', encoding='utf-8'))
+          missing = set()
+          for entry in data:
+              for field in REQUIRED:
+                  if field not in entry:
+                      missing.add(field)
+          if missing:
+              print(f'::error::lessons.json missing required fields: {sorted(missing)}')
+              print('This likely means misakanet-index.py was used instead of update_lessons_json.py (Issue #1374)')
+              sys.exit(1)
+          print(f'Schema OK: {len(data)} entries, all required fields present')
+          "
+
       # ── Audit Report (all PRs) ──
       - name: Post Audit Report
         if: always()

--- a/scripts/misakanet-index.py
+++ b/scripts/misakanet-index.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 """
-misakanet-index.py — 御坂网络知识索引生成器
+misakanet-index.py — 御坂网络知识索引生成器（非规范版本）
 
-从 lessons/ 目录读取所有 lesson 文件，提取 frontmatter + 摘要，
-生成 lessons.json 供 CDN 分发。
+⚠️  WARNING: 此脚本 **不是** data/lessons.json 的规范生成器。
+    规范生成器是 scripts/update_lessons_json.py（由 update-lessons.yml 每日运行）。
+
+    本脚本输出缺少 preview/triggers/verified/evidence_refs/supersedes 字段，
+    若误用会静默回滚线上搜索页的 evidence 统计。参见 Issue #1374。
+
+    仅用于本地调试或独立索引场景，不要提交其输出到 data/lessons.json。
 
 用法:
   python3 misakanet-index.py                     # 输出到 stdout
   python3 misakanet-index.py --output lessons.json  # 写入文件
-
-发布:
-  GitHub Actions 或 cron 定时运行，将 lessons.json 推送到 CDN。
-  也可直接用 raw.githubusercontent.com 从 GitHub 读取。
 """
 
 import json
@@ -128,6 +129,13 @@ def build_index(lessons_dir: str | Path) -> list[dict]:
 
 def main():
     import argparse
+
+    print(
+        "⚠️  WARNING: misakanet-index.py is NOT the canonical lessons.json generator.\n"
+        "   Use scripts/update_lessons_json.py instead (Issue #1374).\n"
+        "   This script omits preview/triggers/verified/evidence_refs/supersedes fields.\n",
+        file=sys.stderr,
+    )
 
     parser = argparse.ArgumentParser(description="御坂网络知识索引生成器")
     parser.add_argument(


### PR DESCRIPTION
## Summary

- Add deprecation warning to `misakanet-index.py` (docstring + stderr on execution)
- Add CI schema validation step in `pr-checks.yml` that fails if required fields are missing from `data/lessons.json`

## Problem

`misakanet-index.py` produces a different schema than the canonical `update_lessons_json.py` — missing `preview`, `triggers`, `verified`, `evidence_refs`, `supersedes` fields. Accidentally using it silently rolls back evidence statistics on the live search page.

## Changes

1. **`scripts/misakanet-index.py`**: Updated docstring with ⚠️ warning, added stderr message on execution
2. **`.github/workflows/pr-checks.yml`**: New "Validate lessons.json schema" step that checks all required fields exist

Closes #1374