### PR TITLE
fix: publish openclaw session_nodes lesson (#1600)

### DIFF
--- a/lessons/contrib/openclaw-session-row-entry-updatedat-mismatch.md
+++ b/lessons/contrib/openclaw-session-row-entry-updatedat-mismatch.md
@@ -1,5 +1,5 @@
 ---
-{"title": "OpenClaw 8.2 — session_nodes entry_valid stays 0 after manual sqlite edit", "domain": "openclaw", "tags": ["openclaw", "sqlite", "session_nodes", "canonical-key", "repair", "entry_valid"], "language": "en", "status": "draft", "evidence_level": "E2", "created": "2026-09-10", "updated": "2026-09-10", "source": "incident-2026-09-09", "provenance": {"source": "self", "contributor": "Community", "evidence": "locally reproduced + fixed + smoke-tested"}}
+{"title": "OpenClaw 8.2 — session_nodes entry_valid stays 0 after manual sqlite edit", "domain": "devops", "tags": ["openclaw", "sqlite", "session_nodes", "canonical-key", "repair", "entry_valid"], "language": "en", "status": "published", "evidence_level": "E2", "created": "2026-09-10", "updated": "2026-09-10", "source": "incident-2026-09-09", "provenance": {"source": "self", "contributor": "Community", "evidence": "locally reproduced + fixed + smoke-tested"}}
 ---
 # OpenClaw 8.2 — session_nodes entry_valid stays 0 after manual sqlite edit
 

--- a/lessons/index.md
+++ b/lessons/index.md
@@ -65,6 +65,7 @@
 - [MCP 标准化协议](contrib/lesson-17-segmentfault-mcp-standardization.md) | mcp | "mcp", "agent", "tool-calling" | segmentfault.com
 - [Model Switch Script Pattern — 多 Agent 模型管理](contrib/model-switch-script-pattern.md) | devops | "model-switching", "proxy", "config-management" | bootstrap
 - [Multi-Forum Scraping Architecture](contrib/multi-forum-scraping-architecture.md) | ops | "scraping", "playwright", "api", "forum" | practical-experience
+- [OpenClaw 8.2 — session_nodes entry_valid stays 0 after manual sqlite edit](contrib/openclaw-session-row-entry-updatedat-mismatch.md) | devops | "openclaw", "sqlite", "session_nodes", "canonical-key", "repair", "entry_valid" | incident-2026-09-09
 - [OpenClaw Gateway 动态模块缺失 — 飞书消息分发失败](contrib/openclaw-gateway-dynamic-module-missing.md) | feishu | "platform:wsl" | bootstrap
 - [OpenClaw 重装教训 — 删除前先停服务清残留](contrib/openclaw-reinstall-lesson.md) | devops | | bootstrap
 - [PR Welcome 未触发排查 — author_association NONE vs FIRST_TIMER 陷阱](core/pull-request-welcome-trigger-trap.md) | devops | "github-actions", "pull_request_target", "author_association", "first-time-contributor", "welcome", "debug" | 2026-06-13


### PR DESCRIPTION
## Summary

Publishes the draft lesson for OpenClaw 8.2 session_nodes.entry_valid stays 0 after manual sqlite edit (issue #1600).

## Changes

- lessons/contrib/openclaw-session-row-entry-updatedat-mismatch.md: domain openclaw → devops (openclaw is a tag, not a domain per repo convention), status draft → published
- lessons/index.md: added lesson entry in alphabetical order

## Verification

- [x] python scripts/lesson_gate.py passes
- [x] No secrets, internal URLs, or personal data in lesson content
- [x] Lesson has Problem → Root Cause → Solution → Verification structure
- [x] Commit signed off (DCO)

Closes #1600