### PR TITLE
ci: auto-reopen protected long-running issues (#1550/#1258)

### DIFF
--- a/.github/workflows/protect-pinned-issues.yml
+++ b/.github/workflows/protect-pinned-issues.yml
@@ -1,0 +1,65 @@
+name: Protect long-running issues
+
+# Guard for curated "always open" issues. GitHub auto-closes an issue whenever a
+# merged PR/commit says "Closes #N" — which has now bitten #1550 twice:
+#   * 2026-09-08  PR #1554 ("Closes #1550") auto-closed it
+#   * 2026-09-09  PR #1560 merge closed it again (workflow #1560 referenced it)
+# #1258 (onboarding entry, "always open" by design) was hit by the same class of
+# accident through register.yml before that.
+#
+# This workflow reopens the protected issues and leaves a short note so the
+# closing cause is visible. To intentionally close one (e.g. #1550 when it
+# reaches 20 pilot reports), remove its number from PROTECTED below first.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  reopen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reopen protected long-running issue
+        uses: actions/github-script@v9
+        env:
+          PROTECTED: "1550,1258"
+        with:
+          script: |
+            const protectedNumbers = (process.env.PROTECTED || '')
+              .split(',').map(s => parseInt(s.trim(), 10)).filter(Boolean);
+            const number = context.payload.issue.number;
+            if (!protectedNumbers.includes(number)) {
+              core.info(`#${number} is not a protected long-running issue — nothing to do`);
+              return;
+            }
+            if (context.payload.issue.state === 'open') {
+              core.info(`#${number} is already open`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              state: 'open',
+            });
+
+            const actor = context.payload.sender?.login || 'unknown';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: [
+                `♻️ **自动重开**（长期开放 issue 守护）`,
+                ``,
+                `本 issue 被 \`${actor}\` 的提交/合并自动关闭了（通常是某个 PR 正文写了 \`Closes #${number}\`）。`,
+                `它是**长期开放**的策展 issue，已由 \`.github/workflows/protect-pinned-issues.yml\` 自动重开。`,
+                ``,
+                `> 贡献者请注意：涉及本 issue 的 PR **不要写 \`Closes #${number}\`**——交付报告用 "Refs #${number}" 即可。`,
+                `> 维护者如需真正关闭（例如 #1550 收满 20 份试点报告），先把编号从 workflow 的 \`PROTECTED\` 列表移除。`,
+              ].join('\n'),
+            });
+            core.info(`Reopened protected issue #${number}`);


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 问题

GitHub 会在合并的 PR/提交写了 `Closes #N` 时自动关闭 issue —— 同一个坑已经踩了两次：

| 时间 | 关闭者 | 被关 issue |
|---|---|---|
| 2026-09-08 | PR #1554（正文 "Closes #1550"）| #1550（zero-bounty 试点征集，目标 20 份报告）|
| 2026-09-09 | #1560 的合并 | #1550 **再次被关** |
| 更早 | register.yml 注册流程 | #1258（onboarding 入口，body 写明 "always open"）|

维护者已两次手工重开（并 pin），但**靠人记着不是机制**。

## 方案

新增 `.github/workflows/protect-pinned-issues.yml`：

- 触发：`issues: closed`
- 若编号在 `PROTECTED`（当前 `1550,1258`）→ **自动 reopen** + 留一条说明评论（谁关的、为什么、以后用 `Refs #N` 而非 `Closes #N`）
- 真正想关闭时（如 #1550 收满 20 份报告）→ 先把编号从 `PROTECTED` 移除，注释里写明了这一点

## 验证

- YAML 解析通过；内嵌 JS 语法检查通过
- 合并后可用「手动关一次 #1550」验证自动重开（或等下一条误关）


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add workflow to auto-reopen protected long-running issues

- Guard against accidental `Closes #N` closures for #1550 and #1258

- Post explanatory comment guiding maintainers and contributors

- Maintainers remove number from `PROTECTED` to intentionally close


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue closed event"] --> B["In PROTECTED list?"]
  B -- "No" --> C["Ignore (log info)"]
  B -- "Yes" --> D{"Already open?"}
  D -- "Yes" --> C
  D -- "No" --> E["Reopen issue via API"]
  E --> F["Post explanatory comment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>protect-pinned-issues.yml</strong><dd><code>Auto-reopen guard for protected long-running issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/protect-pinned-issues.yml

<ul><li>New workflow triggered on <code>issues: closed</code> events with <code>issues: write</code> <br>permission<br> <li> <code>actions/github-script@v9</code> step parses <code>PROTECTED</code> env (<code>1550,1258</code>) and <br>checks issue number<br> <li> Calls <code>issues.update</code> to reopen protected issues and <br><code>issues.createComment</code> with bilingual guidance<br> <li> Encourages <code>Refs #N</code> over <code>Closes #N</code> for contributors</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1607/files#diff-f99ae32cf320f746e5e66ee312b0a2e2eceb38376877654a5411df8154212584">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

