### PR TITLE
fix(release): release-please 提交自带 sign-off，release PR 才能过 DCO

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "signoff": true,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## 问题

release PR [#1608](https://github.com/Ikalus1988/MisakaNet/pull/1608) 的 **DCO Check** 与 **audit**
一直是红的，失败的正是 release-please 自己生成的那个提交：

```
❌ Commit 4334ba7598b0a22f3dec35210f5005a6250da346 is missing Signed-off-by:
   chore(main): release 2.29.0
```

DCO 是本仓硬门禁 → **每一个 release PR 都必然红**，只能靠人工 `/fix-dco` 或手工 amend；
而 release-please 下次刷新分支时又会被它自己覆盖，问题会反复出现。

同样卡住的还有 PR 上 8 个 `action_required`（等待人工批准）的 run —— 那批已另行批准，
不是本 PR 的范围。

## 改动

```diff
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "signoff": true,
   "packages": {
```

`signoff` 是 release-please config 的**顶层**布尔项，已对照官方 schema
[`schemas/config.json`](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json)
的 `properties.signoff` 确认（不是猜的，也不是从文档里抄的位置）。

## 为什么不用"给 bot 开 DCO 白名单"

白名单会把"release 提交"这条路径**永久排除在溯源检查之外**；而 `signoff` 是让这条路径本身合规。
同样是机器动作，后者更诚实——签名由机器产生，但它确实声明了来源。

## 验证

- `release-please-config.json` JSON 解析通过，`signoff == true`
- 下次 release-please 运行后，其生成的 release 提交应带 `Signed-off-by:`，
  届时 DCO Check / audit 应转绿（合并后可观察下一个 release PR）

Refs #1608


___

### **PR Type**
Bug fix, configuration changes


___

### **Description**
- Add `"signoff": true` to `release-please-config.json`

- Fix DCO failures on every release PR (e.g. #1608)

- Replace manual `/fix-dco` workaround with config-level fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["release-please generates<br/>chore(main): release X.Y.Z"] --> B{"signoff in config?"}
  B -- "false (before)" --> C["❌ commit missing Signed-off-by<br/>DCO + audit fail every release"]
  B -- "true (this fix)" --> D["✅ commit carries Signed-off-by<br/>release PR merges cleanly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-please-config.json</strong><dd><code>Enable signoff in release-please config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-please-config.json

<ul><li>Add top-level <code>"signoff": true</code> so release-please signs its commits<br> <li> Aligns with official schema <code>properties.signoff</code> (verified, not guessed)<br> <li> Fixes DCO hard-gate failures on every release PR (#1608, recurring <br>after #1480)<br> <li> Removes the need for manual <code>/fix-dco</code> or amend workarounds</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1628/files#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

