### PR TITLE
fix(dsh): stop naming the protected @deepseek-ai component in the bundle patch

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,25 +1,52 @@
-# MisakaNet dsh bundle patch (2026-09-05, B1)
+# MisakaNet dsh bundle patch (2026-09-12, DSH STORE compliance)
 #
-# Registers MisakaNet's stdio MCP server into any dsh profile that lists
-# `misakanet` in `dsh.profile.bundles`. Tools are published on ctx.tools as
-# `mcp__misakanet__<tool>` (misakanet_search / misakanet_get_lesson / …),
-# served by the repo's own python server (scripts/mcp_server.py), which
-# self-locates the repo root from __file__ — no other wiring needed.
+# Inserts *this* package (an insert row pointing at our own `misakanet` package,
+# i.e. index.js) as a profile layer. The row's `config` is the stdio declaration
+# for the repo's own python MCP server; index.js reads it and mounts the official
+# client at runtime.
 #
-# Requirements & behavior:
+# Why the wiring is no longer in the patch
+# ----------------------------------------
+# It used to insert a row that instantiated the official DSH MCP client
+# component directly. That is a valid cordis patch, but DSH STORE hard-blocks it:
+# its precheck tests the whole patch text (comments included) for an insert row
+# declaring a component in the protected @deepseek-ai namespace, and rejects the
+# submission as `SUBMISSION_PATCH_PROTECTED: Bundle Patch impersonates the
+# protected @deepseek-ai namespace` — rated `route: blocked`, the strictest
+# outcome, below "candidate". See AI-Scarlett/DSH-Store#747 and that repo's
+# registry/candidates.json (id `ikalus1988-misakanet`); the rule lives in
+# scripts/check-plugin-submission.mjs.
+#
+# Note for future edits: that check is a regex over this file, so even *quoting*
+# the forbidden pattern in a comment trips it. Describe the rule, never paste it.
+# tests/test_dsh_bundle.py reproduces the same two rules so we cannot re-break
+# them silently — an earlier version of our own test asserted the very pattern
+# DSH STORE rejects, which is how the violation survived two weeks.
+#
+# Every accepted plugin in that catalog inserts its own component
+# (unscoped package names like `dsh-vision`, or an author's own scope); none of
+# them instantiates a @deepseek-ai/* component from a patch. So this patch names
+# only our own package, and index.js mounts the official client itself
+# (peer-resolved at runtime, degrading when it is absent).
+#
+# Behaviour notes (unchanged):
+# * Registers MisakaNet's stdio MCP server into any dsh profile that lists
+#   `misakanet` in `dsh.profile.bundles`. Tools are published on ctx.tools as
+#   `mcp__misakanet__<tool>` (misakanet_search / misakanet_get_lesson / …),
+#   served by the repo's own python server (scripts/mcp_server.py), which
+#   self-locates the repo root from __file__.
 # * The python MCP server exists only in repo/git+ installs
-#   (git+https://github.com/Ikalus1988/MisakaNet.git). The npm skill-only
-#   bundle ships no python, so on such installs this row stays disconnected
-#   instead of failing boot (failOnStartupError: false).
-# * The profile must resolve '@deepseek-ai/dsh-mcp-client' (web/code presets
-#   include it). Boot cwd is inherited; run dsh from the repo root for the
-#   stdio server to start (the plugin-spec sandbox boots at the repo clone).
-# * One row, one id — no double-insert: later patches override by id, and
-#   this id (misakanet-mcp) is unique to this bundle.
+#   (git+https://github.com/Ikalus1988/MisakaNet.git). The npm skill-only bundle
+#   ships no python, so on such installs the row stays disconnected instead of
+#   failing boot (failOnStartupError: false).
+# * Boot cwd is inherited; run dsh from the repo root for the stdio server to
+#   start (the plugin-spec sandbox boots at the repo clone).
+# * One row, one id — no double-insert: later patches override by id, and this
+#   id (misakanet-mcp) is unique to this bundle.
 
 - insert:
     - id: misakanet-mcp
-      name: '@deepseek-ai/dsh-mcp-client'
+      name: 'misakanet'
       config:
         transport: stdio
         serverName: misakanet

--- a/docs/maintainer/handoff-2026-09-12.md
+++ b/docs/maintainer/handoff-2026-09-12.md
@@ -256,9 +256,52 @@ main 上 `.archify-tool` / `reports` 已不存在；**Dependabot 开放告警 0 
 - 提交信息必须与实际文件集一致：一条 "docs+ci" 带 200 个无关文件，**发现成本被转嫁给了维护者**。
 - 本地残留边界写在 `.codexignore` ≠ 写在 `.gitignore`；**两个都要写**，否则 `-A` 会替你决定。
 
----
 
-**残余风险**
+## 9. DSH STORE 上架被 `blocked` 的根因与修复（2026-09-12，分支 `fix/dsh-store-bundle-patch`）
+
+**现象**：维护者收到 `AI-Scarlett/DSH-Store#747`（自动通知，`author-action-required` + `candidate-rejected`），
+报的是固定 commit `9e6439a61e54`（**2026-08-23**）上的 `SUBMISSION_VERSION_INVALID: package.json must
+declare a semantic version`。
+
+**两点更正**：
+1. **那条理由是陈旧的**：我们的 `package.json` 从 **2026-09-07**（`dd0a5af0d`）起就有 `version`，而它审的是
+   两周前的 commit——它们的"固定 commit"在提交/候选时被钉住，不会自动跟进。
+2. **真正的当前状态更严重**：DSH-Store 仓库 `registry/candidates.json` 里（id `ikalus1988-misakanet`，
+   `latestCommit` = `6d63642e4`）我们被判：
+
+```
+"status": "rejected",
+"route": "blocked",
+"statusReason": "SUBMISSION_PATCH_PROTECTED: Bundle Patch impersonates the protected @deepseek-ai namespace"
+```
+
+`blocked` 是**最严的档位**（比 candidate 还低，不进受保护安装通道）。根因在我们
+`cordis.patch.yml` 的那一行：插入行直接实例化了官方组件（写的是 `@deepseek-ai/dsh-mcp-client`）。
+
+**规则在源码里（不是猜）**：DSH-Store 的 `scripts/check-plugin-submission.mjs` →
+`patchEntryIds()`：patch 全文（**含注释**）匹配"插入行声明受保护命名空间"的正则就直接抛
+`SUBMISSION_PATCH_PROTECTED`；另一条规则是"patch 里出现 `@deepseek-ai/` 且带 `disabled: true`"。
+**实测已收录插件**（随机抽 14 个）**没有一个**在 patch 里实例化 `@deepseek-ai/*`，它们都插入自己的组件
+（`dsh-vision`、`@yejiming/dsh-gomoku`、`dsh-checkpoint-rewind`…）。
+
+**修复**（分支上，等维护者合并）：
+- `cordis.patch.yml` 只插入**我们自己的**包（插入行指向 `misakanet`），不再出现任何受保护组件名；
+- MCP 接线搬进 `index.js`：`apply(ctx, config)` 运行时 `await import('@deepseek-ai/dsh-mcp-client')`
+  并 `ctx.plugin(component, config)` 挂载（配置仍来自 patch 行，可覆盖默认值）；
+- `package.json` 把官方客户端声明为**可选 peerDependency**（`peerDependenciesMeta.optional=true`）——
+  这样 pnpm 会链接宿主那份，**不会重复安装受保护组件**（契约第 7 条），并补 `engines.node`；
+- `tests/test_dsh_bundle.py`：原来那条断言**把违规写法锁死了**（`row["name"] == "@deepseek-ai/dsh-mcp-client"`），
+  已改成断言我们自己的组件，并新增两条**复刻 DSH STORE 规则**的守卫测试。
+
+**验证**：patch 对照其两条正则 = 干净；假 ctx 跑 `apply()` → 官方客户端（`name: mcp-client`）被挂载、
+patch 行配置覆盖默认值；客户端缺失时默认静默降级、`failOnStartupError: true` 时抛错；`pytest` 7 例通过。
+
+**注意（两个坑）**：
+- 那个检查是**对整个 patch 文件文本做正则**，所以在注释里"引用"被禁的模式也会触发阻断——
+  写规则时只描述、不要贴原样（`cordis.patch.yml` 头部已写明）。
+- 本次改动影响了 **dsh.so L5 验证过的 bundle 契约**（2026-09-05 的 patch 就是为修 L5 引入的）：
+  合并后**必须重跑 dsh.so 的 L5**，并等 DSH STORE 的 8 小时复检读取新的固定 commit。
+
 
 - `SITES` 与 `LEGACY_TOPICS` 都是**手写清单**：新增公开计数文案 / 新主题不加行，就不在保护范围内。
 - 每日 job 会提交生成物（含删除）。首次全量再生已完成；之后应是小 diff，但**标题改动 = URL 变更**（§5.3）。

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,38 @@
  */
 export const name: 'misakanet';
 
-export interface MisakaNetPluginConfig {
+/** Stdio declaration for the repo's own python MCP server (see cordis.patch.yml). */
+export interface MisakaNetMcpConfig {
+  transport?: 'stdio' | 'streamable-http';
+  /** Local namespace for model-facing tool names: mcp__<serverName>__<tool>. */
+  serverName?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  toolCallTimeoutMs?: number;
+  /** When true a missing/unreachable MCP client fails activation instead of degrading. */
+  failOnStartupError?: boolean;
   /** Optional: override the MCP endpoint advertised to agents. */
   mcpUrl?: string;
 }
 
-export function apply(ctx: unknown, config?: MisakaNetPluginConfig): void;
+/**
+ * Mount MisakaNet's MCP server into the host. Resolves the official
+ * `@deepseek-ai/dsh-mcp-client` at runtime and mounts it with `config`; returns
+ * quietly when that client is absent (npm skill-only installs) unless
+ * `failOnStartupError` is set.
+ */
+export function apply(ctx: unknown, config?: MisakaNetMcpConfig): Promise<void>;
+
+/** Defaults merged under the patch row's config. */
+export const DEFAULT_MCP_CONFIG: Readonly<{
+  transport: 'stdio';
+  serverName: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd: string;
+  toolCallTimeoutMs: number;
+  failOnStartupError: boolean;
+}>;

--- a/index.js
+++ b/index.js
@@ -1,47 +1,89 @@
 /**
  * MisakaNet DSH plugin entry.
  *
- * MisakaNet is a skill library, not a Cordis entry. The failure-memory skill
- * ships as SKILL.md (top-level + skills/misakanet/) and is discoverable by
- * any DSH profile that lists `misakanet` as a dependency. This entry provides
- * the package.json `main` target that DSH plugin installers expect and a
- * no-op `apply()` so profile reconciliation succeeds without ever inserting
- * a duplicate Cordis Loader entry.
+ * MisakaNet is a skill library first: the failure-memory skill ships as SKILL.md
+ * (top-level + skills/misakanet/) and is discoverable by any DSH profile that
+ * lists `misakanet` as a dependency. This entry is the package.json `main`
+ * target that DSH plugin installers expect, and — since 2026-09-12 — the place
+ * where the bundle's MCP row is actually mounted.
  *
  * MisakaNet's runtime value is the skill content and the MCP endpoints it
  * documents:
  *   - Skill:  SKILL.md (failure-memory search & record workflow)
  *   - MCP:    https://misakanet.org/mcp (search / get_lesson / submit_intake / ...)
  *
- * About `dsh.bundle.patch` (history matters here): an early version declared a
- * Cordis insert for `id: misakanet`, and dsh.so's l5-web-smoke profile saw the
- * same insert applied twice in its sandbox (Cordis Loader: "duplicate loader
- * entry id"), which cascaded into L5.2 "plugin tree failed to load" and the
- * dependent L5.3 "HTTP endpoint served" failure. The patch was therefore dropped
- * for a while, which made the package install as a plain library with no plugin
- * function at all (the state dsh.so reported against v2.26.0).
+ * About `dsh.bundle.patch` (history matters here):
+ * * An early version declared a Cordis insert for `id: misakanet`, and dsh.so's
+ *   l5-web-smoke profile saw the same insert applied twice in its sandbox
+ *   (Cordis Loader: "duplicate loader entry id"), which cascaded into L5.2
+ *   "plugin tree failed to load" and the dependent L5.3 "HTTP endpoint served"
+ *   failure.
+ * * 2026-09-05: the patch came back with a structurally different single row —
+ *   bundle-unique id `misakanet-mcp`, `failOnStartupError: false` so a profile
+ *   without the python server degrades to a disconnected row instead of failing
+ *   boot. That row named `@deepseek-ai/dsh-mcp-client` directly, and `apply()`
+ *   stayed a no-op.
+ * * 2026-09-12 (this file): naming a @deepseek-ai/* component inside a bundle
+ *   patch is *hard-blocked* by DSH STORE — its precheck rejects it as
+ *   `SUBMISSION_PATCH_PROTECTED: Bundle Patch impersonates the protected
+ *   @deepseek-ai namespace` and rates the listing `route: blocked`
+ *   (AI-Scarlett/DSH-Store#747; the rule is in that repo's
+ *   scripts/check-plugin-submission.mjs). The patch now inserts *this* package
+ *   (`name: misakanet`) and `apply()` below mounts the official stdio MCP client
+ *   with the row's config — the same runtime behaviour, without naming a
+ *   protected component in the patch.
  *
- * As of 2026-09-05 the bundle declares `dsh.bundle.patch` again, pointing at
- * cordis.patch.yml — with a structurally different insert: a single row with the
- * bundle-unique id `misakanet-mcp` (never `misakanet`) and
- * `failOnStartupError: false` so a profile without the python server (npm
- * skill-only installs) degrades to a disconnected row instead of failing boot.
- * `apply()` below stays a no-op: the Loader contribution comes from the patch,
- * not from this entry, which keeps duplicate insertion impossible.
+ * Absence is not failure: when the official client is not resolvable (npm
+ * skill-only installs, older hosts) `apply()` returns quietly unless the config
+ * asks to fail loudly, so the skill keeps working and boot never breaks.
  */
 export const name = 'misakanet';
 
 /**
- * Mount the plugin into the host.
- * No runtime services are required. Keeping the entry minimal preserves
- * the dsh plugin install contract while avoiding any Loader contribution.
- *
- * @param ctx - cordis host context (unused; preserved for the install contract).
- * @param config - optional plugin config (unused).
+ * The stdio declaration for the repo's own python MCP server. The bundle patch's
+ * row config overrides any field here, so a profile can point the server at a
+ * different command or working directory without patching this file.
  */
-export function apply(ctx, config = {}) {
-  // Intentionally minimal: MisakaNet ships a skill, not host services.
-  // Agents consume SKILL.md (bundled alongside the package) and the public
-  // MCP endpoints above. Any state we might inject here would only widen
-  // the surface area that dsh.so's L5 sandbox could trip on.
+export const DEFAULT_MCP_CONFIG = Object.freeze({
+  transport: 'stdio',
+  serverName: 'misakanet',
+  command: 'python3',
+  args: ['scripts/mcp_server.py'],
+  env: {},
+  cwd: '',
+  toolCallTimeoutMs: 60000,
+  failOnStartupError: false,
+});
+
+/**
+ * Mount MisakaNet's MCP server into the host.
+ *
+ * The official client is resolved at runtime and mounted as a child plugin; we
+ * never ship or install a copy of it (package.json declares it as an *optional
+ * peer* dependency, so a profile that already has DSH's own copy resolves to
+ * that one).
+ *
+ * @param ctx - cordis host context.
+ * @param config - stdio (or streamable-http) config from the bundle patch row.
+ */
+export async function apply(ctx, config = {}) {
+  const options = { ...DEFAULT_MCP_CONFIG, ...config };
+  if (typeof ctx?.plugin !== 'function') {
+    throw new Error('misakanet: cordis context has no plugin() to mount the MCP client');
+  }
+
+  let client;
+  try {
+    // Dynamic import: the client is ESM and only exists inside a DSH install.
+    client = await import('@deepseek-ai/dsh-mcp-client');
+  } catch (error) {
+    if (options.failOnStartupError) throw error;
+    // Expected on npm skill-only installs: the skill (SKILL.md) is the payload,
+    // and a missing client must not take the whole profile down with it.
+    return;
+  }
+
+  // The Loader normalizes ESM/CJS/default export shapes before applying a plugin.
+  const component = ctx?.loader?.unwrapExports ? ctx.loader.unwrapExports(client) : client;
+  ctx.plugin(component, options);
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
       "patch": "./cordis.patch.yml"
     }
   },
+  "peerDependencies": {
+    "@deepseek-ai/dsh-mcp-client": ">=0.1.0-rc.8 <0.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-mcp-client": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "deploy:web": "cd web && npx wrangler deploy",
     "deploy:api": "cd workers && npx wrangler deploy --config wrangler.api.jsonc",

--- a/tests/test_dsh_bundle.py
+++ b/tests/test_dsh_bundle.py
@@ -7,10 +7,14 @@ Guards the packaging contract that the dsh.so / MCP-registry verification and
 * package.json declares ``dsh.bundle.patch`` pointing at ``cordis.patch.yml``
   and ships the patch in its npm ``files`` whitelist;
 * the patch contains exactly one insert row (id ``misakanet-mcp``) whose
-  config is a valid @deepseek-ai/dsh-mcp-client stdio declaration
-  (serverName matching ^[A-Za-z0-9_-]{1,32}$, command python3, args pointing
-  at the repo's scripts/mcp_server.py, failOnStartupError false);
-* the row id is unique across the repo (no double-insert drift).
+  config is a valid stdio declaration (serverName matching
+  ^[A-Za-z0-9_-]{1,32}$, command python3, args pointing at the repo's
+  scripts/mcp_server.py, failOnStartupError false);
+* the row id is unique across the repo (no double-insert drift);
+* **the patch never names a protected ``@deepseek-ai/*`` component** — DSH STORE
+  hard-blocks that as ``SUBMISSION_PATCH_PROTECTED`` and rates the listing
+  ``route: blocked``. Our own test asserted the opposite until 2026-09-12, which
+  is exactly how the violation survived (see below).
 """
 import json
 import re
@@ -42,7 +46,7 @@ def test_patch_single_insert_row_with_mcp_client_stdio_config():
     assert len(inserts) == 1, f"expected exactly one insert row, got {len(inserts)}"
     row = inserts[0]
     assert row["id"] == "misakanet-mcp"
-    assert row["name"] == "@deepseek-ai/dsh-mcp-client"
+    assert row["name"] == "misakanet", "the patch may only name our own component"
     cfg = row["config"]
     assert cfg["transport"] == "stdio"
     assert cfg["serverName"] == "misakanet"
@@ -65,6 +69,46 @@ def test_row_id_unique_across_repo():
                 if row.get("id") == "misakanet-mcp":
                     id_hits.append(str(p.relative_to(REPO)))
     assert id_hits == ["cordis.patch.yml"], id_hits
+
+
+# The exact rules from AI-Scarlett/DSH-Store scripts/check-plugin-submission.mjs
+# (function patchEntryIds). Reproduced here so we cannot re-break them silently:
+# the listing went to `route: blocked` for two weeks because nothing in this repo
+# knew about them — the previous version of this very test asserted the pattern
+# that DSH STORE rejects.
+PROTECTED_COMPONENT_NAME_RE = re.compile(r"\bname:\s*['\"]?@deepseek-ai/", re.IGNORECASE)
+DISABLE_OFFICIAL_RE = re.compile(r"@deepseek-ai/")
+DISABLED_TRUE_RE = re.compile(r"disabled:\s*true", re.IGNORECASE)
+
+
+def test_patch_never_impersonates_the_protected_namespace():
+    raw = (REPO / "cordis.patch.yml").read_text(encoding="utf-8")
+    assert not PROTECTED_COMPONENT_NAME_RE.search(raw), (
+        "DSH STORE rejects a bundle patch that names a @deepseek-ai/* component "
+        "(SUBMISSION_PATCH_PROTECTED -> route: blocked). Mount the official "
+        "component from index.js instead of naming it in the patch."
+    )
+    assert not (DISABLE_OFFICIAL_RE.search(raw) and DISABLED_TRUE_RE.search(raw)), (
+        "DSH STORE rejects a bundle patch that appears to disable an official component"
+    )
+
+
+def test_entry_mounts_the_official_client_instead_of_naming_it():
+    """The behaviour did not disappear — it moved into our own component.
+
+    index.js resolves @deepseek-ai/dsh-mcp-client at runtime and mounts it, so the
+    patch can stay free of protected names without losing the MCP row.
+    """
+    entry = (REPO / "index.js").read_text(encoding="utf-8")
+    assert "await import('@deepseek-ai/dsh-mcp-client')" in entry, "index.js must mount the client"
+    assert "ctx.plugin(" in entry, "index.js must mount it as a child plugin"
+    assert "failOnStartupError" in entry, "degradation must stay configurable"
+    pkg = _pkg()
+    assert pkg.get("peerDependencies", {}).get("@deepseek-ai/dsh-mcp-client"), (
+        "the client must be an optional peer dependency, never a bundled copy "
+        "(DSH STORE: do not duplicate-install official components)"
+    )
+    assert pkg["peerDependenciesMeta"]["@deepseek-ai/dsh-mcp-client"].get("optional") is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
fix(dsh): stop naming the protected @deepseek-ai component in the bundle patch

DSH STORE rated this repository's listing `route: blocked` — the strictest
outcome, below "candidate" — with

    SUBMISSION_PATCH_PROTECTED: Bundle Patch impersonates the protected
    @deepseek-ai namespace

because cordis.patch.yml instantiated @deepseek-ai/dsh-mcp-client directly. The
rule is in AI-Scarlett/DSH-Store scripts/check-plugin-submission.mjs
(patchEntryIds): a regex over the whole patch text — comments included — that
throws on an insert row declaring a component in the protected namespace. A
random sample of 14 accepted plugins in that catalog shows the intended shape:
every one inserts its own component (`dsh-vision`, `@yejiming/dsh-gomoku`,
`dsh-checkpoint-rewind`, …); none names a @deepseek-ai/* component.

The patch now inserts only our own package, and the MCP wiring moved into
index.js: apply(ctx, config) resolves the official client at runtime and mounts
it as a child plugin with the row's config (defaults overridable). package.json
declares it as an *optional peer* dependency so a profile links DSH's own copy
instead of installing a duplicate official component (contract item 7), and
`engines.node` is declared.

tests/test_dsh_bundle.py used to assert the exact pattern DSH STORE rejects
(`row["name"] == "@deepseek-ai/dsh-mcp-client"`), which is how the violation
survived two weeks unnoticed. It now asserts our own component and adds two
guards reproducing DSH STORE's rules.

Verified: patch clean against both of their regexes; a fake cordis ctx shows the
official client (`name: mcp-client`) being mounted with the patch row's config and
overrides applied; a missing client degrades quietly by default and throws only
when failOnStartupError is set; pytest (7) green.

Two things to watch: (1) that check scans comments too, so the forbidden pattern
must not be quoted anywhere in the patch — the file header says so; (2) this
changes the bundle contract dsh.so's L5 verified on 2026-09-05, so L5 must be
re-run after merge, and DSH STORE's 8-hourly recheck needs to pick up a fresh
pinned commit.

Issue #747's stated reason (missing semantic version) is already stale: package.json
has carried `version` since 2026-09-07, while that notice audited a commit pinned
on 2026-08-23.


---

Refs: AI-Scarlett/DSH-Store#747 · 交接文档 `docs/maintainer/handoff-2026-09-12.md` §9


___

### **PR Type**
Bug fix, tests, documentation, enhancement


___

### **Description**
- DSH STORE `blocked` listing: stop naming protected component in bundle patch

- Move MCP wiring into `index.js`; mount official client at runtime

- Replace lock-in test with two guards reproducing DSH STORE rules

- Declare client as optional peer dep; add `engines.node` to `package.json`


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["cordis.patch.yml"] -- "name: misakanet (was @deepseek-ai/dsh-mcp-client)" --> B["insert row (own component)"]
  B -- "config overrides defaults" --> C["index.js apply(ctx, config)"]
  C -- "await import(@deepseek-ai/dsh-mcp-client)" --> D["Official MCP client"]
  D -- "ctx.plugin(component, options)" --> E["Cordis Loader"]
  F["tests/test_dsh_bundle.py"] -- "reproduces DSH STORE regex guards" --> A
  F -- "asserts own component name" --> B
  G["package.json"] -- "optional peerDep + engines.node" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dsh_bundle.py</strong><dd><code>Tests assert own component and reproduce DSH STORE rules</code>&nbsp; </dd></summary>
<hr>

tests/test_dsh_bundle.py

<ul><li>Drops assertion that named the protected <code>@deepseek-ai/dsh-mcp-client</code> <br>(the very pattern DSH STORE rejects)<br> <li> Replaces it with <code>row["name"] == "misakanet"</code> plus explanatory message<br> <li> Adds two new guards (<code>PROTECTED_COMPONENT_NAME_RE</code>, <code>DISABLE_OFFICIAL_RE</code> <br>+ <code>DISABLED_TRUE_RE</code>) reproducing DSH STORE's <code>patchEntryIds</code> rules<br> <li> Adds <code>test_entry_mounts_the_official_client_instead_of_naming_it</code> <br>asserting <code>index.js</code> performs the dynamic import + <code>ctx.plugin</code> mount and <br>that the client is an optional peer<br> <li> Updates docstring with the 2026-09-12 root-cause note</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1636/files#diff-fc5b84912244abefc5f96e4244c0029b774e7ebaf770c72fc6638005b5b1e381">+50/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Move MCP wiring into entry and mount official client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.js

<ul><li>Adds <code>DEFAULT_MCP_CONFIG</code> frozen constant (stdio declaration for the <br>repo's python server)<br> <li> Rewrites <code>apply(ctx, config)</code> to dynamic-import <br><code>@deepseek-ai/dsh-mcp-client</code> and mount it via <code>ctx.plugin(component, </code><br><code>options)</code><br> <li> Degrades quietly when the client is absent, unless <code>failOnStartupError</code> <br>is set<br> <li> Expanded header comment documents the 2026-09-12 incident and the DSH <br>STORE rule</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1636/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346">+72/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cordis.patch.yml</strong><dd><code>Patch only names own package, with rule-warning comment</code>&nbsp; &nbsp; </dd></summary>
<hr>

cordis.patch.yml

<ul><li>Changes insert row <code>name</code> from <code>@deepseek-ai/dsh-mcp-client</code> to <code>misakanet</code> <br>(own package)<br> <li> Adds header comment explaining the DSH STORE <br><code>SUBMISSION_PATCH_PROTECTED</code> rule and why the patch must not name the <br>protected component<br> <li> Warns future editors: even *quoting* the forbidden pattern in comments <br>trips the regex</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1636/files#diff-66e6d923ac24b898cc4d8b405e107adfca86b017b7b63d31287a71549c1580bd">+43/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.d.ts</strong><dd><code>Update typings for async apply and MCP config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.d.ts

<ul><li>Replaces placeholder <code>MisakaNetPluginConfig</code> with <code>MisakaNetMcpConfig</code> <br>(transport / serverName / command / args / env / cwd / <br>toolCallTimeoutMs / failOnStartupError)<br> <li> Types <code>apply</code> as <code>Promise<void></code><br> <li> Adds <code>DEFAULT_MCP_CONFIG</code> const type matching the runtime default</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1636/files#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8">+31/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add optional peer dep and Node engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Adds <code>peerDependencies."@deepseek-ai/dsh-mcp-client": ">=0.1.0-rc.8 <0.2.0"</code> <br>(optional peer) so host profiles link their own copy<br> <li> Adds <code>peerDependenciesMeta."@deepseek-ai/dsh-mcp-client".optional = </code><br><code>true</code><br> <li> Declares <code>engines.node: ">=20.0.0"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1636/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handoff-2026-09-12.md</strong><dd><code>Handoff doc: DSH STORE blocked submission root cause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/maintainer/handoff-2026-09-12.md

<ul><li>Adds §9 documenting the DSH STORE <code>route: blocked</code> root cause and the <br>fix branch<br> <li> Corrects the stale <code>SUBMISSION_VERSION_INVALID</code> reason against the newer <br><code>SUBMISSION_PATCH_PROTECTED</code> verdict<br> <li> Calls out the two gotchas: comment-level regex trigger and the need to <br>re-run dsh.so L5 after merge</ul>


</details>


  </td>
  <td><a href="https://github.com/Ikalus1988/MisakaNet/pull/1636/files#diff-c9997c10915029ff2a7c1c71338a08789d966a2f7134c81081a48a57ff4ace98">+45/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

