### PR TITLE
Windows voice hook verification

### DIFF
--- a/docs/integrations/mcp-voice-hooks.md
+++ b/docs/integrations/mcp-voice-hooks.md
@@ -50,8 +50,37 @@ Located at `docs/assets/voice/`:
 
 - macOS: `afplay` (built-in)
 - Linux: `aplay` or `paplay` (ALSA/PulseAudio)
+- Windows: Windows Media Player (included with standard Windows installations)
 - Python 3 (for JSON parsing in hook)
+
+## Windows setup and verification
+
+Use either native Windows hook in Claude Code settings:
+
+```json
+"command": "powershell -File C:\\path\\to\\MisakaNet\\scripts\\misakanet_voice_hook.ps1"
+```
+
+or the batch wrapper:
+
+```json
+"command": "C:\\path\\to\\MisakaNet\\scripts\\misakanet_voice_hook.bat"
+```
+
+The Bash hook also detects Git Bash, MSYS2, Cygwin, and WSL, converts the MP3
+path when necessary, and starts Windows Media Player.
+
+To verify a valid mapping without playing sound, set `MISAKANET_VOICE_DRY_RUN=1`.
+For example, in PowerShell:
+
+```powershell
+$env:MISAKANET_VOICE_DRY_RUN = '1'
+'{"voice":"connect-success"}' | .\scripts\misakanet_voice_hook.ps1
+```
+
+It prints `connect-success` and exits with status 0. Unknown voices, malformed
+JSON, and payloads without a `voice` field exit successfully without output.
 
 ## Disabling
 
-Remove the hook from `settings.json` or set `MISAKANET_VOICE=0` in environment.
+Remove the hook from `settings.json` or set `MISAKANET_VOICE=0` in the environment.

--- a/scripts/misakanet_voice_hook.bat
+++ b/scripts/misakanet_voice_hook.bat
@@ -12,9 +12,13 @@ REM   }]
 
 setlocal enabledelayedexpansion
 
+REM Set MISAKANET_VOICE=0 to disable prompts without removing the hook.
+if "%MISAKANET_VOICE%"=="0" exit /b 0
+
 REM Get script directory
 set "SCRIPT_DIR=%~dp0"
 set "VOICE_DIR=%SCRIPT_DIR%..\docs\assets\voice"
+if not "%MISAKANET_VOICE_DIR%"=="" set "VOICE_DIR=%MISAKANET_VOICE_DIR%"
 
 REM Read stdin (tool result JSON)
 set "INPUT="
@@ -26,6 +30,7 @@ for /f "tokens=*" %%a in ('echo !INPUT! ^| python -c "import sys,json; d=json.lo
 if "!VOICE!"=="" exit /b 0
 
 REM Map voice name to file
+set "FILE="
 if "!VOICE!"=="connect-success" set "FILE=%VOICE_DIR%\connect-success.mp3"
 if "!VOICE!"=="pair-success" set "FILE=%VOICE_DIR%\pair-success.mp3"
 if "!VOICE!"=="lesson-found" set "FILE=%VOICE_DIR%\lesson-found.mp3"
@@ -33,7 +38,15 @@ if "!VOICE!"=="failure-warning" set "FILE=%VOICE_DIR%\failure-warning.mp3"
 
 if not exist "!FILE!" exit /b 0
 
-REM Play audio using Windows Media Player COM (non-blocking)
-powershell -Command "$wmp = New-Object -ComObject WMPlayer.OCX; $wmp.URL = '!FILE!'; $wmp.controls.play(); Start-Sleep -Milliseconds 200" 2>nul
+REM Permit CI and users to verify the mapping without opening an audio player.
+if "%MISAKANET_VOICE_DRY_RUN%"=="1" (
+    echo !VOICE!
+    exit /b 0
+)
+
+REM Launch Windows Media Player separately so playback survives hook exit.
+if exist "%ProgramFiles%\Windows Media Player\wmplayer.exe" (
+    start "" /b "%ProgramFiles%\Windows Media Player\wmplayer.exe" /play "!FILE!" >nul 2>nul
+)
 
 exit /b 0

--- a/scripts/misakanet_voice_hook.ps1
+++ b/scripts/misakanet_voice_hook.ps1
@@ -13,16 +13,20 @@ param()
 
 $ErrorActionPreference = "SilentlyContinue"
 
+# Set MISAKANET_VOICE=0 to disable prompts without removing the hook.
+if ($env:MISAKANET_VOICE -eq "0") { exit 0 }
+
 # Get script directory
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$VoiceDir = Join-Path (Split-Path -Parent $ScriptDir) "docs\assets\voice"
+$DefaultVoiceDir = Join-Path (Split-Path -Parent $ScriptDir) "docs\assets\voice"
+$VoiceDir = if ($env:MISAKANET_VOICE_DIR) { $env:MISAKANET_VOICE_DIR } else { $DefaultVoiceDir }
 
 # Read stdin (tool result JSON)
-$Input = [Console]::In.ReadToEnd()
+$Payload = [Console]::In.ReadToEnd()
 
 # Extract voice field
 try {
-    $Data = $Input | ConvertFrom-Json
+    $Data = $Payload | ConvertFrom-Json
     $Voice = $Data.voice
 } catch {
     exit 0
@@ -45,25 +49,22 @@ $FilePath = Join-Path $VoiceDir $FileName
 
 if (-not (Test-Path $FilePath)) { exit 0 }
 
-# Play audio using Windows Media Player COM / MediaPlayer (non-blocking)
+# Permit CI and users to verify the mapping without opening an audio player.
+if ($env:MISAKANET_VOICE_DRY_RUN -eq "1") {
+    Write-Output $Voice
+    exit 0
+}
+
+# Launch Windows Media Player as a separate process.  Keeping a COM object alive
+# for a few milliseconds and then closing it cuts off MP3 playback when the hook
+# exits; the player process continues independently instead.
+$PlayerPath = Join-Path ${env:ProgramFiles} "Windows Media Player\wmplayer.exe"
+if (-not (Test-Path $PlayerPath)) { exit 0 }
+
 try {
-    $wmp = New-Object -ComObject WMPlayer.OCX
-    $wmp.URL = $FilePath
-    $wmp.controls.play()
-    Start-Sleep -Milliseconds 250
-    $wmp.close()
-    [System.Runtime.InteropServices.Marshal]::ReleaseComObject($wmp) | Out-Null
+    Start-Process -FilePath $PlayerPath -ArgumentList @("/play", $FilePath) -ErrorAction Stop | Out-Null
 } catch {
-    try {
-        Add-Type -AssemblyName presentationCore
-        $Player = New-Object System.Windows.Media.MediaPlayer
-        $Player.Open([System.Uri]::new($FilePath))
-        $Player.Play()
-        Start-Sleep -Milliseconds 250
-        $Player.Close()
-    } catch {
-        # Graceful fallback
-    }
+    # Audio is optional: never make a hook failure fail its parent tool call.
 }
 
 exit 0

--- a/scripts/misakanet_voice_hook.sh
+++ b/scripts/misakanet_voice_hook.sh
@@ -10,11 +10,13 @@
 #   }]
 #
 # The hook reads JSON from stdin (MCP tool result) and plays the
-# corresponding MP3 from docs/assets/voice/ via afplay (macOS).
+# corresponding MP3 from docs/assets/voice/.
 
 set -euo pipefail
 
-VOICE_DIR="$(cd "$(dirname "$0")/../docs/assets/voice" && pwd)"
+[ "${MISAKANET_VOICE:-1}" = "0" ] && exit 0
+
+VOICE_DIR="${MISAKANET_VOICE_DIR:-$(cd "$(dirname "$0")/../docs/assets/voice" && pwd)}"
 
 # Read stdin (tool result JSON)
 INPUT=$(cat)
@@ -42,6 +44,8 @@ esac
 
 [ -f "$FILE" ] || exit 0
 
+[ "${MISAKANET_VOICE_DRY_RUN:-0}" = "1" ] && printf '%s\n' "$VOICE" && exit 0
+
 # Play audio (non-blocking, suppress errors from headless environments)
 if command -v afplay &>/dev/null; then
     # macOS
@@ -52,10 +56,12 @@ elif command -v aplay &>/dev/null; then
 elif command -v paplay &>/dev/null; then
     # Linux (PulseAudio)
     paplay "$FILE" &>/dev/null &
-elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+elif [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* || "$OSTYPE" == win32* ]]; then
     # Windows (Git Bash / MSYS2)
-    powershell -Command "\$wmp = New-Object -ComObject WMPlayer.OCX; \$wmp.URL = '$FILE'; \$wmp.controls.play(); Start-Sleep -Milliseconds 200" &>/dev/null &
+    WINDOWS_FILE=$(cygpath -w "$FILE" 2>/dev/null || printf '%s' "$FILE")
+    powershell -NoProfile -Command "Start-Process -FilePath \"\$env:ProgramFiles\\Windows Media Player\\wmplayer.exe\" -ArgumentList @('/play', '$WINDOWS_FILE')" &>/dev/null &
 elif command -v powershell.exe &>/dev/null; then
     # Windows (WSL)
-    powershell.exe -Command "\$wmp = New-Object -ComObject WMPlayer.OCX; \$wmp.URL = '$(wslpath -w "$FILE")'; \$wmp.controls.play(); Start-Sleep -Milliseconds 200" &>/dev/null &
+    WINDOWS_FILE=$(wslpath -w "$FILE")
+    powershell.exe -NoProfile -Command "Start-Process -FilePath \"\$env:ProgramFiles\\Windows Media Player\\wmplayer.exe\" -ArgumentList @('/play', '$WINDOWS_FILE')" &>/dev/null &
 fi

--- a/tests/test_voice_hooks.py
+++ b/tests/test_voice_hooks.py
@@ -59,6 +59,31 @@ class TestHookScript:
             for voice in ["connect-success", "pair-success", "lesson-found", "failure-warning"]:
                 assert voice in content, f"{script.name} missing case for: {voice}"
 
+    def test_hooks_support_non_playback_verification(self):
+        """Every platform can verify its mapping without requiring audio hardware."""
+        for script in [HOOK_SCRIPT_SH, HOOK_SCRIPT_PS1, HOOK_SCRIPT_BAT]:
+            content = script.read_text(encoding="utf-8", errors="ignore")
+            assert "MISAKANET_VOICE_DRY_RUN" in content
+            assert "MISAKANET_VOICE" in content
+
+    def test_bash_dry_run_maps_valid_voices_and_ignores_bad_input(self):
+        env = {**os.environ, "MISAKANET_VOICE_DRY_RUN": "1"}
+        for voice in ["connect-success", "pair-success", "lesson-found", "failure-warning"]:
+            result = subprocess.run(
+                [str(HOOK_SCRIPT_SH)], input=json.dumps({"voice": voice}), text=True,
+                capture_output=True, env=env, timeout=15,
+            )
+            assert result.returncode == 0
+            assert result.stdout.strip() == voice
+
+        for payload in [{"voice": "unknown-voice-type"}, {"other": "field"}]:
+            result = subprocess.run(
+                [str(HOOK_SCRIPT_SH)], input=json.dumps(payload), text=True,
+                capture_output=True, env=env, timeout=15,
+            )
+            assert result.returncode == 0
+            assert result.stdout == ""
+
 
 class TestMCPServerVoiceField:
     """MCP server responses must include voice field."""
@@ -99,14 +124,17 @@ class TestWindowsVoiceHookExecution:
 
     def test_ps1_valid_voice_execution(self):
         if os.name == "nt":
-            res = subprocess.run(
-                ["powershell", "-File", str(HOOK_SCRIPT_PS1)],
-                input=json.dumps({"voice": "connect-success"}),
-                text=True,
-                capture_output=True,
-                timeout=15,
-            )
-            assert res.returncode == 0, f"PS1 failed on valid voice: {res.stderr}"
+            for voice in ["connect-success", "pair-success", "lesson-found", "failure-warning"]:
+                res = subprocess.run(
+                    ["powershell", "-File", str(HOOK_SCRIPT_PS1)],
+                    input=json.dumps({"voice": voice}),
+                    text=True,
+                    capture_output=True,
+                    timeout=15,
+                    env={**os.environ, "MISAKANET_VOICE_DRY_RUN": "1"},
+                )
+                assert res.returncode == 0, f"PS1 failed on {voice}: {res.stderr}"
+                assert res.stdout.strip() == voice
 
     def test_ps1_invalid_voice_graceful(self):
         if os.name == "nt":
@@ -132,15 +160,18 @@ class TestWindowsVoiceHookExecution:
 
     def test_bat_valid_voice_execution(self):
         if os.name == "nt":
-            res = subprocess.run(
-                [str(HOOK_SCRIPT_BAT)],
-                input=json.dumps({"voice": "connect-success"}),
-                text=True,
-                capture_output=True,
-                shell=True,
-                timeout=15,
-            )
-            assert res.returncode == 0, f"BAT failed on valid voice: {res.stderr}"
+            for voice in ["connect-success", "pair-success", "lesson-found", "failure-warning"]:
+                res = subprocess.run(
+                    [str(HOOK_SCRIPT_BAT)],
+                    input=json.dumps({"voice": voice}),
+                    text=True,
+                    capture_output=True,
+                    shell=True,
+                    timeout=15,
+                    env={**os.environ, "MISAKANET_VOICE_DRY_RUN": "1"},
+                )
+                assert res.returncode == 0, f"BAT failed on {voice}: {res.stderr}"
+                assert res.stdout.strip() == voice
 
     def test_bat_invalid_voice_graceful(self):
         if os.name == "nt":
@@ -153,6 +184,18 @@ class TestWindowsVoiceHookExecution:
                 timeout=15,
             )
             assert res.returncode == 0, f"BAT failed on invalid voice: {res.stderr}"
+
+    def test_bat_missing_voice_graceful(self):
+        if os.name == "nt":
+            res = subprocess.run(
+                [str(HOOK_SCRIPT_BAT)],
+                input=json.dumps({"other": "field"}),
+                text=True,
+                capture_output=True,
+                shell=True,
+                timeout=15,
+            )
+            assert res.returncode == 0, f"BAT failed on missing voice: {res.stderr}"
 
 
 class TestDocumentation:
@@ -196,4 +239,3 @@ if __name__ == "__main__":
                 failed += 1
     print(f"\n{passed}/{total} passed, {failed} failed")
     sys.exit(1 if failed else 0)
-


### PR DESCRIPTION
Motivation
Improve reliability of the voice hook behavior on Windows so audio playback survives hook exit and can be verified in CI/headless environments.
Provide safe, user-controllable options to disable prompts and to verify mappings without audio hardware for easier testing and automation.

Description
Updated PowerShell hook to honor MISAKANET_VOICE=0 (disable), MISAKANET_VOICE_DIR (custom directory) and MISAKANET_VOICE_DRY_RUN=1 (print mapping and exit), and launch Windows Media Player as a separate process so playback continues after the hook exits.
Updated batch hook with the same disable/custom-dir/dry-run controls and to start Windows Media Player as an external process rather than relying on ephemeral COM playback.
Improved the Bash hook’s Windows detection and path conversion for Git Bash / MSYS2 / Cygwin / WSL, added dry-run and disable env handling, and made the Windows playback use Start-Process via PowerShell to keep playback alive.
Expanded tests/test_voice_hooks.py to assert the new env controls and dry-run behavior, exercise all valid voice mappings, and verify graceful handling of invalid or missing voice payloads.
Documented Windows setup and dry-run verification in docs/integrations/mcp-voice-hooks.md.

Testing
Ran pytest tests/test_voice_hooks.py -v --tb=short and all voice-hook related tests passed (19 passed).
Performed shell syntax check bash -n scripts/misakanet_voice_hook.sh and python3 -m py_compile tests/test_voice_hooks.py which succeeded.
Ran the repository self-check python3 scripts/doctor.py, which reported unrelated environment issues (existing Wrangler placeholder id and an unreachable MCP endpoint) but did not indicate failures in the hook changes themselves.
Ran the full test collection via PYTHONPATH=. pytest tests/ which produced many passing tests but exposed an unrelated environment-dependent failure in tests/test_misaka_capture.py::test_capture_context_not_found caused by the test environment (a /nonexistent directory), not by the hook changes.