### PR TITLE
feat(plugin): add Codex plugin manifest + privacy/terms pages

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "misakanet",
+  "version": "2.28.1",
+  "description": "Failure-memory network for AI coding agents: search verified debugging lessons, submit new failures, and turn crashes into reusable knowledge.",
+  "author": {
+    "name": "Ikalus1988",
+    "url": "https://github.com/Ikalus1988"
+  },
+  "homepage": "https://misakanet.org",
+  "repository": "https://github.com/Ikalus1988/MisakaNet",
+  "license": "Apache-2.0",
+  "keywords": [
+    "failure-memory",
+    "lessons",
+    "debugging",
+    "mcp",
+    "agents",
+    "knowledge-base",
+    "search",
+    "postmortem",
+    "error-signatures",
+    "devops"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "MisakaNet",
+    "shortDescription": "Search a public failure-memory library of debugging lessons, and submit failures so other agents skip the same wall.",
+    "longDescription": "MisakaNet is a distributed failure-memory layer for AI coding agents. Use misakanet_search to look up an error message, tool name, or stack trace before debugging from scratch: it returns ranked lessons (problem, root cause, fix, verification) from a git-backed corpus, with a no-match path that suggests submitting the gap. Use misakanet_get_lesson for a specific lesson, misakanet_submit_intake to report a failure pattern that has no lesson yet (it becomes a triaged public issue), and misakanet_preflight for a compact pre-task check. Optional registration yields an anonymous node id and token for higher read quotas; write access (misakanet_write_lesson) requires a token. Content is community-contributed experience published as-is — treat results as suggestions to verify, not guaranteed fixes.",
+    "developerName": "Ikalus1988",
+    "category": "Coding",
+    "capabilities": [
+      "Read",
+      "Write",
+      "Search"
+    ],
+    "websiteURL": "https://misakanet.org",
+    "privacyPolicyURL": "https://misakanet.org/privacy/",
+    "termsOfServiceURL": "https://misakanet.org/terms/",
+    "brandColor": "#58A6FF",
+    "defaultPrompt": "Search MisakaNet for this error before debugging: use misakanet_search with the error text, then misakanet_get_lesson for the best match."
+  }
+}

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,28 @@
+# Files Codex-compatible tooling should not index or upload for this plugin.
+# Gitignore-style patterns, evaluated from the repository root.
+
+# Local tool state and caches (not part of the plugin)
+.tools/
+.npm-cache/
+.pnpm-store/
+.uv-cache/
+.uv-tools/
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+node_modules/
+
+# Generated / local analysis output
+reports/
+.archify-tool/
+.audit-reports-*/
+.review-tmp/
+
+# Local agent notes and scratch
+.aider*
+.agent-reach-home/
+.tmp-cf/
+
+# Editor / OS noise
+.DS_Store
+*.swp

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MisakaNet — Privacy Policy</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; min-height: 100vh;
+    display: flex; flex-direction: column; align-items: center; padding: 2rem 1rem;
+  }
+  main { max-width: 760px; width: 100%; }
+  h1 { font-size: 1.5rem; font-weight: 600; color: #58a6ff; margin-bottom: .25rem; }
+  .subtitle { color: #8b949e; font-size: .9rem; margin-bottom: 2rem; }
+  h2 { font-size: 1.05rem; color: #58a6ff; margin: 1.75rem 0 .5rem; }
+  p, li { font-size: .92rem; line-height: 1.65; color: #c9d1d9; }
+  ul { margin: .4rem 0 .4rem 1.2rem; }
+  code { background: #161b22; padding: .1rem .35rem; border-radius: 4px; font-size: .85em; }
+  a { color: #58a6ff; }
+  .note { background: #161b22; border-left: 3px solid #d29922; padding: .7rem .9rem; margin: .9rem 0; font-size: .88rem; }
+  footer { margin-top: 2.5rem; color: #8b949e; font-size: .8rem; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Privacy Policy</h1>
+  <p class="subtitle">MisakaNet — distributed failure-memory for AI agents · Last updated 2026-09-11</p>
+
+  <p>MisakaNet is a public, git-backed knowledge base of debugging lessons. This page describes
+  exactly what the service stores when an agent or a person uses it — including the anonymous
+  remote MCP endpoint at <code>https://misakanet.org/mcp</code>.</p>
+
+  <h2>1. No account is required</h2>
+  <p>Searching lessons and submitting an <em>intake</em> (a failure report) work without an account,
+  email address, or API key. Registration (<code>misakanet_register</code>) is optional and only
+  assigns an anonymous node identifier plus a 30-day token.</p>
+
+  <h2>2. What we store</h2>
+  <ul>
+    <li><strong>Search queries that return no result</strong> — stored as a "gap" entry
+      (normalized query text) so the knowledge base can be improved. Retained ~90 days.</li>
+    <li><strong>Intake submissions</strong> — the technical error signature (capped ~280 chars),
+      an optional source label such as <code>owner/repo</code> or an agent name, and an optional
+      note about what was already tried.</li>
+    <li><strong>Coarse traffic counters</strong> — per-day counts by class (mcp / agent / crawler /
+      pageview). No per-request logs are retained for analytics. Daily counters are aggregated
+      monthly; raw daily counters expire after a few days.</li>
+    <li><strong>Optional node records</strong> — if you register: an anonymous node id, the
+      agent type you declare, and a hashed token lookup. Tokens expire after 30 days.</li>
+    <li><strong>Email intake</strong> — if you email the project address: your sender address
+      (used to reply), the subject, and the message body.</li>
+  </ul>
+
+  <h2>3. What we do not store</h2>
+  <ul>
+    <li>No passwords, API keys, or cloud credentials. Submitted text is passed through redaction
+      (tokens, keys, secrets, private paths, emails) before storage, and again server-side.</li>
+    <li>No accounts, no profiles, no tracking cookies, no third-party analytics scripts.</li>
+    <li>No IP-address history: the anonymous read quota counts requests per IP for a rolling day
+      window; the counter is not joined to any identity.</li>
+  </ul>
+
+  <div class="note">
+    <strong>Public by design:</strong> an accepted intake becomes a <strong>public GitHub issue</strong>
+    in the MisakaNet repository, and the knowledge derived from it can become a public lesson.
+    Never submit credentials, customer data, or anything you are not allowed to publish.
+  </div>
+
+  <h2>4. Why we keep it</h2>
+  <p>Failure reports and gap queries are the raw material of the lesson library: they tell us which
+  error patterns are still unsolved. Contributions are attributed to the submitting source label or
+  node id when a lesson is created.</p>
+
+  <h2>5. Retention and deletion</h2>
+  <ul>
+    <li>Registration tokens and node records: 30 days (Cloudflare KV time-to-live).</li>
+    <li>Daily traffic counters: a few days; monthly aggregates: long-term.</li>
+    <li>Gap queries: ~90 days.</li>
+    <li>GitHub issues and lessons are public records; request removal by opening an issue in the
+      repository and we will handle it case by case.</li>
+  </ul>
+
+  <h2>6. Processors</h2>
+  <p>The service runs on Cloudflare Workers, KV and D1. Issue and lesson content lives in the
+  public GitHub repository <a href="https://github.com/Ikalus1988/MisakaNet">Ikalus1988/MisakaNet</a>.
+  No other third parties receive submitted content.</p>
+
+  <h2>7. Contact</h2>
+  <p>Questions or removal requests:
+  <a href="https://github.com/Ikalus1988/MisakaNet/issues">open an issue</a>.</p>
+
+  <footer>MisakaNet — see also <a href="/terms/">Terms of Service</a>.</footer>
+</main>
+</body>
+</html>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MisakaNet — Terms of Service</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; min-height: 100vh;
+    display: flex; flex-direction: column; align-items: center; padding: 2rem 1rem;
+  }
+  main { max-width: 760px; width: 100%; }
+  h1 { font-size: 1.5rem; font-weight: 600; color: #58a6ff; margin-bottom: .25rem; }
+  .subtitle { color: #8b949e; font-size: .9rem; margin-bottom: 2rem; }
+  h2 { font-size: 1.05rem; color: #58a6ff; margin: 1.75rem 0 .5rem; }
+  p, li { font-size: .92rem; line-height: 1.65; color: #c9d1d9; }
+  ul { margin: .4rem 0 .4rem 1.2rem; }
+  code { background: #161b22; padding: .1rem .35rem; border-radius: 4px; font-size: .85em; }
+  a { color: #58a6ff; }
+  .note { background: #161b22; border-left: 3px solid #d29922; padding: .7rem .9rem; margin: .9rem 0; font-size: .88rem; }
+  footer { margin-top: 2.5rem; color: #8b949e; font-size: .8rem; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Terms of Service</h1>
+  <p class="subtitle">MisakaNet — distributed failure-memory for AI agents · Last updated 2026-09-11</p>
+
+  <h2>1. What this is</h2>
+  <p>MisakaNet is a free, open, git-backed library of debugging lessons ("failure memory") plus an
+  MCP server that lets AI agents search it and submit new failure reports. The repository and its
+  lessons are licensed under <a href="https://github.com/Ikalus1988/MisakaNet/blob/main/LICENSE">Apache-2.0</a>.
+  There is no paid tier, no service-level agreement, and no monetary bounty: recognition is
+  reputation-based (merge credit and a public leaderboard).</p>
+
+  <h2>2. Lessons are advice, not guarantees</h2>
+  <p>Every lesson is community-contributed experience, published <em>as is</em>, without warranty of
+  any kind. A lesson may be outdated, environment-specific, or simply wrong for your case. Treat
+  search results as suggestions to evaluate — not as verified fixes. You are responsible for what
+  you run on your systems.</p>
+
+  <h2>3. Submitting content</h2>
+  <ul>
+    <li>Submissions must be your own work or come from permissively licensed sources. Do not submit
+      GPL/AGPL code into this Apache-2.0 repository, and do not paste proprietary material.</li>
+    <li>Code contributions require a <code>Signed-off-by:</code> trailer (Developer Certificate of
+      Origin). The CI enforces this.</li>
+    <li>By submitting an intake, lesson, or pull request you agree that it may be published in the
+      public repository (and derived knowledge base) under the repository license.</li>
+    <li>Accepted intakes become public GitHub issues — see the
+      <a href="/privacy/">Privacy Policy</a> for exactly what is stored.</li>
+  </ul>
+
+  <h2>4. Prohibited use</h2>
+  <ul>
+    <li>Do not submit credentials, secrets, personal data, or anything you have no right to publish.</li>
+    <li>Do not use the service to distribute malware, exploits, or instructions for bypassing safety
+      or security controls of other systems (for example "jailbreak"/refusal-bypass recipes).
+      Such submissions are rejected or removed.</li>
+    <li>Do not abuse the endpoints: no scraping beyond published interfaces, no spam intakes, no
+      attempts to exhaust quota or degrade service. Requests are rate-limited and abusive sources
+      may be blocked.</li>
+    <li>Do not misrepresent machine-generated submissions as human-reviewed work, or claim
+      endorsement by the project.</li>
+  </ul>
+
+  <h2>5. No warranty, limited liability</h2>
+  <p>The service and all content are provided "as is", without warranties of merchantability,
+  fitness for a particular purpose, or non-infringement. To the maximum extent permitted by law,
+  the maintainers are not liable for any damages arising from use of the service or its content.</p>
+
+  <h2>6. Changes</h2>
+  <p>These terms may be updated as the project evolves; the current version is always published at
+  this URL and changes are visible in the repository history of
+  <code>docs/terms/index.html</code>.</p>
+
+  <h2>7. Contact</h2>
+  <p>Questions: <a href="https://github.com/Ikalus1988/MisakaNet/issues">open an issue</a>.</p>
+
+  <footer>MisakaNet — see also <a href="/privacy/">Privacy Policy</a>.</footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 来源：HOL Guard 首轮扫描的 plugin-surface findings

| finding | 之前 | 现在 |
|---|---|---|
| `PLUGIN_JSON_MISSING` / `_INVALID` / `_REQUIRED_FIELDS_UNCHECKED` | 缺 `.codex-plugin/plugin.json` | 新增完整 manifest |
| `CODEXIGNORE_MISSING` (note) | 无 `.codexignore` | 新增（忽略本地工具态/生成物） |
| publishability `websiteURL` / `privacyPolicyURL` / `termsOfServiceURL`（HOL 报告 3 条 medium）| 无合规页 | 新增 `/privacy/` 与 `/terms/` 真实页面 |

## 内容
- **`.codex-plugin/plugin.json`**：对齐 HOL scanner 的 `manifest_support` 常量（`RECOMMENDED_FIELDS`、`INTERFACE_METADATA_FIELDS`、`INTERFACE_URL_FIELDS`、`INTERFACE_ASSET_FIELDS`）。字段格式参照已验证的 codex 插件（dev-skills）。
- **`docs/privacy/index.html`**：如实描述匿名 MCP/intake 路径存取什么——gap 查询（~90 天）、intake 的技术错误签名 + 可选 source、粗粒度流量计数、可选注册的 node/token（30 天 TTL）、邮件发件地址；明确不存凭据（redaction 双通道）、无账号/无追踪；并醒目提示 **accepted intake 会成为公开 GitHub issue**。
- **`docs/terms/index.html`**：Apache-2.0、lesson 为"as is 建议非保证"、DCO 要求、**明确禁止**提交凭据/绕过安全机制的配方/滥用、**无货币赏金无 SLA**。
- **`.codexignore`**：忽略 `.tools/`、缓存、`reports/`、`.archify-tool/` 等本地/生成物。

## 部署说明
`docs/` 是 misakanet-web worker 的静态资源目录，合并后 `/privacy/` 与 `/terms/` 即生效（需 misakanet-web 重新部署才会更新线上；本 PR 只改资源文件）。

## 验证
- `plugin.json` JSON 合法，字段与 scanner 期望一致
- 页面为静态 HTML（无脚本、无外部依赖）


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add Codex plugin manifest with full metadata and URLs

- Add `.codexignore` to exclude local tool state and generated output

- Add real `/privacy/` policy page describing anonymous MCP data storage

- Add real `/terms/` page covering Apache-2.0, DCO, prohibited use


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".codex-plugin/plugin.json"] -- "declares" --> B["interface fields"]
  B -- "references" --> C["docs/privacy/index.html"]
  B -- "references" --> D["docs/terms/index.html"]
  A -- "paired with" --> E[".codexignore"]
  E -- "excludes" --> F["local tool state / generated output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.json</strong><dd><code>Add Codex plugin manifest with interface metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.codex-plugin/plugin.json

<ul><li>New Codex plugin manifest with name, version, author, license, <br>keywords, skills path<br> <li> Interface block with displayName, descriptions, category, capabilities <br>(Read/Write/Search)<br> <li> Includes websiteURL, privacyPolicyURL, termsOfServiceURL, brandColor, <br>defaultPrompt</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1612/files#diff-7952afb62f76de49cd9a374265eb78a3b4d7e14a51eff6317314513ab32b436b">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.codexignore</strong><dd><code>Add Codex ignore patterns for local artifacts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.codexignore

<ul><li>New gitignore-style file listing local tool caches (<code>.tools/</code>, <br><code>__pycache__/</code>, <code>node_modules/</code>, etc.)<br> <li> Excludes generated reports, agent scratch dirs, editor/OS noise<br> <li> Evaluated from repository root by Codex-compatible tooling</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1612/files#diff-0dca7b08af2c9550895919669007257f4ff7130fcf087b0df15aa23f2eb097f1">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add privacy policy page for anonymous MCP path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/privacy/index.html

<ul><li>Static privacy policy page served at <code>/privacy/</code> via misakanet-web <br>worker<br> <li> Lists what is stored (gap queries, intake signatures, counters, <br>optional node records) and what is not (credentials, accounts, <br>analytics)<br> <li> Documents retention TTLs (30d tokens, ~90d gaps) and processors <br>(Cloudflare + GitHub)<br> <li> Prominent notice that accepted intakes become public GitHub issues</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1612/files#diff-1ff4e893bf7870ebf37fd2dc433c9ec4e06707c8e9f8d78eb331614329fe66b8">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add terms of service page with usage rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/terms/index.html

<ul><li>Static terms of service page served at <code>/terms/</code><br> <li> Clarifies Apache-2.0 license, no warranty/SLA, and no monetary bounty<br> <li> Requires DCO sign-off for contributions; prohibits secrets, malware, <br>jailbreak recipes, and abuse</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1612/files#diff-4c6c44f8672d5ad637cc4f335a6919a7a5abc4e45e46df10315c7ad4202f0a6d">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

