### PR TITLE
fix(ops): debounce keepalive probe failures + cron */15

### DIFF
--- a/workers/keepalive-debounce.test.mjs
+++ b/workers/keepalive-debounce.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runKeepaliveSweep } from "./register-proxy-sw.js";
+
+// Mock the global fetch used by probeKeepaliveEndpoint: force a rejection for
+// every probe so the sweep always reports failures (simulates CF edge 522).
+function forceFailFetch() {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("health returned HTTP 522");
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+function makeFakeKV() {
+  const store = new Map();
+  return {
+    async get(key, type) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    async put(key, value, opts) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+test("keepalive: single failure is a warn, not an error (no throw)", async () => {
+  const restore = forceFailFetch();
+  const kv = makeFakeKV();
+  try {
+    const result = await runKeepaliveSweep("*/15 * * * *", { MISAKANET_KV: kv });
+    assert.equal(result.ok, false);
+    assert.equal(result.consecutive, 1);
+    assert.ok(result.failures.length > 0);
+    assert.equal(kv._store.get("keepalive:fail-count"), "1");
+  } finally {
+    restore();
+  }
+});
+
+test("keepalive: escalates to throw after 3 consecutive failures", async () => {
+  const restore = forceFailFetch();
+  const kv = makeFakeKV();
+  try {
+    await runKeepaliveSweep("*/15 * * * *", { MISAKANET_KV: kv }); // 1
+    const second = await runKeepaliveSweep("*/15 * * * *", { MISAKANET_KV: kv }); // 2
+    assert.equal(second.consecutive, 2);
+    await assert.rejects(
+      () => runKeepaliveSweep("*/15 * * * *", { MISAKANET_KV: kv }), // 3 → error
+      /keepalive/
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("keepalive: success resets the consecutive-failure counter", async () => {
+  const kv = makeFakeKV();
+  kv._store.set("keepalive:fail-count", "2");
+  // Default fetch succeeds against real endpoints only if network allows; stub it.
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  try {
+    const result = await runKeepaliveSweep("manual", { MISAKANET_KV: kv });
+    assert.equal(result.ok, true);
+    assert.equal(kv._store.has("keepalive:fail-count"), false);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/register-proxy-sw.js
+++ b/workers/register-proxy-sw.js
@@ -25,6 +25,11 @@ const KEEPALIVE_ENDPOINTS = [
   { name: "journey", url: "https://misakanet.org/journey/", json: false, metadataOnly: true },
 ];
 
+// Keepalive debounce: transient probe failures (CF edge HTTP 522 on loopback)
+// are warnings; only escalate after this many consecutive failures.
+const KEEPALIVE_FAIL_KEY = "keepalive:fail-count";
+const KEEPALIVE_FAIL_ALERT_AFTER = 3;
+
 // 输入校验
 const MAX_AGENT_TYPE = 30;
 const MAX_NODE_NAME = 50;
@@ -2389,17 +2394,37 @@ async function aggregateDailyTraffic(env) {
   return { aggregated: totalAggregated, month, date: today };
 }
 
-async function runKeepaliveSweep(cron = "manual") {
+async function runKeepaliveSweep(cron = "manual", env = null) {
   const results = await Promise.allSettled(KEEPALIVE_ENDPOINTS.map(probeKeepaliveEndpoint));
   const failures = results
     .filter((item) => item.status === "rejected")
     .map((item) => item.reason?.message || String(item.reason));
 
   if (failures.length) {
-    console.error("[keepalive] failed", JSON.stringify({ cron, failures }));
-    throw new Error(`[keepalive] failed: ${failures.join("; ")}`);
+    // Debounce: transient probe failures (e.g. CF edge HTTP 522 on the public
+    // loopback keepalive to misakanet.org) are monitoring noise, not service
+    // outages. Escalate to an error only after KEEPALIVE_FAIL_ALERT_AFTER
+    // consecutive failures; reset on any healthy sweep.
+    const kv = env?.MISAKANET_KV;
+    let count = 1;
+    if (kv) {
+      const raw = await kv.get(KEEPALIVE_FAIL_KEY, "text").catch(() => null);
+      count = (parseInt(raw || "0", 10) || 0) + 1;
+      await kv.put(KEEPALIVE_FAIL_KEY, String(count), { expirationTtl: 3600 }).catch(() => {});
+    }
+    if (count >= KEEPALIVE_FAIL_ALERT_AFTER) {
+      console.error("[keepalive] failed", JSON.stringify({ cron, failures, consecutive: count }));
+      if (kv) await kv.delete(KEEPALIVE_FAIL_KEY).catch(() => {});
+      throw new Error(`[keepalive] failed: ${failures.join("; ")}`);
+    }
+    console.warn("[keepalive] degraded (transient)", JSON.stringify({ cron, failures, consecutive: count }));
+    return { ok: false, failures, consecutive: count };
   }
 
+  // Healthy — reset the consecutive-failure counter.
+  if (env?.MISAKANET_KV) {
+    await env.MISAKANET_KV.delete(KEEPALIVE_FAIL_KEY).catch(() => {});
+  }
   console.log("[keepalive] ok", JSON.stringify({ cron, endpoints: KEEPALIVE_ENDPOINTS.length }));
   return { ok: true, failures: [] };
 }
@@ -3301,7 +3326,7 @@ async function getCode() {
   },
 
   async scheduled(controller, env, ctx) {
-    ctx.waitUntil(runKeepaliveSweep(controller.cron));
+    ctx.waitUntil(runKeepaliveSweep(controller.cron, env));
     // Daily traffic aggregation: accumulate daily traffic:* into monthly traffic-month:*
     if (env.MISAKANET_KV) {
       ctx.waitUntil(aggregateDailyTraffic(env).catch(e =>
@@ -3390,4 +3415,5 @@ export {
   hashString,
   findCoveringLesson,
   aggregateDailyTraffic,
+  runKeepaliveSweep,
 };

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -2,6 +2,12 @@ name = "misakanet-register-proxy"
 main = "register-proxy-sw.js"
 compatibility_date = "2024-01-01"
 
+# Self-monitoring keepalive probe cadence (was */5 — every 5 min; HTTP 522 on
+# the public loopback probe was generating error noise. */15 keeps watch with
+# 1/3 the noise; failures are debounced in code before they escalate).
+[triggers]
+crons = ["*/15 * * * *"]
+
 [[kv_namespaces]]
 binding = "MISAKANET_KV"
 id = "d5fb6b0797b84d17b0586fb982231ffe"


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 背景

CF dashboard：misakanet-register-proxy 累计 ~225 errors = keepalive cron（*/5）对
misakanet.org 公网回环探测（/api/health|counter|lessons）间歇 HTTP 522，每次失败都
console.error + throw → 错误刷屏。服务本身健康（同窗口 MCP 流量正常、手动探测 200）。

## 修复
1. **失败降噪**（register-proxy-sw.js `runKeepaliveSweep`）：单次/瞬时失败 → console.warn
   （KV 连续失败计数）；**连续 ≥3 次才 error + throw**；健康 sweep 重置计数。
2. **降频**（wrangler.toml）：cron `*/5` → `*/15`（探测噪音降 1/3）。
3. 测试：workers/keepalive-debounce.test.mjs（单次 warn / 连续 3 次 escalate / 成功重置）。

## 验证
- node --test：keepalive-debounce 3 ✓ + traffic-aggregation 4 ✓（共 7 pass）
- node --check + toml 解析通过

Signed-off-by: Ikalus1988 <136884451+Ikalus1988@users.noreply.github.com>


___

### **PR Type**
Bug fix, Tests, configuration changes


___

### **Description**
- Debounce keepalive failures: warn on transient, error after 3 consecutive

- Drop keepalive cron from */5 to */15 to reduce probe noise

- Add unit tests for debounce escalation and counter reset

- Export `runKeepaliveSweep` and pass `env` for KV-backed counter


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Cron sweep */15"] --> B["Probe all endpoints"]
  B --> C{"Any failures?"}
  C -- "no" --> D["Reset KV counter"] --> E["log ok"]
  C -- "yes" --> F["Increment KV fail-count"]
  F --> G{"count >= 3?"}
  G -- "no" --> H["console.warn (degraded)"]
  G -- "yes" --> I["console.error + throw"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register-proxy-sw.js</strong><dd><code>Debounce keepalive failures via KV counter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workers/register-proxy-sw.js

<ul><li>Add <code>KEEPALIVE_FAIL_KEY</code> / <code>KEEPALIVE_FAIL_ALERT_AFTER = 3</code> constants<br> <li> Track consecutive failures in KV; warn on transient, escalate only <br>after 3<br> <li> Reset failure counter on healthy sweep; pass <code>env</code> into <br><code>runKeepaliveSweep</code><br> <li> Export <code>runKeepaliveSweep</code> for unit testing; wire <code>env</code> from <code>scheduled</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1598/files#diff-55537d922a19e93e77ddd38c37d845f1af9382db11e13c42aa33e5394ca92195">+31/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keepalive-debounce.test.mjs</strong><dd><code>Add keepalive debounce unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workers/keepalive-debounce.test.mjs

<ul><li>Test: single failure warns, does not throw, increments counter to 1<br> <li> Test: escalates to throw after 3 consecutive failures<br> <li> Test: healthy sweep resets the consecutive-failure counter</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1598/files#diff-638698f96ff5848fca36f07356ee7ebe1195c00dd4d8472ee502f08aca90f0f4">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wrangler.toml</strong><dd><code>Lower keepalive cron to every 15 minutes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workers/wrangler.toml

<ul><li>Add <code>[triggers] crons = ["*/15 * * * *"]</code> (was */5)<br> <li> Comment explains 522 noise rationale and code-side debounce</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1598/files#diff-e8aa6545a05a55783b175b7eddd3cd128a11c5b315128b7f6c3aca8205c6ffb8">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

