### PR TITLE
lesson(contrib): push 触发的 bot workflow 自我竞争（`|| true` 掩盖 rebase 冲突 → detached HEAD）

### DIFF
--- a/lessons/contrib/ci-push-triggered-bot-races-generated-artifact.md
+++ b/lessons/contrib/ci-push-triggered-bot-races-generated-artifact.md
@@ -1,0 +1,151 @@
+---
+title: 'Push-triggered bot workflow races itself: `|| true` hides rebase conflict and leaves detached HEAD'
+domain: devops
+tags:
+  - github-actions
+  - concurrency
+  - rebase
+  - generated-artifacts
+  - race-condition
+  - git
+  - ci
+status: published
+created: '2026-09-11'
+updated: '2026-09-11'
+source: leaderboard-watch-detached-head-2026-09-11
+evidence_level: E1
+
+provenance:
+  source: "external"
+  contributor: "Ikalus1988"
+  merged_at: "2026-09-11"
+  evidence: "post-publication"
+---
+
+# Push-triggered bot workflow races itself: `|| true` hides rebase conflict and leaves detached HEAD
+
+## Problem
+
+A workflow that **runs on every push to main, generates a file, and commits it** fails
+intermittently — but only when two pushes land close together. The failing step's log ends with
+something like:
+
+```text
+CONFLICT (content): Merge conflict in data/leaderboard_meta.json
+error: could not apply 0dae5f4c... chore: update leaderboard snapshot [skip ci]
+hint: Resolve all conflicts manually, mark them as resolved with ...
+fatal: You are not currently on a branch.
+To push the history leading to the current (detached HEAD)
+state now, use
+
+    git push origin HEAD:<name-of-remote-branch>
+
+##[error]Process completed with exit code 128.
+```
+
+The message is misleading: the step *does* start on a branch, and the previous run of the same
+workflow succeeded. Nothing in the repository was edited by a human.
+
+## Root Cause
+
+Three ingredients, all of them individually reasonable:
+
+1. **Trigger shape.** `on: push: branches: [main]` starts one workflow run per push. Two pushes
+   a minute apart start **two concurrent runs**.
+2. **Both runs write the same generated artifact.** Each run computes the snapshot from its own
+   checkout and then commits it (`data/leaderboard_meta.json` here — any generated JSON/CSV behaves
+   the same). The first run pushes its commit; main has now moved.
+3. **The rebase is allowed to fail silently.** The step contained:
+
+   ```bash
+   git pull --rebase origin main || true
+   git push
+   ```
+
+   The second run's rebase now replays its snapshot commit on top of the *other* run's snapshot
+   commit. Both changed the same fields → content conflict. `|| true` swallows the non-zero exit,
+   and a conflicted rebase is **not** a no-op: git leaves the worktree in a rebase-in-progress state
+   with a **detached HEAD**. The next command, `git push`, therefore dies with
+   `fatal: You are not currently on a branch` (exit 128) — an error that points at the wrong thing.
+
+So the race is the trigger, but `|| true` is what converts a *resolvable* conflict into a *confusing*
+hard failure. A conflicted rebase must never be ignored: unlike a failed `git pull --ff-only`, it
+mutates repository state that later commands depend on.
+
+## Solution
+
+Three changes, in order of importance:
+
+**1. Stop swallowing the rebase failure.** Fail loudly and leave a clean tree:
+
+```bash
+if ! git pull --rebase -X theirs origin main; then
+  echo "::error::rebase onto origin/main failed; leaving a clean tree"
+  git rebase --abort || true
+  exit 1
+fi
+git push
+```
+
+**2. Serialize the runs** so the race mostly cannot happen:
+
+```yaml
+concurrency:
+  group: leaderboard-watch
+  cancel-in-progress: false
+```
+
+`cancel-in-progress: false` matters: cancelling the queued run would drop a snapshot; letting it run
+means it starts from the newest main.
+
+**3. Resolve artifact conflicts in favour of the fresh computation** with `-X theirs`. In a **rebase**,
+`theirs` is the commit being replayed — i.e. *your* freshly generated file — while `ours` is upstream.
+This is the opposite of the intuition people carry from merges, and it is exactly what you want for a
+generated artifact: the newest snapshot wins, upstream's unrelated changes are kept.
+
+Cheaper structural fixes worth considering instead, when applicable: commit the artifact only from a
+`scheduled` (cron) trigger where runs are naturally spaced, don't commit generated output at all, or
+have the workflow open a PR instead of pushing to main.
+
+## Verification
+
+A conflicted rebase is easy to reproduce in a scratch repo without touching CI — create a bare remote,
+push a "base", then simulate the two racing runs:
+
+```bash
+git init -q --bare remote.git && git clone -q remote.git work && cd work
+git config user.email t@t; git config user.name t
+mkdir -p data && printf '{"rank":1,"ts":"T0"}\n' > data/leaderboard_meta.json
+git add -A && git commit -qm base && git push -q -u origin HEAD:main
+
+# the other concurrent run lands on main first
+printf '{"rank":9,"ts":"OTHER"}\n' > data/leaderboard_meta.json
+git commit -qam "other run snapshot" && git push -q origin HEAD:main
+git reset -q --hard HEAD~1
+
+# our run computed its own snapshot, then commits and tries to push
+printf '{"rank":5,"ts":"OURS"}\n' > data/leaderboard_meta.json
+git commit -qam "update snapshot [skip ci]"
+
+git pull --rebase origin main            # -> CONFLICT, rebase in progress
+test -d .git/rebase-merge && echo "detached mid-rebase: yes"
+git rebase --abort
+
+git pull --rebase -X theirs origin main  # -> Successfully rebased
+cat data/leaderboard_meta.json           # -> {"rank":5,"ts":"OURS"}
+git symbolic-ref -q --short HEAD         # -> main  (still on a branch, push will work)
+```
+
+Observed on both branches of the experiment: the naive rebase stops mid-conflict with a detached
+HEAD, while `-X theirs` completes and keeps the freshly computed content. The production failure that
+motivated this was a real GitHub Actions run whose log contains all three signatures —
+`CONFLICT`, `could not apply`, and `fatal: You are not currently on a branch` — inside the *same*
+step.
+
+## Detection Heuristics
+
+- `fatal: You are not currently on a branch` almost always means **an earlier rebase in the same
+  step failed and was ignored** — look *up* the log for `CONFLICT` before touching the push command.
+- A bot-commit step that is green on isolated pushes and red on bursts of activity is a concurrency
+  bug, not a flaky network.
+- Any `git pull --rebase ... || true` in CI is a latent instance of this pattern; grep for it.


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 新课程（E1）

`lessons/contrib/ci-push-triggered-bot-races-generated-artifact.md`

### 为什么值得进语料

这是**今天真实发生**的失败：`Leaderboard Watch` 在两次 push 间隔很近时必挂，报
`fatal: You are not currently on a branch`——而这句话指向的位置（`git push`）不是根因所在。
根因是三件事叠加：

1. `on: push: branches: [main]` → 两次 push 起两个并发 run
2. 两个 run 各自提交**同一份生成物**（`data/leaderboard_meta.json`）
3. 脚本里的 `git pull --rebase origin main || true` 把冲突吞掉 → rebase 半途、**detached HEAD**
   → 紧接着的 `git push` 报 128

第 3 点是关键洞察：**rebase 失败不是幂等的**，它会留下后续命令依赖的仓库状态，
所以它和 `git pull --ff-only` 失败不能用同一个 `|| true` 处理。

### 课程内容

- 三要素根因 + 完整原始日志片段（含 `CONFLICT` / `could not apply` / `not currently on a branch`）
- 三步修法：显式失败（`git rebase --abort` + 非零）· `concurrency` 串行化 ·
  `-X theirs` 让生成物以本次为准，并点明 **rebase 里 theirs = 正在重放的提交（你的）**，
  与 merge 的直觉相反
- 结构性替代方案（改用 cron / 不提交生成物 / 改成开 PR）
- **可自己跑的本地复现**：裸仓库 + 两个"run"的脚本，输出 `{"rank":5,"ts":"OURS"}` 与
  `still on a branch`，无需碰 CI
- 判别启发式：看到 `not currently on a branch` 先往上看 `CONFLICT`；`git pull --rebase ... || true`
  一律视为潜在同型问题

### 本地门禁

```
$ python3 scripts/lesson_gate.py lessons/contrib/ci-push-triggered-bot-races-generated-artifact.md
OK: 1 file(s) passed the lesson quality gate.
$ python3 scripts/injection_scan.py lessons/contrib/ci-push-triggered-bot-races-generated-artifact.md
injection scan: 0 finding(s) — high=0 {}
```

实体案例 run [34595461217](https://github.com/Ikalus1988/MisakaNet/actions/runs/34595461217/job/103250068868)，
对应修复 #1625。

Refs #1625


___

### **PR Type**
Documentation


___

### **Description**
- Add E1 lesson documenting push-triggered bot workflow races

- Explain three-factor root cause and the `|| true` amplifier

- Document three-step fix with verification script

- Provide detection heuristics for similar CI failures


___

### Diagram Walkthrough


```mermaid
  flowchart TD
    P1["push #1"] --> RA["run A: compute snapshot"]
    P2["push #2"] --> RB["run B: queued"]
    RA --> CA["commit snapshot"]
    CA --> PA["push to main"]
    PA --> MR["main moved"]
    RB --> FR["run B starts"]
    MR --> FR
    FR --> CB["commit own snapshot"]
    CB --> RP["git pull --rebase || true"]
    RP --> CONF["CONFLICT: artifact"]
    CONF --> SWALLOW["|| true hides exit 1"]
    SWALLOW --> DH["detached HEAD, rebase in progress"]
    DH --> GP["git push → exit 128"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-push-triggered-bot-races-generated-artifact.md</strong><dd><code>Add lesson on push-triggered bot race condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lessons/contrib/ci-push-triggered-bot-races-generated-artifact.md

<ul><li>New E1 lesson documenting <code>on: push</code> bot workflow racing itself on a <br>generated artifact<br> <li> Details the three-factor root cause (trigger shape, shared artifact, <br>silent rebase failure with <code>|| true</code>)<br> <li> Provides three-step fix (explicit rebase failure, <code>concurrency</code> <br>serialization, <code>-X theirs</code> strategy) with bash snippet and YAML snippet<br> <li> Includes reproducible scratch-repo verification script and detection <br>heuristics</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1626/files#diff-1efaba8c3f3af5a0174bb095fee5db5cff37daa1e6b7493f956a50c135831509">+151/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

