### PR TITLE
fix(ci): leaderboard-watch 并发快照冲突（`|| true` 掩盖 → detached HEAD）

### DIFF
--- a/.github/workflows/leaderboard-watch.yml
+++ b/.github/workflows/leaderboard-watch.yml
@@ -9,6 +9,14 @@ permissions:
   contents: write
   issues: write
 
+# Two pushes within ~a minute start two runs that both commit the same generated
+# snapshot; rebasing one onto the other conflicts in data/leaderboard_meta.json.
+# Serialize instead of racing (cancel-in-progress: false so a queued run still runs
+# and picks up the newest main).
+concurrency:
+  group: leaderboard-watch
+  cancel-in-progress: false
+
 jobs:
   watch:
     runs-on: ubuntu-latest
@@ -30,13 +38,27 @@ jobs:
 
       - name: Commit updated leaderboard snapshot
         run: |
-          if [ -f data/leaderboard.json ]; then
-            git config user.name "misakanet-bot"
-            git config user.email "bot@misakanet.org"
-            # leaderboard_watch.py also writes leaderboard_meta.json; stage both
-            # so `git pull --rebase` never trips on unstaged changes.
-            git add data/leaderboard.json data/leaderboard_meta.json
-            git diff --cached --quiet || git commit -s -m "chore: update leaderboard snapshot [skip ci]"
-            git pull --rebase origin main || true
-            git push
+          if [ ! -f data/leaderboard.json ]; then
+            echo "no snapshot produced; nothing to commit"
+            exit 0
           fi
+          git config user.name "misakanet-bot"
+          git config user.email "bot@misakanet.org"
+          # leaderboard_watch.py also writes leaderboard_meta.json; stage both
+          # so `git pull --rebase` never trips on unstaged changes.
+          git add data/leaderboard.json data/leaderboard_meta.json
+          if git diff --cached --quiet; then
+            echo "snapshot unchanged; nothing to commit"
+            exit 0
+          fi
+          git commit -s -m "chore: update leaderboard snapshot [skip ci]"
+          # main can still move between checkout and push (other workflows, manual
+          # pushes). The snapshot is a generated artifact, so on conflict the freshly
+          # computed one wins: during a rebase, -X theirs means the commit being
+          # replayed, i.e. ours.
+          if ! git pull --rebase -X theirs origin main; then
+            echo "::error::rebase onto origin/main failed; leaving a clean tree"
+            git rebase --abort || true
+            exit 1
+          fi
+          git push


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 问题

`Leaderboard Watch` 在 **两次 push 间隔很近** 时必挂：

```
CONFLICT (content): Merge conflict in data/leaderboard_meta.json
error: could not apply ... chore: update leaderboard snapshot [skip ci]
fatal: You are not currently on a branch.
##[error]Process completed with exit code 128.
```

复现：run [34595461217](https://github.com/Ikalus1988/MisakaNet/actions/runs/34595461217/job/103250068868)（本地先推 AGENTS.md、再推 handoff，两个 run 重叠）。

## 根因

1. 触发条件是 `on: push: branches: [main]`。两次 push → 两个 run 并发，**各自算出一份快照并提交**同一个生成物 `data/leaderboard_meta.json`。
2. 后一个 run 的 `git pull --rebase origin main` 撞上前一个 run 的快照 → 内容冲突。
3. 脚本写的是 `git pull --rebase origin main || true`：**冲突失败被吞掉**，rebase 停在半途（detached HEAD），紧接着的 `git push` 就报 `You are not currently on a branch`。

也就是说：并发是诱因，`|| true` 是把"可恢复的冲突"变成"看不懂的硬失败"的放大器。

## 改动

- 加 `concurrency: {group: leaderboard-watch, cancel-in-progress: false}` —— 串行化；排队的 run 照跑且基于最新 main（不 cancel，避免丢快照）
- rebase 改 `-X theirs` —— 快照是**生成物**，冲突时以本次刚算出的为准（rebase 语境下 `theirs` = 正在重放的提交 = 我们的）
- 去掉 `|| true` —— 真失败时显式 `git rebase --abort` + 非零退出，不再把半途状态留给下一步
- 顺带：无快照 / 快照无变化时显式 `exit 0` 并打印原因（原来靠 `if` 包住整体，日志里看不出发生了什么）

## 验证

本地裸仓库双向复现：

| | 旧写法 | 新写法 |
|---|---|---|
| `git pull --rebase origin main` | CONFLICT，rebase in progress，detached HEAD | — |
| `git pull --rebase -X theirs origin main` | — | `Successfully rebased`，仍在 `main` |
| 文件最终内容 | 停在冲突态 | `{"rank":5,"ts":"OURS"}`（本次快照胜出，符合预期） |

`yaml.safe_load` 通过，脚本 `bash -n` 通过。

## 备注

同一天我另外发现站点其实是 **Cloudflare Workers Builds 自动部署**的（`docs/` 改动 push 即上线），
已在 #1614 里修掉 AGENTS.md / 运维手册里"必须手动 `wrangler deploy`"的过时说法——与本 PR 无关，仅说明背景。

Refs #1614


___

### **PR Type**
Bug fix


___

### **Description**
- Add `concurrency` block to serialize leaderboard-watch runs

- Replace `|| true` with explicit rebase error handling

- Use `-X theirs` rebase strategy for generated snapshot

- Split step into explicit no-snapshot / no-change early exits


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["push #1 to main"] --> B["run A: compute snapshot"]
  A2["push #2 to main"] --> C["run B: queued"]
  B --> D["commit snapshot"]
  D --> E["git pull --rebase -X theirs"]
  C --> F["run B starts after A"]
  F --> E
  E --> G["rebase succeeds, ours wins"]
  G --> H["git push"]
  H --> I["snapshot on main"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leaderboard-watch.yml</strong><dd><code>Serialize leaderboard-watch and harden rebase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/leaderboard-watch.yml

<ul><li>Added <code>concurrency: group=leaderboard-watch, cancel-in-progress=false</code> <br>to serialize overlapping runs<br> <li> Replaced <code>git pull --rebase origin main || true</code> with <code>git pull --rebase </code><br><code>-X theirs origin main</code> plus explicit <code>git rebase --abort</code> and <code>exit 1</code> on <br>failure<br> <li> Inverted the early-exit check so a missing <code>data/leaderboard.json</code> logs <br>and returns 0 cleanly<br> <li> Split the cached-diff guard into an explicit <code>exit 0</code> branch when the <br>snapshot is unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1625/files#diff-ae95e636c736259cd97689c1ef3f59907316881b6f8c0c88fc199e602e2356ff">+31/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

